### PR TITLE
Add support for Hive's LEFT SEMI JOIN

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -39,6 +39,7 @@ public class Join {
 	private boolean inner = false;
 	private boolean simple = false;
 	private boolean cross = false;
+	private boolean semi = false;
 	private FromItem rightItem;
 	private Expression onExpression;
 	private List<Column> usingColumns;
@@ -81,6 +82,15 @@ public class Join {
 	public void setOuter(boolean b) {
 		outer = b;
 	}
+
+	/**
+	 * Whether is a "SEMI" join
+	 *
+	 * @return true if is a "SEMI" join
+	 */
+	public boolean isSemi() { return semi; }
+
+	public void setSemi(boolean b) { semi = b; }
 
 	/**
 	 * Whether is a "LEFT" join
@@ -199,6 +209,8 @@ public class Join {
 				type += "OUTER ";
 			} else if (isInner()) {
 				type += "INNER ";
+			} else if (isSemi()) {
+				type += "SEMI ";
 			}
 
 			return type + "JOIN " + rightItem + ((onExpression != null) ? " ON " + onExpression + "" : "")

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -338,6 +338,8 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
                 buffer.append(" OUTER");
             } else if (join.isInner()) {
                 buffer.append(" INNER");
+            } else if (join.isSemi()) {
+                buffer.append(" SEMI");
             }
 
             buffer.append(" JOIN ");

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -232,6 +232,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |	<K_DELAYED : "DELAYED">
 |	<K_HIGH_PRIORITY : "HIGH_PRIORITY">
 |	<K_IGNORE : "IGNORE">
+|   <K_SEMI : "SEMI">
 }
 
 TOKEN : /* Operators */
@@ -1224,9 +1225,9 @@ Join JoinerExpression():
 	List<Column> columns = null;
 }
 {
-    [   
-           ( <K_LEFT> { join.setLeft(true); }
-  		   | <K_RIGHT> { join.setRight(true); }
+    [
+  		<K_LEFT> { join.setLeft(true); } [ <K_SEMI> { join.setSemi(true); } | <K_OUTER> { join.setOuter(true); } ]
+  		|  ( <K_RIGHT> { join.setRight(true); }
   		   | <K_FULL> { join.setFull(true); } 
            ) [ <K_OUTER> { join.setOuter(true); } ]
         | <K_INNER> { join.setInner(true); }

--- a/src/test/java/net/sf/jsqlparser/test/select/HiveTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/HiveTest.java
@@ -1,0 +1,42 @@
+package net.sf.jsqlparser.test.select;
+
+import junit.framework.*;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+
+import static net.sf.jsqlparser.test.TestUtils.*;
+
+/**
+ * Created by nhanitvn on 5/19/16.
+ */
+public class HiveTest extends TestCase {
+
+    public void testLeftSemiJoin() throws Exception {
+        String sql;
+        Statement statement;
+
+        sql = "SELECT\n"
+                + "    Something\n"
+                + "FROM\n"
+                + "    Sometable\n"
+                + "LEFT SEMI JOIN\n"
+                + "    Othertable\n";
+
+        statement = CCJSqlParserUtil.parse(sql);
+
+        System.out.println(statement.toString());
+
+        Select select = (Select) statement;
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertEquals(1, plainSelect.getJoins().size());
+        assertEquals("Othertable", ((Table) plainSelect.getJoins().get(0).getRightItem()).getFullyQualifiedName());
+        assertTrue(plainSelect.getJoins().get(0).isLeft());
+        assertTrue(plainSelect.getJoins().get(0).isSemi());
+        assertStatementCanBeDeparsedAs(select, sql, true);
+
+        assertSqlCanBeParsedAndDeparsed(sql, true);
+    }
+}


### PR DESCRIPTION
HiveQL provides a type of JOIN named LEFT SEMI JOIN as a way to write IN/EXIST clause.

> LEFT SEMI JOIN implements the uncorrelated IN/EXISTS subquery semantics in an efficient way. As of Hive 0.13 the IN/NOT IN/EXISTS/NOT EXISTS operators are supported using subqueries so most of these JOINs don't have to be performed manually anymore. The restrictions of using LEFT SEMI JOIN is that the right-hand-side table should only be referenced in the join condition (ON-clause), but not in WHERE- or SELECT-clauses etc.

More information [here](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Joins)