### PR TITLE
Fix inline usage of foreign keys in CREATE TABLE statements

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2522,6 +2522,10 @@ String CreateParameter():
 			tk=<K_NOT> { retval = tk.image; }
 			|
 			tk=<K_PRIMARY> { retval = tk.image; }
+			|
+			tk=<K_FOREIGN> { retval=tk.image; }
+            |
+            tk=<K_REFERENCES> { retval=tk.image; }
             |
 			tk=<K_KEY> { retval = tk.image; }
 			|

--- a/src/test/java/net/sf/jsqlparser/test/create/CreateTableTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/create/CreateTableTest.java
@@ -86,6 +86,16 @@ public class CreateTableTest extends TestCase {
 		String statement = "CREATE TABLE test (id INT UNSIGNED NOT NULL AUTO_INCREMENT, string VARCHAR (20), user_id INT UNSIGNED, PRIMARY KEY (id), CONSTRAINT fkIdx FOREIGN KEY (user_id) REFERENCES ra_user(id))";
 		assertSqlCanBeParsedAndDeparsed(statement);
 	}
+
+    public void testCreateTableForeignKey3() throws JSQLParserException {
+        String statement = "CREATE TABLE test (id INT UNSIGNED NOT NULL AUTO_INCREMENT, string VARCHAR (20), user_id INT UNSIGNED REFERENCES ra_user(id), PRIMARY KEY (id))";
+        assertSqlCanBeParsedAndDeparsed(statement,true);
+    }
+
+    public void testCreateTableForeignKey4() throws JSQLParserException {
+        String statement = "CREATE TABLE test (id INT UNSIGNED NOT NULL AUTO_INCREMENT, string VARCHAR (20), user_id INT UNSIGNED FOREIGN KEY REFERENCES ra_user(id), PRIMARY KEY (id))";
+        assertSqlCanBeParsedAndDeparsed(statement,true);
+    }
     
     public void testCreateTablePrimaryKey() throws JSQLParserException {
 		String statement = "CREATE TABLE test (id INT UNSIGNED NOT NULL AUTO_INCREMENT, string VARCHAR (20), user_id INT UNSIGNED, CONSTRAINT pk_name PRIMARY KEY (id))";


### PR DESCRIPTION
The parser is crashing if a CREATE TABLE statement contains a inlined foreign key(see testcases).