### PR TITLE
fix bug of TablesNamesFinder when SubSelect has withItemsList

### DIFF
--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -141,6 +141,11 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
 
     @Override
     public void visit(SubSelect subSelect) {
+        if (subSelect.getWithItemsList() != null) {
+            for (WithItem withItem : subSelect.getWithItemsList()) {
+                withItem.accept(this);
+            }
+        }
         subSelect.getSelectBody().accept(this);
     }
 

--- a/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
@@ -13,6 +13,7 @@ import net.sf.jsqlparser.expression.OracleHint;
 
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.create.table.CreateTable;
 import net.sf.jsqlparser.statement.delete.Delete;
 import net.sf.jsqlparser.statement.insert.Insert;
@@ -37,6 +38,11 @@ public class TablesNamesFinderTest {
     @Test
     public void testMoreComplexExamples() throws Exception {
         runTestOnResource("complex-select-requests.txt");
+    }
+
+    @Test
+    public void testComplexMergeExamples() throws Exception {
+        runTestOnResource("complex-merge-requests.txt");
     }
 
     private void runTestOnResource(String resPath) throws Exception {
@@ -79,7 +85,7 @@ public class TablesNamesFinderTest {
                 String whereCols = getLine(in);
                 String type = getLine(in);
                 try {
-                    Select select = (Select) pm.parse(new StringReader(query));
+                    Statement statement = pm.parse(new StringReader(query));
                     StringTokenizer tokenizer = new StringTokenizer(tables, " ");
                     List tablesList = new ArrayList();
                     while (tokenizer.hasMoreTokens()) {
@@ -88,7 +94,7 @@ public class TablesNamesFinderTest {
 
                     String[] tablesArray = (String[]) tablesList.toArray(new String[tablesList.size()]);
 
-                    List<String> tableListRetr = tablesNamesFinder.getTableList(select);
+                    List<String> tableListRetr = tablesNamesFinder.getTableList(statement);
                     assertEquals("stm num:" + numSt, tablesArray.length, tableListRetr.size());
 
                     for (int i = 0; i < tablesArray.length; i++) {

--- a/src/test/resources/net/sf/jsqlparser/util/complex-merge-requests.txt
+++ b/src/test/resources/net/sf/jsqlparser/util/complex-merge-requests.txt
@@ -1,0 +1,122 @@
+// -----------------------------------------------------------------------------------------------------------------------
+// MERGE requests test
+//
+// The requests must have the following format:
+// #begin
+// <MERGE request>
+// #end
+// <isValid flag>: true if this request is valid
+//
+// If the request is valid:
+// <selected columns concerning by the select clause prefixed by the table>: for example: my_table.id
+// <selected table concerning by the from clause, eventually suffixed by an alias>: for example: my_table, my_table.my_alias, my_table
+// <selected columns concerning by the where clause prefixed by the table>: for example: my_table.id
+// <request type>: either CACHEABLE, UNCACHEABLE or UNIQUE_CACHEABLE
+//
+// If the request is not valid:
+// <error message>
+//
+// do not add empty line between the lines defining a test
+// line beginning by a // are ignored except in a test
+// -----------------------------------------------------------------------------------------------------------------------
+
+//1
+#begin
+MERGE INTO TEST_TABLE1 A
+USING
+(WITH
+    ALL_SID AS (
+        SELECT
+        TS.SID
+
+        FROM
+        TEST_TABLE2 TG
+        LEFT JOIN
+        TEST_TABLE3 TS
+        ON TG.GID=TS.GID
+
+        WHERE
+        TG.GID IN (
+            SELECT
+            DISTINCT GID
+
+            FROM
+            TEST_TABLE4
+
+            WHERE
+            LOGDAY > TRUNC(SYSDATE-90)
+        )
+    ),
+
+    VIRTUAL_SPLIT AS (
+        SELECT
+        VIRTUAL_SID,
+        MEMBER_SID
+
+        FROM
+        ALL_SID,
+        TEST_TABLE5
+
+        WHERE
+        ALL_SID.SID=TEST_TABLE5.VIRTUAL_SID
+    ),
+
+    ALL_CFS AS (
+        SELECT
+        DISTINCT SID AS SID
+
+        FROM (
+            SELECT
+            SID
+            FROM
+            ALL_SID
+            WHERE
+            SID NOT IN (
+                SELECT
+                VIRTUAL_SID
+                FROM
+                VIRTUAL_SPLIT
+            ) UNION ALL
+            SELECT
+            MEMBER_SID AS SID
+            FROM
+            VIRTUAL_SPLIT
+        )
+    )
+
+    SELECT
+    INV.SID,
+
+    CASE
+    WHEN
+    CF.SID IS NULL
+    THEN
+    0
+    ELSE
+    1
+    END AS FOCUS_MARK
+
+    FROM
+    TEST_TABLE1 INV
+    LEFT JOIN
+    ALL_CFS CF
+    ON INV.SID=CF.SID
+) B
+ON (
+    A.SID=B.SID
+)
+
+WHEN
+MATCHED
+
+THEN
+UPDATE
+SET
+A.FOCUS_REMARK = B.FOCUS_MARK,
+A.UPDATE_TIME = SYSDATE
+#end
+true
+?
+TEST_TABLE1 TEST_TABLE2 TEST_TABLE3 TEST_TABLE4 TEST_TABLE5
+?
+?


### PR DESCRIPTION
In original code, `TablesNamesFinder` just parse the `selectBody` in a `SubSelect` object. However it would lead to a mistake when a `SubSelect` object has `withItemsList`. This pull request fix it and add the corresponding unit test.
By the way, for the universal of unit test module, this pull request use `Statement` object replacing `Select` object.
Thanks for your reading.