### PR TITLE
Add support for LIMIT 0 and LIMIT NULL statements

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/Limit.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Limit.java
@@ -32,6 +32,7 @@ public class Limit {
 	private boolean rowCountJdbcParameter = false;
 	private boolean offsetJdbcParameter = false;
 	private boolean limitAll;
+    private boolean limitNull = false;
 
 	public long getOffset() {
 		return offset;
@@ -76,10 +77,19 @@ public class Limit {
 		limitAll = b;
 	}
 
+    /**
+     * @return true if the limit is "LIMIT NULL [OFFSET ...])
+     */
+    public boolean isLimitNull() { return limitNull; }
+
+    public void setLimitNull(boolean b) { limitNull = b; }
+
 	@Override
 	public String toString() {
 		String retVal = "";
-		if (rowCount > 0 || rowCountJdbcParameter) {
+		if (limitNull) {
+            retVal += " LIMIT NULL";
+        } else if (rowCount >= 0 || rowCountJdbcParameter) {
 			retVal += " LIMIT " + (rowCountJdbcParameter ? "?" : rowCount + "");
 		}
 		if (offset > 0 || offsetJdbcParameter) {

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -241,9 +241,11 @@ public class SelectDeParser implements SelectVisitor, OrderByVisitor, SelectItem
         if (limit.isRowCountJdbcParameter()) {
             buffer.append(" LIMIT ");
             buffer.append("?");
-        } else if (limit.getRowCount() != 0) {
+        } else if (limit.getRowCount() >= 0) {
             buffer.append(" LIMIT ");
             buffer.append(limit.getRowCount());
+        } else if (limit.isLimitNull()) {
+            buffer.append(" LIMIT NULL");
         }
 
         if (limit.isOffsetJdbcParameter()) {

--- a/src/main/javacc/net/sf/jsqlparser/parser/JSqlParserCC.jj
+++ b/src/main/javacc/net/sf/jsqlparser/parser/JSqlParserCC.jj
@@ -1104,6 +1104,7 @@ OrderByElement OrderByElement():
 Limit Limit():
 {
 	Limit limit = new Limit();
+	limit.setRowCount(-1l);
 	Token token = null;
 }
 {
@@ -1127,7 +1128,7 @@ Limit Limit():
 			 <K_OFFSET>
 				 (token=<S_LONG> { limit.setOffset(Long.parseLong(token.image)); } | "?" { limit.setOffsetJdbcParameter(true);} )
 			|
-				// mysql-postgresql-> LIMIT (row_count | ALL) [OFFSET offset]
+				// mysql-postgresql-> LIMIT (row_count | ALL | NULL) [OFFSET offset]
 				<K_LIMIT>
 				 (
 				 	token=<S_LONG> { limit.setRowCount(Long.parseLong(token.image)); }
@@ -1135,6 +1136,8 @@ Limit Limit():
 				 	"?" { limit.setRowCountJdbcParameter(true);}
 				 	|
 				 	<K_ALL> { limit.setLimitAll(true);}
+				 	|
+				 	<K_NULL> { limit.setLimitNull(true); }
 				 )
 
 				 [LOOKAHEAD(2) <K_OFFSET>

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -220,17 +220,37 @@ public class SelectTest extends TestCase {
         assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isRowCountJdbcParameter());
         assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isOffsetJdbcParameter());
         assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isLimitAll());
+        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isLimitNull());
 
         // toString uses standard syntax
         statement = "SELECT * FROM mytable WHERE mytable.col = 9 LIMIT ? OFFSET 3";
         assertSqlCanBeParsedAndDeparsed(statement);
 
+        statement = "SELECT * FROM mytable WHERE mytable.col = 9 LIMIT NULL OFFSET 3";
+        select = (Select) parserManager.parse(new StringReader(statement));
+        assertEquals(-1, ((PlainSelect) select.getSelectBody()).getLimit().getRowCount());
+        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isRowCountJdbcParameter());
+        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isOffsetJdbcParameter());
+        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isLimitAll());
+        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isLimitNull());
+        assertSqlCanBeParsedAndDeparsed(statement);
+
+        statement = "SELECT * FROM mytable WHERE mytable.col = 9 LIMIT 0 OFFSET 3";
+        select = (Select) parserManager.parse(new StringReader(statement));
+        assertEquals(0, ((PlainSelect) select.getSelectBody()).getLimit().getRowCount());
+        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isRowCountJdbcParameter());
+        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isOffsetJdbcParameter());
+        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isLimitAll());
+        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isLimitNull());
+        assertSqlCanBeParsedAndDeparsed(statement);
+
         statement = "SELECT * FROM mytable WHERE mytable.col = 9 OFFSET ?";
         select = (Select) parserManager.parse(new StringReader(statement));
 
-        assertEquals(0, ((PlainSelect) select.getSelectBody()).getLimit().getRowCount());
+        assertEquals(-1, ((PlainSelect) select.getSelectBody()).getLimit().getRowCount());
         assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isOffsetJdbcParameter());
         assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isLimitAll());
+        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isLimitNull());
         assertStatementCanBeDeparsedAs(select, statement);
 
         statement = "(SELECT * FROM mytable WHERE mytable.col = 9 OFFSET ?) UNION "
@@ -249,7 +269,6 @@ public class SelectTest extends TestCase {
                 + "(SELECT * FROM mytable2 WHERE mytable2.col = 9 OFFSET ?) UNION ALL "
                 + "(SELECT * FROM mytable3 WHERE mytable4.col = 9 OFFSET ?) LIMIT 4 OFFSET 3";
         assertSqlCanBeParsedAndDeparsed(statement);
-
     }
 
     public void testTop() throws JSQLParserException {


### PR DESCRIPTION
I've added support for `LIMIT 0` which is used to create empty result queries but having metadata.
Also added support for `LIMIT NULL` which is the same as omitting the `LIMIT` clause.
