### PR TITLE
multiple code improvements 1

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/ExistsExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/ExistsExpression.java
@@ -51,7 +51,7 @@ public class ExistsExpression implements Expression {
 	}
 
 	public String getStringExpression() {
-		return ((not) ? "NOT " : "") + "EXISTS";
+		return not ? "NOT " : "" + "EXISTS";
 	}
 
 	@Override

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/ExistsExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/ExistsExpression.java
@@ -51,7 +51,7 @@ public class ExistsExpression implements Expression {
 	}
 
 	public String getStringExpression() {
-		return not ? "NOT " : "" + "EXISTS";
+		return (not ? "NOT " : "") + "EXISTS";
 	}
 
 	@Override

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/InExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/InExpression.java
@@ -97,7 +97,7 @@ public class InExpression implements Expression, SupportsOldOracleJoinSyntax {
 
 	@Override
 	public String toString() {
-		return (leftExpression == null ? leftItemsList : getLeftExpressionString()) + " " + ((not) ? "NOT " : "") + "IN " + rightItemsList + "";
+		return (leftExpression == null ? leftItemsList : getLeftExpressionString()) + " " + (not ? "NOT " : "") + "IN " + rightItemsList + "";
 	}
 
 	@Override

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsNullExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsNullExpression.java
@@ -52,6 +52,6 @@ public class IsNullExpression implements Expression {
 
 	@Override
 	public String toString() {
-		return leftExpression + " IS " + ((not) ? "NOT " : "") + "NULL";
+		return leftExpression + " IS " + (not ? "NOT " : "") + "NULL";
 	}
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/LikeExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/LikeExpression.java
@@ -46,7 +46,7 @@ public class LikeExpression extends BinaryExpression {
 
 	@Override
 	public String getStringExpression() {
-		return ((not) ? "NOT " : "") + (caseInsensitive?"ILIKE":"LIKE");
+		return (not ? "NOT " : "") + (caseInsensitive?"ILIKE":"LIKE");
 	}
 
 	@Override

--- a/src/main/java/net/sf/jsqlparser/statement/select/Fetch.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Fetch.java
@@ -65,6 +65,6 @@ public class Fetch {
 
 	@Override
 	public String toString() {
-		return " FETCH " + (isFetchParamFirst ? "FIRST" : "NEXT") + " " + (fetchJdbcParameter ? "?" : rowCount + "") + " "+ fetchParam + " ONLY";
+		return " FETCH " + (isFetchParamFirst ? "FIRST" : "NEXT") + " " + (fetchJdbcParameter ? "?" : Long.toString(rowCount)) + " " + fetchParam + " ONLY";
 	}
 }

--- a/src/main/java/net/sf/jsqlparser/statement/select/Limit.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Limit.java
@@ -90,10 +90,10 @@ public class Limit {
 		if (limitNull) {
             retVal += " LIMIT NULL";
         } else if (rowCount >= 0 || rowCountJdbcParameter) {
-			retVal += " LIMIT " + (rowCountJdbcParameter ? "?" : rowCount + "");
+			retVal += " LIMIT " + (rowCountJdbcParameter ? "?" : Long.toString(rowCount));
 		}
 		if (offset > 0 || offsetJdbcParameter) {
-			retVal += " OFFSET " + (offsetJdbcParameter ? "?" : offset + "");
+			retVal += " OFFSET " + (offsetJdbcParameter ? "?" : Long.toString(offset));
 		}
 		return retVal;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S2131 - Primitives should not be boxed just for "String" conversion.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AUselessParenthesesCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2131
Please let me know if you have any questions.
George Kankava