### PR TITLE
Issue 198: make mvn package work on Java 8+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,9 @@
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
+                        <configuration>
+                            <additionalparam>${javadoc.opts}</additionalparam>
+                        </configuration>
                         <goals>
                             <goal>jar</goal>
                         </goals>
@@ -322,6 +325,15 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.opts>-Xdoclint:none</javadoc.opts>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
Added profile to ensure doclint is turned off with Java 8+. Without this, the project won't build on Java 8 (you can run `mvn test` successfully, but not `mvn package`).

The extra maven config allows `mvn package` to work on Java 6/7.