### PR TITLE
Multiple code improvements: squid:S2131, squid:S1155

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/drop/Drop.java
+++ b/src/main/java/net/sf/jsqlparser/statement/drop/Drop.java
@@ -77,7 +77,7 @@ public class Drop implements Statement {
 		String sql = "DROP " + type + " "
            + (ifExists?"IF EXISTS ":"") + name.toString();
 
-		if (parameters != null && parameters.size() > 0) {
+		if (parameters != null && !parameters.isEmpty()) {
 			sql += " " + PlainSelect.getStringList(parameters);
 		}
 

--- a/src/main/java/net/sf/jsqlparser/statement/select/Distinct.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Distinct.java
@@ -48,7 +48,7 @@ public class Distinct {
 	public String toString() {
 		String sql = "DISTINCT";
 
-		if (onSelectItems != null && onSelectItems.size() > 0) {
+		if (onSelectItems != null && !onSelectItems.isEmpty()) {
 			sql += " ON (" + PlainSelect.getStringList(onSelectItems) + ")";
 		}
 

--- a/src/main/java/net/sf/jsqlparser/statement/select/Fetch.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Fetch.java
@@ -65,6 +65,6 @@ public class Fetch {
 
 	@Override
 	public String toString() {
-		return " FETCH " + (isFetchParamFirst ? "FIRST" : "NEXT") + " " + (fetchJdbcParameter ? "?" : rowCount + "") + " "+ fetchParam + " ONLY";
+		return " FETCH " + (isFetchParamFirst ? "FIRST" : "NEXT") + " " + (fetchJdbcParameter ? "?" : Long.toString(rowCount)) + " "+ fetchParam + " ONLY";
 	}
 }

--- a/src/main/java/net/sf/jsqlparser/statement/select/Limit.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Limit.java
@@ -90,10 +90,10 @@ public class Limit {
 		if (limitNull) {
             retVal += " LIMIT NULL";
         } else if (rowCount >= 0 || rowCountJdbcParameter) {
-			retVal += " LIMIT " + (rowCountJdbcParameter ? "?" : rowCount + "");
+			retVal += " LIMIT " + (rowCountJdbcParameter ? "?" : Long.toString(rowCount));
 		}
 		if (offset > 0 || offsetJdbcParameter) {
-			retVal += " OFFSET " + (offsetJdbcParameter ? "?" : offset + "");
+			retVal += " OFFSET " + (offsetJdbcParameter ? "?" : Long.toString(offset));
 		}
 		return retVal;
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2131 - Primitives should not be boxed just for "String" conversion.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2131
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155
Please let me know if you have any questions.
George Kankava