### PR TITLE
Support for SQL Server and Oracle OFFSET ... FETCH ... clauses

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/Fetch.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Fetch.java
@@ -1,0 +1,70 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2013 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 2.1 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package net.sf.jsqlparser.statement.select;
+
+/**
+ * A fetch clause in the form FETCH (FIRST | NEXT) row_count (ROW | ROWS) ONLY
+ */
+public class Fetch {
+
+	private long rowCount;
+	private boolean fetchJdbcParameter = false;
+    private boolean isFetchParamFirst = false;
+	private String fetchParam = "ROW";
+
+	public long getRowCount() {
+		return rowCount;
+	}
+
+	public void setRowCount(long l) {
+		rowCount = l;
+	}
+
+	public boolean isFetchJdbcParameter() {
+		return fetchJdbcParameter;
+	}
+
+    public String getFetchParam() {
+		return fetchParam;
+	}
+
+	public boolean isFetchParamFirst() {
+		return isFetchParamFirst;
+	}
+
+	public void setFetchJdbcParameter(boolean b) {
+		fetchJdbcParameter = b;
+	}
+
+	public void setFetchParam(String s) {
+		this.fetchParam = s;
+	}
+
+	public void setFetchParamFirst(boolean b) {
+		this.isFetchParamFirst = b;
+	}
+
+	@Override
+	public String toString() {
+		return " FETCH " + (isFetchParamFirst ? "FIRST" : "NEXT") + " " + (fetchJdbcParameter ? "?" : rowCount + "") + " "+ fetchParam + " ONLY";
+	}
+}

--- a/src/main/java/net/sf/jsqlparser/statement/select/Limit.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Limit.java
@@ -24,8 +24,6 @@ package net.sf.jsqlparser.statement.select;
 /**
  * A limit clause in the form [LIMIT {[offset,] row_count) | (row_count | ALL)
  * OFFSET offset}]
- * or in the form [OFFSET offset (ROW | ROWS) [FETCH (FIRST | NEXT) row_count (ROW | ROWS) ONLY]]
- * or in the form FETCH (FIRST | NEXT) row_count (ROW | ROWS) ONLY
  */
 public class Limit {
 
@@ -35,12 +33,6 @@ public class Limit {
 	private boolean offsetJdbcParameter = false;
 	private boolean limitAll;
     private boolean limitNull = false;
-    private boolean oracleSqlServerVersion = false;
-    private boolean hasOffset = false;
-	private boolean isOffsetParamRows = false;
-    private boolean hasFetch = false;
-    private boolean isFetchParamRows = false;
-    private boolean isFetchParamFirst = false;
 
 	public long getOffset() {
 		return offset;
@@ -66,59 +58,12 @@ public class Limit {
 		return rowCountJdbcParameter;
 	}
 
-	public boolean isOracleSqlServerVersion() {
-		return oracleSqlServerVersion;
-	}
-
-	public boolean isHasOffset() {
-		return hasOffset;
-	}
-
-	public boolean isHasFetch() {
-		return hasFetch;
-	}
-    public boolean isOffsetParamRows() {
-		return isOffsetParamRows;
-	}
-
-	public boolean isFetchParamRows() {
-		return isFetchParamRows;
-	}
-
-	public boolean isFetchParamFirst() {
-		return isFetchParamFirst;
-	}
-
 	public void setOffsetJdbcParameter(boolean b) {
 		offsetJdbcParameter = b;
 	}
 
 	public void setRowCountJdbcParameter(boolean b) {
 		rowCountJdbcParameter = b;
-	}
-
-	public void setOracleSqlServerVersion(boolean b) {
-		oracleSqlServerVersion = b;
-	}
-
-	public void setHasOffset(boolean b) {
-		hasOffset = b;
-	}
-
-	public void setHasFetch(boolean b) {
-		hasFetch = b;
-	}
-
-	public void setOffsetParamRows(boolean isOffsetParamRows) {
-		this.isOffsetParamRows = isOffsetParamRows;
-	}
-
-	public void setFetchParamRows(boolean isFetchParamRows) {
-		this.isFetchParamRows = isFetchParamRows;
-	}
-
-	public void setFetchParamFirst(boolean isFetchParamFirst) {
-		this.isFetchParamFirst = isFetchParamFirst;
 	}
 
 	/**
@@ -142,22 +87,13 @@ public class Limit {
 	@Override
 	public String toString() {
 		String retVal = "";
-		if (oracleSqlServerVersion) {
-			if (hasOffset) {
-				retVal = " OFFSET " + offset + " "+(isOffsetParamRows ? "ROWS" : "ROW");
-			}
-			if (hasFetch) {
-				retVal += " FETCH "+(isFetchParamFirst ? "FIRST" : "NEXT")+" " + rowCount + " "+(isFetchParamRows ? "ROWS" : "ROW")+" ONLY";
-			}
-		} else {
-			if (limitNull) {
-	            retVal += " LIMIT NULL";
-	        } else if (rowCount >= 0 || rowCountJdbcParameter) {
-				retVal += " LIMIT " + (rowCountJdbcParameter ? "?" : rowCount + "");
-			}
-			if (offset > 0 || offsetJdbcParameter) {
-				retVal += " OFFSET " + (offsetJdbcParameter ? "?" : offset + "");
-			}
+		if (limitNull) {
+            retVal += " LIMIT NULL";
+        } else if (rowCount >= 0 || rowCountJdbcParameter) {
+			retVal += " LIMIT " + (rowCountJdbcParameter ? "?" : rowCount + "");
+		}
+		if (offset > 0 || offsetJdbcParameter) {
+			retVal += " OFFSET " + (offsetJdbcParameter ? "?" : offset + "");
 		}
 		return retVal;
 	}

--- a/src/main/java/net/sf/jsqlparser/statement/select/Offset.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Offset.java
@@ -1,0 +1,62 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2013 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 2.1 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package net.sf.jsqlparser.statement.select;
+
+/**
+ * An offset clause in the form OFFSET offset
+ * or in the form OFFSET offset (ROW | ROWS)
+ */
+public class Offset {
+
+	private long offset;
+	private boolean offsetJdbcParameter = false;
+	private String offsetParam = null;
+
+	public long getOffset() {
+		return offset;
+	}
+
+	public String getOffsetParam() {
+		return offsetParam;
+	}
+
+	public void setOffset(long l) {
+		offset = l;
+	}
+
+	public void setOffsetParam(String s) {
+		offsetParam = s;
+	}
+
+	public boolean isOffsetJdbcParameter() {
+		return offsetJdbcParameter;
+	}
+
+	public void setOffsetJdbcParameter(boolean b) {
+		offsetJdbcParameter = b;
+	}
+
+	@Override
+	public String toString() {
+		return " OFFSET " + (offsetJdbcParameter ? "?" : offset) + (offsetParam != null ? " "+offsetParam : "");
+	}
+}

--- a/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
@@ -45,6 +45,8 @@ public class PlainSelect implements SelectBody {
     private List<OrderByElement> orderByElements;
     private Expression having;
     private Limit limit;
+    private Offset offset;
+    private Fetch fetch;
     private Top top;
     private OracleHierarchicalExpression oracleHierarchical = null;
     private boolean oracleSiblings = false;
@@ -131,6 +133,22 @@ public class PlainSelect implements SelectBody {
 
     public void setLimit(Limit limit) {
         this.limit = limit;
+    }
+
+    public Offset getOffset() {
+        return offset;
+    }
+
+    public void setOffset(Offset offset) {
+        this.offset = offset;
+    }
+
+    public Fetch getFetch() {
+        return fetch;
+    }
+
+    public void setFetch(Fetch fetch) {
+        this.fetch = fetch;
     }
 
     public Top getTop() {
@@ -235,6 +253,12 @@ public class PlainSelect implements SelectBody {
             sql.append(orderByToString(oracleSiblings, orderByElements));
             if (limit != null) {
                 sql.append(limit);
+            }
+            if (offset != null) {
+            	sql.append(offset);
+            }
+            if (fetch != null) {
+            	sql.append(fetch);
             }
         }
         return sql.toString();

--- a/src/main/java/net/sf/jsqlparser/statement/select/SetOperationList.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/SetOperationList.java
@@ -36,6 +36,8 @@ public class SetOperationList implements SelectBody {
 	private List<SetOperation> operations;
 	private List<OrderByElement> orderByElements;
 	private Limit limit;
+	private Offset offset;
+	private Fetch fetch;
 
 	@Override
 	public void accept(SelectVisitor selectVisitor) {
@@ -75,6 +77,22 @@ public class SetOperationList implements SelectBody {
 		this.limit = limit;
 	}
 
+	public Offset getOffset() {
+		return offset;
+	}
+
+	public void setOffset(Offset offset) {
+		this.offset = offset;
+	}
+
+	public Fetch getFetch() {
+		return fetch;
+	}
+
+	public void setFetch(Fetch fetch) {
+		this.fetch = fetch;
+	}
+
 	@Override
 	public String toString() {
 		StringBuilder buffer = new StringBuilder();
@@ -91,6 +109,12 @@ public class SetOperationList implements SelectBody {
 		}
 		if (limit != null) {
 			buffer.append(limit.toString());
+		}
+		if (offset != null) {
+			buffer.append(offset.toString());
+		}
+		if (fetch != null) {
+			buffer.append(fetch.toString());
 		}
 		return buffer.toString();
 	}

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -134,6 +134,12 @@ public class SelectDeParser implements SelectVisitor, OrderByVisitor, SelectItem
         if (plainSelect.getLimit() != null) {
             deparseLimit(plainSelect.getLimit());
         }
+        if (plainSelect.getOffset() != null) {
+            deparseOffset(plainSelect.getOffset());
+        }
+        if (plainSelect.getFetch() != null) {
+            deparseFetch(plainSelect.getFetch());
+        }
 
     }
 
@@ -248,54 +254,53 @@ public class SelectDeParser implements SelectVisitor, OrderByVisitor, SelectItem
 
     public void deparseLimit(Limit limit) {
         // LIMIT n OFFSET skip
-        // or
-        // OFFSET offset (ROW | ROWS) [FETCH (FIRST | NEXT) row_count (ROW | ROWS) ONLY]
-        // or
-        // FETCH (FIRST | NEXT) row_count (ROW | ROWS) ONLY
-        if (limit.isOracleSqlServerVersion()) {
-            if (limit.isHasOffset()) {
-                buffer.append(" OFFSET ");
-                buffer.append(limit.getOffset());
-                buffer.append(" ");
-                if (limit.isOffsetParamRows()) {
-                    buffer.append("ROWS");
-                } else {
-                    buffer.append("ROW");
-                }
-            }
-            if (limit.isHasFetch()) {
-                buffer.append(" FETCH ");
-                if (limit.isFetchParamFirst()) {
-                    buffer.append("FIRST ");
-                } else {
-                    buffer.append("NEXT ");
-                }
-                buffer.append(limit.getRowCount());
-                buffer.append(" ");
-                if (limit.isFetchParamRows()) {
-                    buffer.append("ROWS");
-                } else {
-                    buffer.append("ROW");
-                }
-                buffer.append(" ONLY");
-            }
-        } else {
-            if (limit.isRowCountJdbcParameter()) {
-                buffer.append(" LIMIT ");
-                buffer.append("?");
-            } else if (limit.getRowCount() >= 0) {
-                buffer.append(" LIMIT ");
-                buffer.append(limit.getRowCount());
-            } else if (limit.isLimitNull()) {
-                buffer.append(" LIMIT NULL");
-            }
-
-            if (limit.isOffsetJdbcParameter()) {
-                buffer.append(" OFFSET ?");
-            } else if (limit.getOffset() != 0) {
-                buffer.append(" OFFSET ").append(limit.getOffset());
-            }
+        if (limit.isRowCountJdbcParameter()) {
+            buffer.append(" LIMIT ");
+            buffer.append("?");
+        } else if (limit.getRowCount() >= 0) {
+            buffer.append(" LIMIT ");
+            buffer.append(limit.getRowCount());
+        } else if (limit.isLimitNull()) {
+            buffer.append(" LIMIT NULL");
         }
+
+        if (limit.isOffsetJdbcParameter()) {
+            buffer.append(" OFFSET ?");
+        } else if (limit.getOffset() != 0) {
+            buffer.append(" OFFSET ").append(limit.getOffset());
+        }
+
+    }
+
+    public void deparseOffset(Offset offset) {
+        // OFFSET offset
+    	// or OFFSET offset (ROW | ROWS)
+        if (offset.isOffsetJdbcParameter()) {
+            buffer.append(" OFFSET ?");
+        } else if (offset.getOffset() != 0) {
+            buffer.append(" OFFSET ");
+            buffer.append(offset.getOffset());
+        }
+        if (offset.getOffsetParam() != null) {
+        	buffer.append(" ").append(offset.getOffsetParam());
+        }
+
+    }
+
+    public void deparseFetch(Fetch fetch) {
+        // FETCH (FIRST | NEXT) row_count (ROW | ROWS) ONLY
+    	buffer.append(" FETCH ");
+    	if (fetch.isFetchParamFirst()) {
+    		buffer.append("FIRST ");
+    	} else {
+    		buffer.append("NEXT ");
+    	}
+    	if (fetch.isFetchJdbcParameter()) {
+    		buffer.append("?");
+    	} else {
+    		buffer.append(fetch.getRowCount());
+    	}
+    	buffer.append(" ").append(fetch.getFetchParam()).append(" ONLY");
 
     }
 
@@ -391,6 +396,12 @@ public class SelectDeParser implements SelectVisitor, OrderByVisitor, SelectItem
 
         if (list.getLimit() != null) {
             deparseLimit(list.getLimit());
+        }
+        if (list.getOffset() != null) {
+            deparseOffset(list.getOffset());
+        }
+        if (list.getFetch() != null) {
+            deparseFetch(list.getFetch());
         }
     }
 

--- a/src/main/javacc/net/sf/jsqlparser/parser/JSqlParserCC.jj
+++ b/src/main/javacc/net/sf/jsqlparser/parser/JSqlParserCC.jj
@@ -586,6 +586,8 @@ PlainSelect PlainSelect():
 	List<Expression> groupByColumnReferences = null;
 	Expression having = null;
 	Limit limit = null;
+	Offset offset = null;
+	Fetch fetch = null;
 	Top top = null;
 	OracleHierarchicalExpression oracleHierarchicalQueryClause = null;
     List<Table> intoTables = null;
@@ -618,7 +620,9 @@ PlainSelect PlainSelect():
     [ having=Having() { plainSelect.setHaving(having); }]
 	[LOOKAHEAD(<K_ORDER> <K_SIBLINGS> <K_BY>) orderByElements = OrderByElements() { plainSelect.setOracleSiblings(true); plainSelect.setOrderByElements(orderByElements);	}   ]
 	[LOOKAHEAD(<K_ORDER> <K_BY>) orderByElements = OrderByElements() { plainSelect.setOrderByElements(orderByElements);	}   ]
-    [LOOKAHEAD(2) limit = Limit() { plainSelect.setLimit(limit);	} ]
+    [LOOKAHEAD(<K_LIMIT>) limit = Limit() { plainSelect.setLimit(limit);	} ]
+	[LOOKAHEAD(<K_OFFSET>) offset = Offset() { plainSelect.setOffset(offset);	} ]
+	[LOOKAHEAD(<K_FETCH>) fetch = Fetch() { plainSelect.setFetch(fetch);	} ]
 
 	{
 		plainSelect.setSelectItems(selectItems);
@@ -634,6 +638,8 @@ SetOperationList SetOperationList():
 	SetOperationList list = new SetOperationList();
 	List<OrderByElement> orderByElements = null;
 	Limit limit = null;
+	Offset offset = null;
+	Fetch fetch = null;
 	PlainSelect select = null;
 	List<PlainSelect> selects = new ArrayList<PlainSelect>();
 	List<SetOperation> operations = new ArrayList<SetOperation>();
@@ -655,7 +661,9 @@ SetOperationList SetOperationList():
 		)
 
 		[orderByElements=OrderByElements() {list.setOrderByElements(orderByElements);} ]
-		[limit=Limit() {list.setLimit(limit);} ]
+		[LOOKAHEAD(<K_LIMIT>) limit=Limit() {list.setLimit(limit);} ]
+		[LOOKAHEAD(<K_OFFSET>) offset = Offset() { list.setOffset(offset);} ]
+		[LOOKAHEAD(<K_FETCH>) fetch = Fetch() { list.setFetch(fetch);} ]
 	)
 
 	{
@@ -1166,7 +1174,7 @@ Limit Limit():
 				token=<S_LONG> { limit.setRowCount(Long.parseLong(token.image)); } | "?" { limit.setRowCountJdbcParameter(true);}
 				)
 			|
-				// mysql-postgresql-> LIMIT (row_count | ALL | NULL) [OFFSET offset]
+				// mysql-postgresql-> LIMIT (row_count | ALL | NULL)
 				<K_LIMIT>
 				 (
 				 	token=<S_LONG> { limit.setRowCount(Long.parseLong(token.image)); }
@@ -1178,31 +1186,50 @@ Limit Limit():
 				 	<K_NULL> { limit.setLimitNull(true); }
 				 )
 
-				 [LOOKAHEAD(2) <K_OFFSET>
-					 (token=<S_LONG> { limit.setOffset(Long.parseLong(token.image)); } | "?" { limit.setOffsetJdbcParameter(true);} )  ]
-			|
+		)
+	{
+		return limit;
+	}
+}
+
+Offset Offset():
+{
+	Offset offset = new Offset();
+	Token token = null;
+}
+{
+	(
 			// postgresql-> OFFSET offset
-			// sqlserver-oracle-> OFFSET offset (ROW | ROWS) [FETCH (FIRST | NEXT) row_count (ROW | ROWS) ONLY]
+			// sqlserver-oracle-> OFFSET offset (ROW | ROWS)
 			 <K_OFFSET>
-				 (token=<S_LONG> { limit.setOffset(Long.parseLong(token.image)); }
-					 [(<K_ROWS> { limit.setOffsetParamRows(true); } | <K_ROW>) {limit.setOracleSqlServerVersion(true); limit.setHasOffset(true); }]
-				 | "?" { limit.setOffsetJdbcParameter(true);} )
-			 [LOOKAHEAD(5) <K_FETCH>
-			 	 (<K_FIRST> { limit.setFetchParamFirst(true); } | <K_NEXT>)
-				 (token=<S_LONG> { limit.setOracleSqlServerVersion(true); limit.setHasFetch(true); limit.setRowCount(Long.parseLong(token.image)); })
-				 (<K_ROWS> { limit.setFetchParamRows(true); } | <K_ROW>) 
-				 <K_ONLY> ]
-			|
-			// oracle-> FETCH (FIRST | NEXT) row_count (ROW | ROWS) ONLY
+				 (token=<S_LONG> { offset.setOffset(Long.parseLong(token.image)); }
+				 | "?" { offset.setOffsetJdbcParameter(true); } )
+				 [(<K_ROWS> { offset.setOffsetParam("ROWS"); } | <K_ROW> { offset.setOffsetParam("ROW"); })]
+
+		)
+	{
+		return offset;
+	}
+}
+
+Fetch Fetch():
+{
+	Fetch fetch = new Fetch();
+	Token token = null;
+}
+{
+	(
+			// sqlserver-oracle-> FETCH (FIRST | NEXT) row_count (ROW | ROWS) ONLY
 			 <K_FETCH>
-			 	 (<K_FIRST> { limit.setFetchParamFirst(true); } | <K_NEXT>)
-				 (token=<S_LONG> { limit.setOracleSqlServerVersion(true); limit.setHasFetch(true); limit.setRowCount(Long.parseLong(token.image)); })
-				 (<K_ROWS> { limit.setFetchParamRows(true); } | <K_ROW>) 
+			 	 (<K_FIRST> { fetch.setFetchParamFirst(true); } | <K_NEXT>)
+				 (token=<S_LONG> { fetch.setRowCount(Long.parseLong(token.image)); }
+				 | "?" { fetch.setFetchJdbcParameter(true); } )
+				 (<K_ROWS> { fetch.setFetchParam("ROWS"); } | <K_ROW>) 
 				 <K_ONLY>
 
 		)
 	{
-		return limit;
+		return fetch;
 	}
 }
 

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -228,9 +228,9 @@ public class SelectTest extends TestCase {
         statement = "SELECT * FROM mytable WHERE mytable.col = 9 OFFSET ?";
         select = (Select) parserManager.parse(new StringReader(statement));
 
-        assertEquals(-1, ((PlainSelect) select.getSelectBody()).getLimit().getRowCount());
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isOffsetJdbcParameter());
-        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isLimitAll());
+        assertNull(((PlainSelect) select.getSelectBody()).getLimit());
+        assertNotNull(((PlainSelect) select.getSelectBody()).getOffset());
+        assertTrue(((PlainSelect) select.getSelectBody()).getOffset().isOffsetJdbcParameter());
         assertStatementCanBeDeparsedAs(select, statement);
 
         statement = "(SELECT * FROM mytable WHERE mytable.col = 9 OFFSET ?) UNION "
@@ -288,10 +288,9 @@ public class SelectTest extends TestCase {
         statement = "SELECT * FROM mytable WHERE mytable.col = 9 OFFSET ?";
         select = (Select) parserManager.parse(new StringReader(statement));
 
-        assertEquals(-1, ((PlainSelect) select.getSelectBody()).getLimit().getRowCount());
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isOffsetJdbcParameter());
-        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isLimitAll());
-        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isLimitNull());
+        assertNull(((PlainSelect) select.getSelectBody()).getLimit());
+        assertNotNull(((PlainSelect) select.getSelectBody()).getOffset());
+        assertTrue(((PlainSelect) select.getSelectBody()).getOffset().isOffsetJdbcParameter());
         assertStatementCanBeDeparsedAs(select, statement);
 
         statement = "(SELECT * FROM mytable WHERE mytable.col = 9 OFFSET ?) UNION "
@@ -317,14 +316,15 @@ public class SelectTest extends TestCase {
 
         Select select = (Select) parserManager.parse(new StringReader(statement));
 
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isOracleSqlServerVersion());
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isHasOffset());
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isHasFetch());
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isOffsetParamRows());
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isFetchParamRows());
-        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isFetchParamFirst());
-        assertEquals(3, ((PlainSelect) select.getSelectBody()).getLimit().getOffset());
-        assertEquals(5, ((PlainSelect) select.getSelectBody()).getLimit().getRowCount());
+        assertNotNull(((PlainSelect) select.getSelectBody()).getOffset());
+        assertEquals("ROWS", ((PlainSelect) select.getSelectBody()).getOffset().getOffsetParam());
+        assertNotNull(((PlainSelect) select.getSelectBody()).getFetch());
+        assertEquals("ROWS", ((PlainSelect) select.getSelectBody()).getFetch().getFetchParam());
+        assertFalse(((PlainSelect) select.getSelectBody()).getFetch().isFetchParamFirst());
+        assertFalse(((PlainSelect) select.getSelectBody()).getOffset().isOffsetJdbcParameter());
+        assertFalse(((PlainSelect) select.getSelectBody()).getFetch().isFetchJdbcParameter());
+        assertEquals(3, ((PlainSelect) select.getSelectBody()).getOffset().getOffset());
+        assertEquals(5, ((PlainSelect) select.getSelectBody()).getFetch().getRowCount());
         assertStatementCanBeDeparsedAs(select, statement);
     }
 
@@ -334,14 +334,13 @@ public class SelectTest extends TestCase {
 
         Select select = (Select) parserManager.parse(new StringReader(statement));
 
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isOracleSqlServerVersion());
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isHasOffset());
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isHasFetch());
-        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isOffsetParamRows());
-        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isFetchParamRows());
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isFetchParamFirst());
-        assertEquals(3, ((PlainSelect) select.getSelectBody()).getLimit().getOffset());
-        assertEquals(5, ((PlainSelect) select.getSelectBody()).getLimit().getRowCount());
+        assertNotNull(((PlainSelect) select.getSelectBody()).getOffset());
+        assertNotNull(((PlainSelect) select.getSelectBody()).getFetch());
+        assertEquals("ROW", ((PlainSelect) select.getSelectBody()).getOffset().getOffsetParam());
+        assertEquals("ROW", ((PlainSelect) select.getSelectBody()).getFetch().getFetchParam());
+        assertTrue(((PlainSelect) select.getSelectBody()).getFetch().isFetchParamFirst());
+        assertEquals(3, ((PlainSelect) select.getSelectBody()).getOffset().getOffset());
+        assertEquals(5, ((PlainSelect) select.getSelectBody()).getFetch().getRowCount());
         assertStatementCanBeDeparsedAs(select, statement);
     }
 
@@ -351,11 +350,10 @@ public class SelectTest extends TestCase {
 
         Select select = (Select) parserManager.parse(new StringReader(statement));
 
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isOracleSqlServerVersion());
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isHasOffset());
-        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isHasFetch());
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isOffsetParamRows());
-        assertEquals(3, ((PlainSelect) select.getSelectBody()).getLimit().getOffset());
+        assertNotNull(((PlainSelect) select.getSelectBody()).getOffset());
+        assertNull(((PlainSelect) select.getSelectBody()).getFetch());
+        assertEquals("ROWS", ((PlainSelect) select.getSelectBody()).getOffset().getOffsetParam());
+        assertEquals(3, ((PlainSelect) select.getSelectBody()).getOffset().getOffset());
         assertStatementCanBeDeparsedAs(select, statement);
     }
 
@@ -365,12 +363,26 @@ public class SelectTest extends TestCase {
 
         Select select = (Select) parserManager.parse(new StringReader(statement));
 
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isOracleSqlServerVersion());
-        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isHasOffset());
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isHasFetch());
-        assertTrue(((PlainSelect) select.getSelectBody()).getLimit().isFetchParamRows());
-        assertFalse(((PlainSelect) select.getSelectBody()).getLimit().isFetchParamFirst());
-        assertEquals(5, ((PlainSelect) select.getSelectBody()).getLimit().getRowCount());
+        assertNull(((PlainSelect) select.getSelectBody()).getOffset());
+        assertNotNull(((PlainSelect) select.getSelectBody()).getFetch());
+        assertEquals("ROWS", ((PlainSelect) select.getSelectBody()).getFetch().getFetchParam());
+        assertFalse(((PlainSelect) select.getSelectBody()).getFetch().isFetchParamFirst());
+        assertEquals(5, ((PlainSelect) select.getSelectBody()).getFetch().getRowCount());
+        assertStatementCanBeDeparsedAs(select, statement);
+    }
+
+    public void testLimitSqlServerJdbcParameters() throws JSQLParserException {
+        String statement = "SELECT * FROM mytable WHERE mytable.col = 9 ORDER BY mytable.id OFFSET ? ROWS FETCH NEXT ? ROWS ONLY";
+
+        Select select = (Select) parserManager.parse(new StringReader(statement));
+
+        assertNotNull(((PlainSelect) select.getSelectBody()).getOffset());
+        assertEquals("ROWS", ((PlainSelect) select.getSelectBody()).getOffset().getOffsetParam());
+        assertNotNull(((PlainSelect) select.getSelectBody()).getFetch());
+        assertEquals("ROWS", ((PlainSelect) select.getSelectBody()).getFetch().getFetchParam());
+        assertFalse(((PlainSelect) select.getSelectBody()).getFetch().isFetchParamFirst());
+        assertTrue(((PlainSelect) select.getSelectBody()).getOffset().isOffsetJdbcParameter());
+        assertTrue(((PlainSelect) select.getSelectBody()).getFetch().isFetchJdbcParameter());
         assertStatementCanBeDeparsedAs(select, statement);
     }
 


### PR DESCRIPTION
The parser does not currently support new SQL Server 2012 and Oracle 12c OFFSET ... FETCH ... clauses.
This commit adds only a partial support of them, by allowing only integers for both clauses.

See http://technet.microsoft.com/en-gb/library/gg699618(v=sql.110).aspx for SQL Server and http://docs.oracle.com/database/121/SQLRF/statements_10002.htm#SQLRF55636 for Oracle.
