### PR TITLE
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/OracleHint.java
+++ b/src/main/java/net/sf/jsqlparser/expression/OracleHint.java
@@ -32,15 +32,15 @@ public class OracleHint implements Expression {
 
     private static final Pattern SINGLE_LINE = Pattern.compile("--\\+ *([^ ].*[^ ])");
     private static final Pattern MULTI_LINE = Pattern.compile("\\/\\*\\+ *([^ ].*[^ ]) *\\*+\\/", Pattern.MULTILINE | Pattern.DOTALL);
-    
+
+    private String value;
+    private boolean singleLine = false;
+
     public static boolean isHintMatch(String comment) {
         return SINGLE_LINE.matcher(comment).find() || 
                MULTI_LINE.matcher(comment).find();
     }
     
-    private String value;
-    private boolean singleLine = false;
-
     public final void setComment(String comment) {
         Matcher m;
         {

--- a/src/main/java/net/sf/jsqlparser/expression/WithinGroupExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/WithinGroupExpression.java
@@ -32,6 +32,10 @@ import net.sf.jsqlparser.statement.select.OrderByElement;
 public class WithinGroupExpression implements Expression {
 
     private String name;
+    
+    private List<OrderByElement> orderByElements;
+    
+    private ExpressionList exprList;
 
     public String getName() {
         return name;
@@ -41,8 +45,6 @@ public class WithinGroupExpression implements Expression {
         this.name = name;
     }
 
-    private List<OrderByElement> orderByElements;
-
     public List<OrderByElement> getOrderByElements() {
         return orderByElements;
     }
@@ -50,8 +52,6 @@ public class WithinGroupExpression implements Expression {
     public void setOrderByElements(List<OrderByElement> orderByElements) {
         this.orderByElements = orderByElements;
     }
-
-    private ExpressionList exprList;
 
     public ExpressionList getExprList() {
         return exprList;

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/SupportsOldOracleJoinSyntax.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/SupportsOldOracleJoinSyntax.java
@@ -26,14 +26,13 @@ public interface SupportsOldOracleJoinSyntax {
 	int NO_ORACLE_JOIN = 0;
 	int ORACLE_JOIN_RIGHT = 1;
 	int ORACLE_JOIN_LEFT = 2;
+	int NO_ORACLE_PRIOR = 0;
+	int ORACLE_PRIOR_START = 1;
+	int ORACLE_PRIOR_END = 2;
 
 	int getOldOracleJoinSyntax();
 
 	void setOldOracleJoinSyntax(int oldOracleJoinSyntax);
-
-	int NO_ORACLE_PRIOR = 0;
-	int ORACLE_PRIOR_START = 1;
-	int ORACLE_PRIOR_END = 2;
 
 	int getOraclePriorPosition();
 

--- a/src/main/java/net/sf/jsqlparser/parser/CCJSqlParserUtil.java
+++ b/src/main/java/net/sf/jsqlparser/parser/CCJSqlParserUtil.java
@@ -34,6 +34,9 @@ import net.sf.jsqlparser.statement.Statements;
  * @author toben
  */
 public final class CCJSqlParserUtil {
+	
+	private CCJSqlParserUtil() {}
+	
 	public static Statement parse(Reader statementReader) throws JSQLParserException {
 		CCJSqlParser parser = new CCJSqlParser(statementReader);
 		try {
@@ -122,6 +125,4 @@ public final class CCJSqlParserUtil {
 		} 
 	}
 
-	private CCJSqlParserUtil() {
-	}
 }

--- a/src/main/java/net/sf/jsqlparser/statement/alter/Alter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/Alter.java
@@ -44,8 +44,12 @@ public class Alter implements Statement {
     private ForeignKeyIndex fkIndex = null;
 	private String operation;
     private String constraintName;
-
+    private boolean onDeleteRestrict;
+    private boolean onDeleteSetNull;
     private boolean onDeleteCascade;
+    private List<String> fkColumns;
+    private String fkSourceTable;
+    private List<String> fkSourceColumns;
 
     public boolean isOnDeleteCascade() {
         return onDeleteCascade;
@@ -55,8 +59,6 @@ public class Alter implements Statement {
         this.onDeleteCascade = onDeleteCascade;
     }
 
-    private boolean onDeleteRestrict;
-
     public boolean isOnDeleteRestrict() {
         return onDeleteRestrict;
     }
@@ -64,8 +66,6 @@ public class Alter implements Statement {
     public void setOnDeleteRestrict(boolean onDeleteRestrict) {
         this.onDeleteRestrict = onDeleteRestrict;
     }
-
-    private boolean onDeleteSetNull;
 
     public boolean isOnDeleteSetNull() {
         return onDeleteSetNull;
@@ -75,8 +75,6 @@ public class Alter implements Statement {
         this.onDeleteSetNull = onDeleteSetNull;
     }
 
-    private List<String> fkColumns;
-
     public List<String> getFkColumns() {
         return fkColumns;
     }
@@ -84,8 +82,6 @@ public class Alter implements Statement {
     public void setFkColumns(List<String> fkColumns) {
         this.fkColumns = fkColumns;
     }
-
-    private String fkSourceTable;
 
     public String getFkSourceTable() {
         return fkSourceTable;
@@ -102,8 +98,6 @@ public class Alter implements Statement {
     public void setOperation(String operation) {
         this.operation = operation;
     }
-
-    private List<String> fkSourceColumns;
 
     public List<String> getFkSourceColumns() {
         return fkSourceColumns;

--- a/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
@@ -36,6 +36,12 @@ import net.sf.jsqlparser.statement.select.SubSelect;
 public class Merge implements Statement {
 
     private Table table;
+    private Table usingTable;
+    private SubSelect usingSelect;
+    private Alias usingAlias;
+    private Expression onCondition;
+    private MergeInsert mergeInsert;
+    private MergeUpdate mergeUpdate;
 
     public Table getTable() {
         return table;
@@ -45,8 +51,6 @@ public class Merge implements Statement {
         table = name;
     }
 
-    private Table usingTable;
-
     public Table getUsingTable() {
         return usingTable;
     }
@@ -54,8 +58,6 @@ public class Merge implements Statement {
     public void setUsingTable(Table usingTable) {
         this.usingTable = usingTable;
     }
-
-    private SubSelect usingSelect;
 
     public SubSelect getUsingSelect() {
         return usingSelect;
@@ -68,8 +70,6 @@ public class Merge implements Statement {
         }
     }
 
-    private Alias usingAlias;
-
     public Alias getUsingAlias() {
         return usingAlias;
     }
@@ -77,8 +77,6 @@ public class Merge implements Statement {
     public void setUsingAlias(Alias usingAlias) {
         this.usingAlias = usingAlias;
     }
-
-    private Expression onCondition;
 
     public Expression getOnCondition() {
         return onCondition;
@@ -88,8 +86,6 @@ public class Merge implements Statement {
         this.onCondition = onCondition;
     }
 
-    private MergeInsert mergeInsert;
-
     public MergeInsert getMergeInsert() {
         return mergeInsert;
     }
@@ -97,8 +93,6 @@ public class Merge implements Statement {
     public void setMergeInsert(MergeInsert insert) {
         this.mergeInsert = insert;
     }
-
-    private MergeUpdate mergeUpdate;
 
     public MergeUpdate getMergeUpdate() {
         return mergeUpdate;

--- a/src/main/java/net/sf/jsqlparser/statement/merge/MergeUpdate.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/MergeUpdate.java
@@ -33,6 +33,8 @@ public class MergeUpdate {
 
     private List<Column> columns = null;
     private List<Expression> values = null;
+    private Expression whereCondition;
+    private Expression deleteWhereCondition;
 
     public List<Column> getColumns() {
         return columns;
@@ -50,8 +52,6 @@ public class MergeUpdate {
         this.values = values;
     }
 
-    private Expression whereCondition;
-
     public Expression getWhereCondition() {
         return whereCondition;
     }
@@ -59,8 +59,6 @@ public class MergeUpdate {
     public void setWhereCondition(Expression whereCondition) {
         this.whereCondition = whereCondition;
     }
-
-    private Expression deleteWhereCondition;
 
     public Expression getDeleteWhereCondition() {
         return deleteWhereCondition;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
Please let me know if you have any questions.
George Kankava