### PR TITLE
Enable parsing of escaped single quotes within string values.

### DIFF
--- a/src/main/javacc/net/sf/jsqlparser/parser/JSqlParserCC.jj
+++ b/src/main/javacc/net/sf/jsqlparser/parser/JSqlParserCC.jj
@@ -226,7 +226,7 @@ TOKEN:
 	< S_IDENTIFIER: ( <LETTER> | <ADDITIONAL_LETTERS> )+ ( <DIGIT> | <LETTER> | <ADDITIONAL_LETTERS> | <SPECIAL_CHARS>)* >
 | 	< #LETTER: ["a"-"z", "A"-"Z", "_"] >
 |   < #SPECIAL_CHARS: "$" | "_" | "#" | "@">
-|   < S_CHAR_LITERAL: "'" (~["'"])* "'" ("'" (~["'"])* "'")*>
+|   < S_CHAR_LITERAL: "'" ("\\" "\'" | ~["'"])* "'" ("'" ("\\" "\'" | ~["'"])* "'")*>
 |   < S_QUOTED_IDENTIFIER: "\"" (~["\n","\r","\""])* "\"" | ("`" (~["\n","\r","`"])* "`") | ("[" (~["\n","\r","]"])* "]") >
 
 /*

--- a/src/test/resources/simple_parsing.txt
+++ b/src/test/resources/simple_parsing.txt
@@ -59,6 +59,8 @@ insert into tabName VALUES ('sdgf', ?, ?)
 
 insert into myschama.tabName2 (col1, col2, col3) VALUES ('sdgf', ?, ?)
 
+insert into tabName3 VALUES ('isn\'t', ?)
+
 delete from jk
 
 delete from asdff where INI = 94 OR (ASD>9 AND (SELECT MAX(ID) from myt) > ?)


### PR DESCRIPTION
The current parser breaks when parsing values of the form `'There\'s an escaped single quote here.'` This change respects backslash escapes of single quotes within string values.