### PR TITLE
LongValue does not catch NumberFormatException

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/LongValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/LongValue.java
@@ -34,8 +34,12 @@ public class LongValue implements Expression {
 		if (val.charAt(0) == '+') {
 			val = val.substring(1);
 		}
-		this.value = Long.parseLong(val);
-        this.stringValue = val;
+		try {
+		        this.value = Long.parseLong(val);
+		} catch (NumberFormatException e) {
+		        throw new NumberFormatException("Passed value does not contain a parsable long value");
+		}
+		this.stringValue = val;
 	}
 	
 	public LongValue(long value) {


### PR DESCRIPTION
`LongValue.java` calls `java.lang.long.parseLong` without first checking whether the argument parses. This lead to an uncaught `NumberFormatException`: [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#parseLong%28java.lang.String,%20int%29).

This pull request adds a check with a  more helpful exception message and also fix an indentation issue at line no. 38.
