### PR TITLE
multiple code improvements: squid:S1905, squid:S00122, squid:S1155, squid:S00105

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/Select.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Select.java
@@ -29,45 +29,45 @@ import net.sf.jsqlparser.statement.StatementVisitor;
 
 public class Select implements Statement {
 
-	private SelectBody selectBody;
-	private List<WithItem> withItemsList;
+    private SelectBody selectBody;
+    private List<WithItem> withItemsList;
 
-	@Override
-	public void accept(StatementVisitor statementVisitor) {
-		statementVisitor.visit(this);
-	}
+    @Override
+    public void accept(StatementVisitor statementVisitor) {
+        statementVisitor.visit(this);
+    }
 
-	public SelectBody getSelectBody() {
-		return selectBody;
-	}
+    public SelectBody getSelectBody() {
+        return selectBody;
+    }
 
-	public void setSelectBody(SelectBody body) {
-		selectBody = body;
-	}
+    public void setSelectBody(SelectBody body) {
+        selectBody = body;
+    }
 
-	@Override
-	public String toString() {
-		StringBuilder retval = new StringBuilder();
-		if (withItemsList != null && !withItemsList.isEmpty()) {
-			retval.append("WITH ");
-			for (Iterator<WithItem> iter = withItemsList.iterator(); iter.hasNext();) {
-				WithItem withItem = (WithItem) iter.next();
-				retval.append(withItem);
-				if (iter.hasNext()) {
-					retval.append(",");
-				}
-				retval.append(" ");
-			}
-		}
-		retval.append(selectBody);
-		return retval.toString();
-	}
+    @Override
+    public String toString() {
+        StringBuilder retval = new StringBuilder();
+        if (withItemsList != null && !withItemsList.isEmpty()) {
+            retval.append("WITH ");
+            for (Iterator<WithItem> iter = withItemsList.iterator(); iter.hasNext();) {
+                WithItem withItem = iter.next();
+                retval.append(withItem);
+                if (iter.hasNext()) {
+                    retval.append(",");
+                }
+                retval.append(" ");
+            }
+        }
+        retval.append(selectBody);
+        return retval.toString();
+    }
 
-	public List<WithItem> getWithItemsList() {
-		return withItemsList;
-	}
+    public List<WithItem> getWithItemsList() {
+        return withItemsList;
+    }
 
-	public void setWithItemsList(List<WithItem> withItemsList) {
-		this.withItemsList = withItemsList;
-	}
+    public void setWithItemsList(List<WithItem> withItemsList) {
+        this.withItemsList = withItemsList;
+    }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/select/SubSelect.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/SubSelect.java
@@ -34,47 +34,47 @@ import net.sf.jsqlparser.expression.operators.relational.ItemsListVisitor;
  */
 public class SubSelect implements FromItem, Expression, ItemsList {
 
-	private SelectBody selectBody;
-	private Alias alias;
+    private SelectBody selectBody;
+    private Alias alias;
     private boolean useBrackets = true;
     private List<WithItem> withItemsList;
 
     private Pivot pivot;
 
-	@Override
-	public void accept(FromItemVisitor fromItemVisitor) {
-		fromItemVisitor.visit(this);
-	}
+    @Override
+    public void accept(FromItemVisitor fromItemVisitor) {
+        fromItemVisitor.visit(this);
+    }
 
-	public SelectBody getSelectBody() {
-		return selectBody;
-	}
+    public SelectBody getSelectBody() {
+        return selectBody;
+    }
 
-	public void setSelectBody(SelectBody body) {
-		selectBody = body;
-	}
+    public void setSelectBody(SelectBody body) {
+        selectBody = body;
+    }
 
-	@Override
-	public void accept(ExpressionVisitor expressionVisitor) {
-		expressionVisitor.visit(this);
-	}
+    @Override
+    public void accept(ExpressionVisitor expressionVisitor) {
+        expressionVisitor.visit(this);
+    }
 
-	@Override
-	public Alias getAlias() {
-		return alias;
-	}
+    @Override
+    public Alias getAlias() {
+        return alias;
+    }
 
-	@Override
-	public void setAlias(Alias alias) {
-		this.alias = alias;
-	}
+    @Override
+    public void setAlias(Alias alias) {
+        this.alias = alias;
+    }
 
-	@Override
+    @Override
     public Pivot getPivot() {
         return pivot;
     }
 
-	@Override
+    @Override
     public void setPivot(Pivot pivot) {
         this.pivot = pivot;
     }
@@ -88,41 +88,45 @@ public class SubSelect implements FromItem, Expression, ItemsList {
     }
     
     public List<WithItem> getWithItemsList() {
-		return withItemsList;
-	}
+        return withItemsList;
+    }
 
-	public void setWithItemsList(List<WithItem> withItemsList) {
-		this.withItemsList = withItemsList;
-	}
+    public void setWithItemsList(List<WithItem> withItemsList) {
+        this.withItemsList = withItemsList;
+    }
 
-	@Override
-	public void accept(ItemsListVisitor itemsListVisitor) {
-		itemsListVisitor.visit(this);
-	}
+    @Override
+    public void accept(ItemsListVisitor itemsListVisitor) {
+        itemsListVisitor.visit(this);
+    }
 
-	@Override
-	public String toString() {
+    @Override
+    public String toString() {
         StringBuilder retval = new StringBuilder();
         if (useBrackets)
             retval.append("(");
         if (withItemsList != null && !withItemsList.isEmpty()) {
-			retval.append("WITH ");
-			for (Iterator<WithItem> iter = withItemsList.iterator(); iter.hasNext();) {
-				WithItem withItem = (WithItem) iter.next();
-				retval.append(withItem);
-				if (iter.hasNext()) {
-					retval.append(",");
-				}
-				retval.append(" ");
-			}
-		}
+            retval.append("WITH ");
+            for (Iterator<WithItem> iter = withItemsList.iterator(); iter.hasNext();) {
+                WithItem withItem = iter.next();
+                retval.append(withItem);
+                if (iter.hasNext()) {
+                    retval.append(",");
+                }
+                retval.append(" ");
+            }
+        }
         retval.append(selectBody);
         if (useBrackets)
             retval.append(")");
                 
-		if (pivot != null) retval.append(" ").append(pivot);
-        if (alias != null) retval.append(alias.toString());
+        if (pivot != null) {
+            retval.append(" ").append(pivot);
+        }
+        if (alias != null) {
+            retval.append(alias.toString());
+        }
         
         return retval.toString();
-	}
+    }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/DropDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/DropDeParser.java
@@ -32,29 +32,29 @@ public class DropDeParser {
 
     private StringBuilder buffer;
 
-	public DropDeParser(StringBuilder buffer) {
-		this.buffer = buffer;
-	}
+    public DropDeParser(StringBuilder buffer) {
+        this.buffer = buffer;
+    }
 
-	public void deParse(Drop drop) {
-		buffer.append("DROP ");
+    public void deParse(Drop drop) {
+        buffer.append("DROP ");
         buffer.append(drop.getType());
         if (drop.isIfExists())
             buffer.append(" IF EXISTS");
 
-		buffer.append(" ").append(drop.getName());
+        buffer.append(" ").append(drop.getName());
         
-        if (drop.getParameters() != null && drop.getParameters().size() > 0) {
-			buffer.append(" ").append(PlainSelect.getStringList(drop.getParameters()));
-		}
-	}
+        if (drop.getParameters() != null && !drop.getParameters().isEmpty()) {
+            buffer.append(" ").append(PlainSelect.getStringList(drop.getParameters()));
+        }
+    }
 
-	public StringBuilder getBuffer() {
-		return buffer;
-	}
+    public StringBuilder getBuffer() {
+        return buffer;
+    }
 
-	public void setBuffer(StringBuilder buffer) {
-		this.buffer = buffer;
-	}
+    public void setBuffer(StringBuilder buffer) {
+        this.buffer = buffer;
+    }
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1905 Redundant casts should not be used,
squid:S00122 Statements should be on separate lines,
squid:S1155 Collection.isEmpty() should be used to test for emptiness,
squid:S00105 Tabulation characters should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1905
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00122
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00105
Please let me know if you have any questions.
George Kankava