### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/src/main/java/net/sf/jsqlparser/util/AddAliasesVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/util/AddAliasesVisitor.java
@@ -37,6 +37,7 @@ import java.util.*;
  */
 public class AddAliasesVisitor implements SelectVisitor, SelectItemVisitor {
 
+	private static final String NOT_SUPPORTED_YET = "Not supported yet.";
 	private List<String> aliases = new LinkedList<String>();
 	private boolean firstRun = true;
 	private int counter = 0;
@@ -65,7 +66,7 @@ public class AddAliasesVisitor implements SelectVisitor, SelectItemVisitor {
 
 	@Override
 	public void visit(AllTableColumns allTableColumns) {
-		throw new UnsupportedOperationException("Not supported yet.");
+		throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
 	}
 
 	@Override
@@ -110,11 +111,11 @@ public class AddAliasesVisitor implements SelectVisitor, SelectItemVisitor {
 
 	@Override
 	public void visit(WithItem withItem) {
-		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+		throw new UnsupportedOperationException(NOT_SUPPORTED_YET); //To change body of generated methods, choose Tools | Templates.
 	}
 
 	@Override
 	public void visit(AllColumns allColumns) {
-		throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+		throw new UnsupportedOperationException(NOT_SUPPORTED_YET); //To change body of generated methods, choose Tools | Templates.
 	}
 }

--- a/src/main/java/net/sf/jsqlparser/util/SelectUtils.java
+++ b/src/main/java/net/sf/jsqlparser/util/SelectUtils.java
@@ -24,6 +24,7 @@ package net.sf.jsqlparser.util;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
@@ -45,6 +46,8 @@ import net.sf.jsqlparser.statement.select.WithItem;
  * @author toben
  */
 public final class SelectUtils {
+
+	private static final String NOT_SUPPORTED_YET = "Not supported yet.";
 
 	private SelectUtils() {
 	}
@@ -113,12 +116,12 @@ public final class SelectUtils {
 
 			@Override
 			public void visit(SetOperationList setOpList) {
-				throw new UnsupportedOperationException("Not supported yet.");
+				throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
 			}
 
 			@Override
 			public void visit(WithItem withItem) {
-				throw new UnsupportedOperationException("Not supported yet.");
+				throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
 			}
 		});
 	}
@@ -145,7 +148,7 @@ public final class SelectUtils {
 			joins.add(join);
 			return join;
 		}
-		throw new UnsupportedOperationException("Not supported yet.");
+		throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
 	}
     
     /**
@@ -163,12 +166,12 @@ public final class SelectUtils {
 
 			@Override
 			public void visit(SetOperationList setOpList) {
-				throw new UnsupportedOperationException("Not supported yet.");
+				throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
 			}
 
 			@Override
 			public void visit(WithItem withItem) {
-				throw new UnsupportedOperationException("Not supported yet.");
+				throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
 			}
 		});
     }

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -36,6 +36,7 @@ import net.sf.jsqlparser.statement.update.Update;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import net.sf.jsqlparser.statement.SetStatement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.Statements;
@@ -53,7 +54,8 @@ import net.sf.jsqlparser.statement.truncate.Truncate;
  */
 public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, ExpressionVisitor, ItemsListVisitor, SelectItemVisitor, StatementVisitor {
 
-    private List<String> tables;
+    private static final String NOT_SUPPORTED_YET = "Not supported yet.";
+	private List<String> tables;
     /**
      * There are special names, that are not table names but are parsed as
      * tables. These names are collected here and are not included in the tables
@@ -573,17 +575,17 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
 
     @Override
     public void visit(Drop drop) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
     public void visit(Truncate truncate) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
     public void visit(CreateIndex createIndex) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
@@ -596,27 +598,27 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
 
     @Override
     public void visit(CreateView createView) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
     public void visit(Alter alter) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
     public void visit(Statements stmts) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
     public void visit(Execute execute) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
     public void visit(SetStatement set) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
@@ -633,7 +635,7 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
 
     @Override
     public void visit(Merge merge) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException(NOT_SUPPORTED_YET); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -38,7 +38,8 @@ import java.util.Iterator;
  */
 public class ExpressionDeParser implements ExpressionVisitor, ItemsListVisitor {
 
-    private StringBuilder buffer;
+    private static final String NOT = " NOT ";
+	private StringBuilder buffer;
     private SelectVisitor selectVisitor;
     private boolean useBracketsInExprList = true;
 
@@ -119,7 +120,7 @@ public class ExpressionDeParser implements ExpressionVisitor, ItemsListVisitor {
 
     public void visitOldOracleJoinBinaryExpression(OldOracleJoinBinaryExpression expression, String operator) {
         if (expression.isNot()) {
-            buffer.append(" NOT ");
+            buffer.append(NOT);
         }
         expression.getLeftExpression().accept(this);
         if (expression.getOldOracleJoinSyntax() == EqualsTo.ORACLE_JOIN_RIGHT) {
@@ -250,7 +251,7 @@ public class ExpressionDeParser implements ExpressionVisitor, ItemsListVisitor {
     @Override
     public void visit(Parenthesis parenthesis) {
         if (parenthesis.isNot()) {
-            buffer.append(" NOT ");
+            buffer.append(NOT);
         }
 
         buffer.append("(");
@@ -273,7 +274,7 @@ public class ExpressionDeParser implements ExpressionVisitor, ItemsListVisitor {
 
     private void visitBinaryExpression(BinaryExpression binaryExpression, String operator) {
         if (binaryExpression.isNot()) {
-            buffer.append(" NOT ");
+            buffer.append(NOT);
         }
         binaryExpression.getLeftExpression().accept(this);
         buffer.append(operator);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1192 - String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
Please let me know if you have any questions.
George Kankava