### PR TITLE
Supporting Oracle operators like '>=' or '<=' with embedded whitespace.

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/ComparisonOperator.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/ComparisonOperator.java
@@ -21,20 +21,16 @@
  */
 package net.sf.jsqlparser.expression.operators.relational;
 
-import net.sf.jsqlparser.expression.ExpressionVisitor;
+public abstract class ComparisonOperator extends OldOracleJoinBinaryExpression {
 
-public class GreaterThanEquals extends ComparisonOperator {
+    private final String operator;
 
-	public GreaterThanEquals() {
-		super(">=");
-	}
+    public ComparisonOperator(String operator) {
+        this.operator = operator;
+    }
 
-	public GreaterThanEquals(String operator) {
-		super(operator);
-	}
-
-	@Override
-	public void accept(ExpressionVisitor expressionVisitor) {
-		expressionVisitor.visit(this);
-	}
+    @Override
+    public String getStringExpression() {
+        return operator;
+    }
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/EqualsTo.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/EqualsTo.java
@@ -23,15 +23,14 @@ package net.sf.jsqlparser.expression.operators.relational;
 
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 
-public class EqualsTo extends OldOracleJoinBinaryExpression {
+public class EqualsTo extends ComparisonOperator {
+
+	public EqualsTo() {
+		super("=");
+	}
 
 	@Override
 	public void accept(ExpressionVisitor expressionVisitor) {
 		expressionVisitor.visit(this);
-	}
-
-	@Override
-	public String getStringExpression() {
-		return "=";
 	}
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/GreaterThan.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/GreaterThan.java
@@ -23,15 +23,14 @@ package net.sf.jsqlparser.expression.operators.relational;
 
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 
-public class GreaterThan extends OldOracleJoinBinaryExpression {
+public class GreaterThan extends ComparisonOperator {
 
+	public GreaterThan() {
+		super(">");
+	}
+	
 	@Override
 	public void accept(ExpressionVisitor expressionVisitor) {
 		expressionVisitor.visit(this);
-	}
-
-	@Override
-	public String getStringExpression() {
-		return ">";
 	}
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/MinorThan.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/MinorThan.java
@@ -23,15 +23,14 @@ package net.sf.jsqlparser.expression.operators.relational;
 
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 
-public class MinorThan extends OldOracleJoinBinaryExpression {
+public class MinorThan extends ComparisonOperator {
+
+	public MinorThan() {
+		super("<");
+	}
 
 	@Override
 	public void accept(ExpressionVisitor expressionVisitor) {
 		expressionVisitor.visit(this);
-	}
-
-	@Override
-	public String getStringExpression() {
-		return "<";
 	}
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/MinorThanEquals.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/MinorThanEquals.java
@@ -23,15 +23,18 @@ package net.sf.jsqlparser.expression.operators.relational;
 
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 
-public class MinorThanEquals extends OldOracleJoinBinaryExpression {
+public class MinorThanEquals extends ComparisonOperator {
+
+	public MinorThanEquals() {
+		super("<=");
+	}
+
+	public MinorThanEquals(String operator) {
+		super(operator);
+	}
 
 	@Override
 	public void accept(ExpressionVisitor expressionVisitor) {
 		expressionVisitor.visit(this);
-	}
-
-	@Override
-	public String getStringExpression() {
-		return "<=";
 	}
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/NotEqualsTo.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/NotEqualsTo.java
@@ -23,28 +23,18 @@ package net.sf.jsqlparser.expression.operators.relational;
 
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 
-public class NotEqualsTo extends OldOracleJoinBinaryExpression {
-
-    private final String operator;
+public class NotEqualsTo extends ComparisonOperator {
 
     public NotEqualsTo() {
-        operator = "<>";
+        super("<>");
     }
 
     public NotEqualsTo(String operator) {
-        this.operator = operator;
-        if (!"!=".equals(operator) && !"<>".equals(operator)) {
-            throw new IllegalArgumentException("only <> or != allowed");
-        }
+        super(operator);
     }
 
     @Override
     public void accept(ExpressionVisitor expressionVisitor) {
         expressionVisitor.visit(this);
-    }
-
-    @Override
-    public String getStringExpression() {
-        return operator;
     }
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -95,10 +95,7 @@ PARSER_END(CCJSqlParser)
 
 SKIP:
 {
-    " "
-|   "\t"
-|   "\r"
-|   "\n"
+    <WHITESPACE: " " | "\t" | "\r" | "\n">
 }
 
 TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
@@ -235,6 +232,14 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |	<K_DELAYED : "DELAYED">
 |	<K_HIGH_PRIORITY : "HIGH_PRIORITY">
 |	<K_IGNORE : "IGNORE">
+}
+
+TOKEN : /* Operators */
+{
+	<OP_GREATERTHANEQUALS: ">" (<WHITESPACE>)* "=">
+|	<OP_MINORTHANEQUALS: "<" (<WHITESPACE>)* "=">
+|	<OP_NOTEQUALSSTANDARD: "<" (<WHITESPACE>)* ">">
+|	<OP_NOTEQUALSBANG: "!=">
 }
 
 TOKEN : /* Numeric Constants */
@@ -1611,14 +1616,14 @@ Expression RegularCondition():
 
 	[ "(" "+" ")" { oracleJoin=EqualsTo.ORACLE_JOIN_RIGHT; } ]
 
-	(
+	( LOOKAHEAD(2)
 	">" { result = new GreaterThan(); }
 	| "<" { result = new MinorThan(); }
 	| "=" { result = new EqualsTo(); }
-	| ">=" { result = new GreaterThanEquals(); }
-	| "<=" { result = new MinorThanEquals(); }
-	| "<>" { result = new NotEqualsTo(); }
-    | "!=" { result = new NotEqualsTo("!="); }
+	| token=<OP_GREATERTHANEQUALS> { result = new GreaterThanEquals(token.image); }
+	| token=<OP_MINORTHANEQUALS> { result = new MinorThanEquals(token.image); }
+	| token=<OP_NOTEQUALSSTANDARD> { result = new NotEqualsTo(token.image); }
+	| token=<OP_NOTEQUALSBANG> { result = new NotEqualsTo(token.image); }
 	| "@@" { result = new Matches(); }
 	| "~" { result = new RegExpMatchOperator(RegExpMatchOperatorType.MATCH_CASESENSITIVE); }
 	| <K_REGEXP> [ <K_BINARY> { binary=true; } ] { result = new RegExpMySQLOperator(binary?RegExpMatchOperatorType.MATCH_CASESENSITIVE:RegExpMatchOperatorType.MATCH_CASEINSENSITIVE); }

--- a/src/test/java/net/sf/jsqlparser/test/TestUtils.java
+++ b/src/test/java/net/sf/jsqlparser/test/TestUtils.java
@@ -25,6 +25,7 @@ import net.sf.jsqlparser.statement.*;
 import net.sf.jsqlparser.util.deparser.*;
 
 import java.io.*;
+import java.util.regex.Pattern;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.TestCase.assertEquals;
@@ -41,6 +42,8 @@ import org.junit.Test;
  * @author toben
  */
 public class TestUtils {
+
+    private static final Pattern SQL_COMMENT_PATTERN = Pattern.compile("(--.*$)|(/\\*.*?\\*/)",Pattern.MULTILINE);
 
     public static void assertSqlCanBeParsedAndDeparsed(String statement) throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed(statement, false);
@@ -72,8 +75,9 @@ public class TestUtils {
         assertEquals(buildSqlString(statement, laxDeparsingCheck), 
                 buildSqlString(deParser.getBuffer().toString(), laxDeparsingCheck));
     }
-
+    
     public static String buildSqlString(String sql, boolean laxDeparsingCheck) {
+    	sql = SQL_COMMENT_PATTERN.matcher(sql).replaceAll("");
         if (laxDeparsingCheck) {
             return sql.replaceAll("\\s", " ").replaceAll("\\s+", " ").replaceAll("\\s*([/,()=+\\-*|\\]<>])\\s*", "$1").toLowerCase().trim();
         } else {


### PR DESCRIPTION
Added ability to have operators like '>=' or '<=' separated by a space.

This includes:
- Modifying the JJT syntax to support the 'space in the middle' versions of operators (any quantity of whitespace is supported).
- Modifying the various operators to inherit from a new 'ComparisonOperator' class, which handles the (previously NotEqualsTo-only) logic for capturing the form of the operator.
- Giving each of the various operators a constructor that accepts the syntax used.
- Modifying TestUtils to strip comments out before comparing SQL text (necessary because condition07.sql is now passing, and has a comment).
- Updating SpecialOracleTest to indicate 130 tests passing now (condition7.sql now passes).
- Adding a new test specifically for operators into SpecialOracleTest.

NOTE: Because the "! =" form of the 'not equals' operator means something different in PostgresSQL (factorial of previous argument + equals), we do NOT include that case.