### PR TITLE
Support for Oracle 'HAVING' & 'GROUP BY' reversed.

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -806,6 +806,7 @@ PlainSelect PlainSelect():
 
     [ where=WhereClause() { plainSelect.setWhere(where); }]
 	[ oracleHierarchicalQueryClause=OracleHierarchicalQueryClause() { plainSelect.setOracleHierarchical(oracleHierarchicalQueryClause); } ]
+	[LOOKAHEAD(2) having=Having() { plainSelect.setHaving(having); }]
     [ groupByColumnReferences=GroupByColumnReferences() { plainSelect.setGroupByColumnReferences(groupByColumnReferences); }]
     [ having=Having() { plainSelect.setHaving(having); }]
 	[LOOKAHEAD(<K_ORDER> <K_SIBLINGS> <K_BY>) orderByElements = OrderByElements() { plainSelect.setOracleSiblings(true); plainSelect.setOrderByElements(orderByElements);	}   ]

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -818,6 +818,19 @@ public class SelectTest extends TestCase {
         assertTrue(plainSelect.getHaving() instanceof InExpression);
         assertStatementCanBeDeparsedAs(select, statement);
     }
+    
+    // Oracle allows us to 'mis-order' the having and group by clauses.
+    public void testHavingAndGroupByBackwards() throws JSQLParserException {
+    	String selectFromWhere = "SELECT MAX(tab1.b) FROM tab1 WHERE a > 34";
+    	String groupBy = "GROUP BY tab1.b";
+    	String having = "HAVING MAX(tab1.b) > 56";
+        String statement = selectFromWhere + " " + having + " " + groupBy;
+        Select select = (Select) parserManager.parse(new StringReader(statement));
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertTrue(plainSelect.getHaving() instanceof GreaterThan);
+        // NOTE: Expected SQL is in a different order than that passed in -- the parser 'corrects' the ordering.
+        assertStatementCanBeDeparsedAs(select, selectFromWhere + " " + groupBy + " " + having);
+    }
 
     public void testExists() throws JSQLParserException {
         String statement = "SELECT * FROM tab1 WHERE ";


### PR DESCRIPTION
Oracle allows the 'HAVING' clause and the 'GROUP BY' clause to be reversed (that is, the HAVING clause appearing first, followed by the GROUP BY clause).  We've modified the parser grammar to support this, and updated tests.

This necessitated some changes to the "SpecialOracleTest" class, specifically:
- Addition of the ability to have 'exceptions' to the 'execute all files in the directory' test.
- Addition of a method to specifically test that exception.
- Addition of an "after all tests are done" verification that all exceptions have been individually tested.
