### PR TITLE
Issue 195: support for ORDER BY and LIMIT, in UPDATE and DELETE statements

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
+++ b/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
@@ -25,11 +25,26 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
+import net.sf.jsqlparser.statement.select.Limit;
+import net.sf.jsqlparser.statement.select.OrderByElement;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+
+import java.util.List;
 
 public class Delete implements Statement {
 
 	private Table table;
 	private Expression where;
+	private Limit limit;
+	private List<OrderByElement> orderByElements;
+
+	public List<OrderByElement> getOrderByElements() {
+		return orderByElements;
+	}
+
+	public void setOrderByElements(List<OrderByElement> orderByElements) {
+		this.orderByElements = orderByElements;
+	}
 
 	@Override
 	public void accept(StatementVisitor statementVisitor) {
@@ -52,8 +67,19 @@ public class Delete implements Statement {
 		where = expression;
 	}
 
+	public Limit getLimit() {
+		return limit;
+	}
+
+	public void setLimit(Limit limit) {
+		this.limit = limit;
+	}
+
 	@Override
 	public String toString() {
-		return "DELETE FROM " + table + ((where != null) ? " WHERE " + where : "");
+		return "DELETE FROM " + table +
+				((where != null) ? " WHERE " + where : "") +
+				(orderByElements!=null? PlainSelect.orderByToString(orderByElements):"") +
+				(limit != null ? limit : "");
 	}
 }

--- a/src/main/java/net/sf/jsqlparser/statement/update/Update.java
+++ b/src/main/java/net/sf/jsqlparser/statement/update/Update.java
@@ -32,6 +32,8 @@ import net.sf.jsqlparser.statement.select.FromItem;
 import net.sf.jsqlparser.statement.select.Join;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.OrderByElement;
+import net.sf.jsqlparser.statement.select.Limit;
 
 /**
  * The update statement.
@@ -47,6 +49,8 @@ public class Update implements Statement {
 	private Select select;
 	private boolean useColumnsBrackets = true;
 	private boolean useSelect = false;
+	private List<OrderByElement> orderByElements;
+	private Limit limit;
 
 	@Override
 	public void accept(StatementVisitor statementVisitor) {
@@ -137,6 +141,22 @@ public class Update implements Statement {
 	        this.useSelect = useSelect;
     	}
 
+	public void setOrderByElements(List<OrderByElement> orderByElements) {
+		this.orderByElements = orderByElements;
+	}
+
+	public void setLimit(Limit limit) {
+		this.limit = limit;
+	}
+
+	public List<OrderByElement> getOrderByElements() {
+		return orderByElements;
+	}
+
+	public Limit getLimit() {
+		return limit;
+	}
+
 	@Override
 	public String toString() {
 		StringBuilder b = new StringBuilder("UPDATE ");
@@ -183,6 +203,12 @@ public class Update implements Statement {
 		if (where != null) {
 			b.append(" WHERE ");
 			b.append(where);
+		}
+		if (orderByElements!=null) {
+			b.append(PlainSelect.orderByToString(orderByElements));
+		}
+		if (limit != null) {
+			b.append(limit);
 		}
 		return b.toString();
 	}

--- a/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
@@ -59,6 +59,13 @@ public class DeleteDeParser {
 			delete.getWhere().accept(expressionVisitor);
 		}
 
+		if(delete.getOrderByElements()!=null){
+			new OrderByDeParser(expressionVisitor, buffer).deParse(delete.getOrderByElements());
+		}
+		if (delete.getLimit() != null) {
+			new LimitDeparser(buffer).deParse(delete.getLimit());
+		}
+
 	}
 
 	public ExpressionVisitor getExpressionVisitor() {

--- a/src/main/java/net/sf/jsqlparser/util/deparser/LimitDeparser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/LimitDeparser.java
@@ -1,0 +1,52 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2015 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package net.sf.jsqlparser.util.deparser;
+
+import net.sf.jsqlparser.statement.select.Limit;
+
+public class LimitDeparser {
+
+    private StringBuilder buffer;
+
+    public LimitDeparser(StringBuilder buffer) {
+        this.buffer = buffer;
+    }
+
+    public void deParse(Limit limit) {
+        if (limit.isRowCountJdbcParameter()) {
+            buffer.append(" LIMIT ");
+            buffer.append("?");
+        } else if (limit.getRowCount() >= 0) {
+            buffer.append(" LIMIT ");
+            buffer.append(limit.getRowCount());
+        } else if (limit.isLimitNull()) {
+            buffer.append(" LIMIT NULL");
+        }
+
+        if (limit.isOffsetJdbcParameter()) {
+            buffer.append(" OFFSET ?");
+        } else if (limit.getOffset() != 0) {
+            buffer.append(" OFFSET ").append(limit.getOffset());
+        }
+    }
+
+}

--- a/src/main/java/net/sf/jsqlparser/util/deparser/OrderByDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/OrderByDeParser.java
@@ -1,0 +1,74 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2015 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package net.sf.jsqlparser.util.deparser;
+
+
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.statement.select.OrderByElement;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class OrderByDeParser {
+
+    private StringBuilder buffer;
+    private ExpressionVisitor expressionVisitor;
+
+    public OrderByDeParser(ExpressionVisitor expressionVisitor, StringBuilder buffer) {
+        this.expressionVisitor= expressionVisitor;
+        this.buffer = buffer;
+    }
+
+    public void deParse( List<OrderByElement> orderByElementList) {
+        deParse(false, orderByElementList);
+    }
+
+
+    public void deParse(boolean oracleSiblings, List<OrderByElement> orderByElementList){
+        if (oracleSiblings) {
+            buffer.append(" ORDER SIBLINGS BY ");
+        } else {
+            buffer.append(" ORDER BY ");
+        }
+
+        for (Iterator<OrderByElement> iter = orderByElementList.iterator(); iter.hasNext();) {
+            OrderByElement orderByElement = iter.next();
+            deParseElement(orderByElement);
+            if (iter.hasNext()) {
+                buffer.append(", ");
+            }
+        }
+    }
+
+    public void deParseElement(OrderByElement orderBy){
+        orderBy.getExpression().accept(expressionVisitor);
+        if (!orderBy.isAsc()) {
+            buffer.append(" DESC");
+        } else if (orderBy.isAscDescPresent()) {
+            buffer.append(" ASC");
+        }
+        if (orderBy.getNullOrdering() != null) {
+            buffer.append(' ');
+            buffer.append(orderBy.getNullOrdering() == OrderByElement.NullOrdering.NULLS_FIRST ? "NULLS FIRST" : "NULLS LAST");
+        }
+    }
+}

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -349,6 +349,8 @@ Update Update():
 	FromItem fromItem = null;
 	List<Join> joins = null;
 	Select select = null;
+	Limit limit = null;
+	List<OrderByElement> orderByElements;
 	boolean useColumnsBrackets = false;
 }
 {
@@ -375,6 +377,9 @@ Update Update():
       joins=JoinsList() ]
 
    [ where=WhereClause() { update.setWhere(where); } ]
+
+   [ orderByElements = OrderByElements() { update.setOrderByElements(orderByElements); } ]
+   [ limit = PlainLimit() { update.setLimit(limit); } ]
    {
    		update.setColumns(columns);
    		update.setExpressions(expList);
@@ -534,10 +539,14 @@ Delete Delete():
 	Delete delete = new Delete();
 	Table table = null;
 	Expression where = null;
+	Limit limit = null;
+	List<OrderByElement> orderByElements;
 }
 {
     <K_DELETE> [<K_FROM>] table=TableWithAlias()
     [where=WhereClause() { delete.setWhere(where); } ]
+    [orderByElements = OrderByElements() { delete.setOrderByElements(orderByElements); } ]
+    [limit=PlainLimit() {delete.setLimit(limit); } ]
     {
     	delete.setTable(table);
     	return delete;
@@ -773,7 +782,7 @@ PlainSelect PlainSelect():
     [ having=Having() { plainSelect.setHaving(having); }]
 	[LOOKAHEAD(<K_ORDER> <K_SIBLINGS> <K_BY>) orderByElements = OrderByElements() { plainSelect.setOracleSiblings(true); plainSelect.setOrderByElements(orderByElements);	}   ]
 	[LOOKAHEAD(<K_ORDER> <K_BY>) orderByElements = OrderByElements() { plainSelect.setOrderByElements(orderByElements);	}   ]
-    [LOOKAHEAD(<K_LIMIT>) limit = Limit() { plainSelect.setLimit(limit);	} ]
+    [LOOKAHEAD(<K_LIMIT>) limit = LimitWithOffset() { plainSelect.setLimit(limit);	} ]
 	[LOOKAHEAD(<K_OFFSET>) offset = Offset() { plainSelect.setOffset(offset);	} ]
 	[LOOKAHEAD(<K_FETCH>) fetch = Fetch() { plainSelect.setFetch(fetch);	} ]
 
@@ -817,7 +826,7 @@ SetOperationList SetOperationList():
 		)
 
 		[orderByElements=OrderByElements() {list.setOrderByElements(orderByElements);} ]
-		[LOOKAHEAD(<K_LIMIT>) limit=Limit() {list.setLimit(limit);} ]
+		[LOOKAHEAD(<K_LIMIT>) limit=LimitWithOffset() {list.setLimit(limit);} ]
 		[LOOKAHEAD(<K_OFFSET>) offset = Offset() { list.setOffset(offset);} ]
 		[LOOKAHEAD(<K_FETCH>) fetch = Fetch() { list.setFetch(fetch);} ]
 	)
@@ -1296,7 +1305,7 @@ OrderByElement OrderByElement():
 	}
 }
 
-Limit Limit():
+Limit LimitWithOffset():
 {
 	Limit limit = new Limit();
 	limit.setRowCount(-1l);
@@ -1319,19 +1328,31 @@ Limit Limit():
 				token=<S_LONG> { limit.setRowCount(Long.parseLong(token.image)); } | "?" { limit.setRowCountJdbcParameter(true);}
 				)
 			|
-				// mysql-postgresql-> LIMIT (row_count | ALL | NULL)
-				<K_LIMIT>
-				 (
-				 	token=<S_LONG> { limit.setRowCount(Long.parseLong(token.image)); }
-				 	|
-				 	"?" { limit.setRowCountJdbcParameter(true);}
-				 	|
-				 	<K_ALL> { limit.setLimitAll(true);}
-				 	|
-				 	<K_NULL> { limit.setLimitNull(true); }
-				 )
-
+			limit = PlainLimit()
 		)
+	{
+		return limit;
+	}
+}
+
+Limit PlainLimit():
+{
+	Limit limit = new Limit();
+	limit.setRowCount(-1l);
+	Token token = null;
+}
+{
+	// mysql-postgresql-> LIMIT (row_count | ALL | NULL)
+	<K_LIMIT>
+	 (
+	 	token=<S_LONG> { limit.setRowCount(Long.parseLong(token.image)); }
+	 	|
+	 	"?" { limit.setRowCountJdbcParameter(true);}
+	 	|
+	 	<K_ALL> { limit.setLimitAll(true);}
+	 	|
+	 	<K_NULL> { limit.setLimitNull(true); }
+	 )
 	{
 		return limit;
 	}

--- a/src/test/java/net/sf/jsqlparser/test/delete/DeleteTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/delete/DeleteTest.java
@@ -3,20 +3,18 @@ package net.sf.jsqlparser.test.delete;
 import java.io.StringReader;
 import static junit.framework.Assert.assertEquals;
 
-import junit.framework.TestCase;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
 import net.sf.jsqlparser.statement.delete.Delete;
+import org.junit.Test;
+
 import static net.sf.jsqlparser.test.TestUtils.*;
 
-public class DeleteTest extends TestCase {
+public class DeleteTest {
 
 	CCJSqlParserManager parserManager = new CCJSqlParserManager();
 
-	public DeleteTest(String arg0) {
-		super(arg0);
-	}
-
+	@Test
 	public void testDelete() throws JSQLParserException {
 		String statement = "DELETE FROM mytable WHERE mytable.col = 9";
 
@@ -25,8 +23,34 @@ public class DeleteTest extends TestCase {
 		assertEquals(statement, "" + delete);
 	}
 	
+	@Test
 	public void testDeleteWhereProblem1() throws JSQLParserException {
 		String stmt = "DELETE FROM tablename WHERE a = 1 AND b = 1";
 		assertSqlCanBeParsedAndDeparsed(stmt);
 	}
+
+	@Test
+	public void testDeleteWithLimit() throws JSQLParserException {
+		String stmt = "DELETE FROM tablename WHERE a = 1 AND b = 1 LIMIT 5";
+		assertSqlCanBeParsedAndDeparsed(stmt);
+	}
+
+	@Test(expected = JSQLParserException.class)
+	public void testDeleteDoesNotAllowLimitOffset() throws JSQLParserException {
+		String statement = "DELETE FROM table1 WHERE A.cod_table = 'YYY' LIMIT 3,4";
+		parserManager.parse(new StringReader(statement));
+	}
+
+	@Test
+	public void testDeleteWithOrderBy() throws JSQLParserException {
+		String stmt = "DELETE FROM tablename WHERE a = 1 AND b = 1 ORDER BY col";
+		assertSqlCanBeParsedAndDeparsed(stmt);
+	}
+
+	@Test
+	public void testDeleteWithOrderByAndLimit() throws JSQLParserException {
+		String stmt = "DELETE FROM tablename WHERE a = 1 AND b = 1 ORDER BY col LIMIT 10";
+		assertSqlCanBeParsedAndDeparsed(stmt);
+	}
+
 }

--- a/src/test/java/net/sf/jsqlparser/test/update/UpdateTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/update/UpdateTest.java
@@ -70,4 +70,26 @@ public class UpdateTest {
     public void testUpdateIssue167_SingleQuotes() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("UPDATE tablename SET NAME = 'Customer 2', ADDRESS = 'Address \\' ddad2', AUTH_KEY = 'samplekey' WHERE ID = 2");
     }
+
+	@Test
+	public void testUpdateWithLimit() throws JSQLParserException {
+		assertSqlCanBeParsedAndDeparsed("UPDATE tablename SET col = 'thing' WHERE id = 1 LIMIT 10");
+	}
+
+	@Test
+	public void testUpdateWithOrderBy() throws JSQLParserException {
+		assertSqlCanBeParsedAndDeparsed("UPDATE tablename SET col = 'thing' WHERE id = 1 ORDER BY col");
+	}
+
+	@Test
+	public void testUpdateWithOrderByAndLimit() throws JSQLParserException {
+		assertSqlCanBeParsedAndDeparsed("UPDATE tablename SET col = 'thing' WHERE id = 1 ORDER BY col LIMIT 10");
+	}
+
+	@Test(expected = JSQLParserException.class)
+	public void testUpdateDoesNotAllowLimitOffset() throws JSQLParserException {
+		String statement = "UPDATE table1 A SET A.columna = 'XXX' WHERE A.cod_table = 'YYY' LIMIT 3,4";
+		parserManager.parse(new StringReader(statement));
+	}
+
 }


### PR DESCRIPTION
Add support for ORDER BY and LIMIT in UPDATE and DELETE statements (as supported by MySQL).

LimitDeparser and OrderByDeParser have been pulled out into separate classes to avoid code duplication from SelectDeParser.