### PR TITLE
Delete from table using join to another table

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
+++ b/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
@@ -25,6 +25,8 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
+import net.sf.jsqlparser.statement.select.FromItem;
+import net.sf.jsqlparser.statement.select.Join;
 import net.sf.jsqlparser.statement.select.Limit;
 import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.PlainSelect;
@@ -34,6 +36,8 @@ import java.util.List;
 public class Delete implements Statement {
 
 	private Table table;
+	private List<Table> tables;
+	private List<Join> joins;
 	private Expression where;
 	private Limit limit;
 	private List<OrderByElement> orderByElements;
@@ -75,11 +79,58 @@ public class Delete implements Statement {
 		this.limit = limit;
 	}
 
+	
+	public List<Table> getTables() {
+		return tables;
+	}
+
+	public void setTables(List<Table> tables) {
+		this.tables = tables;
+	}
+
+	public List<Join> getJoins() {
+		return joins;
+	}
+
+	public void setJoins(List<Join> joins) {
+		this.joins = joins;
+	}
+
 	@Override
 	public String toString() {
-		return "DELETE FROM " + table +
-				((where != null) ? " WHERE " + where : "") +
-				(orderByElements!=null? PlainSelect.orderByToString(orderByElements):"") +
-				(limit != null ? limit : "");
+		StringBuilder b = new StringBuilder("DELETE");
+	
+		if( tables != null && tables.size() > 0){
+			b.append(" ");
+			for(Table t : tables){
+				b.append(t.toString());
+			}
+		}
+		
+		b.append(" FROM ");
+		b.append(table);
+		
+		if (joins != null) {
+			for (Join join : joins) {
+				if (join.isSimple()) {
+					b.append(", ").append(join);
+				} else {
+					b.append(" ").append(join);
+				}
+			}
+		}
+		
+		if( where != null ){
+			b.append(" WHERE ").append(where);
+		}
+		
+		if(orderByElements!=null){
+			b.append(PlainSelect.orderByToString(orderByElements));
+		}
+		
+		if(limit != null){
+			b.append(limit);
+		}
+		return b.toString();
 	}
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
@@ -23,7 +23,9 @@ package net.sf.jsqlparser.util.deparser;
 
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.delete.Delete;
+import net.sf.jsqlparser.statement.select.Join;
 
 /**
  * A class to de-parse (that is, tranform from JSqlParser hierarchy into a
@@ -57,7 +59,24 @@ public class DeleteDeParser {
 	}
 
 	public void deParse(Delete delete) {
-		buffer.append("DELETE FROM ").append(delete.getTable().getFullyQualifiedName());
+		buffer.append("DELETE");
+		if(delete.getTables() != null && delete.getTables().size() > 0){
+			for( Table table : delete.getTables() ){
+				buffer.append(" ").append(table.getFullyQualifiedName());
+			}
+		}
+		buffer.append(" FROM ").append(delete.getTable().toString());
+		
+		if (delete.getJoins() != null) {
+            for (Join join : delete.getJoins()) {
+                if (join.isSimple()) {
+                    buffer.append(", ").append(join);
+                } else {
+                    buffer.append(" ").append(join);
+                }
+            }
+        }
+		
 		if (delete.getWhere() != null) {
 			buffer.append(" WHERE ");
 			delete.getWhere().accept(expressionVisitor);

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -631,16 +631,23 @@ Delete Delete():
 {
 	Delete delete = new Delete();
 	Table table = null;
+	List<Table> tables = new ArrayList<Table>();
+	List<Join> joins = null;
 	Expression where = null;
 	Limit limit = null;
 	List<OrderByElement> orderByElements;
 }
 {
-    <K_DELETE> [<K_FROM>] table=TableWithAlias()
+    <K_DELETE> [table=TableWithAlias() { tables.add(table); } 
+          ("," table=TableWithAlias() { tables.add(table); } )*] [<K_FROM>]
+    [ table=TableWithAlias()      joins=JoinsList() ]
     [where=WhereClause() { delete.setWhere(where); } ]
     [orderByElements = OrderByElements() { delete.setOrderByElements(orderByElements); } ]
     [limit=PlainLimit() {delete.setLimit(limit); } ]
     {
+      	delete.setTables(tables);
+		if (joins != null && joins.size() > 0)
+			delete.setJoins(joins);
     	delete.setTable(table);
     	return delete;
     }

--- a/src/test/java/net/sf/jsqlparser/test/TestUtils.java
+++ b/src/test/java/net/sf/jsqlparser/test/TestUtils.java
@@ -18,24 +18,26 @@
  */
 package net.sf.jsqlparser.test;
 
-import net.sf.jsqlparser.*;
-import net.sf.jsqlparser.expression.*;
-import net.sf.jsqlparser.parser.*;
-import net.sf.jsqlparser.statement.*;
-import net.sf.jsqlparser.util.deparser.*;
-
-import java.io.*;
-import java.util.regex.Pattern;
-
-import static junit.framework.Assert.assertEquals;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertNotNull;
-import net.sf.jsqlparser.statement.select.PlainSelect;
-import net.sf.jsqlparser.statement.select.Select;
-import net.sf.jsqlparser.statement.select.SelectBody;
-import net.sf.jsqlparser.statement.select.SetOperationList;
+
+import java.io.StringReader;
+import java.util.regex.Pattern;
+
 import org.junit.Assert;
 import org.junit.Test;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.OracleHint;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SetOperationList;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
 
 /**
  *

--- a/src/test/java/net/sf/jsqlparser/test/delete/DeleteTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/delete/DeleteTest.java
@@ -1,14 +1,15 @@
 package net.sf.jsqlparser.test.delete;
 
-import java.io.StringReader;
 import static junit.framework.Assert.assertEquals;
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+
+import java.io.StringReader;
+
+import org.junit.Test;
 
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
 import net.sf.jsqlparser.statement.delete.Delete;
-import org.junit.Test;
-
-import static net.sf.jsqlparser.test.TestUtils.*;
 
 public class DeleteTest {
 
@@ -52,5 +53,22 @@ public class DeleteTest {
 		String stmt = "DELETE FROM tablename WHERE a = 1 AND b = 1 ORDER BY col LIMIT 10";
 		assertSqlCanBeParsedAndDeparsed(stmt);
 	}
-
+	
+	@Test
+	public void testDeleteFromTableUsingInnerJoinToAnotherTable() throws JSQLParserException {
+		String stmt = "DELETE Table1 FROM Table1 INNER JOIN Table2 ON Table1.ID = Table2.ID";
+		assertSqlCanBeParsedAndDeparsed(stmt);
+	}
+	
+	@Test
+	public void testDeleteFromTableUsingLeftJoinToAnotherTable() throws JSQLParserException {
+		String stmt = "DELETE g FROM Table1 AS g LEFT JOIN Table2 ON Table1.ID = Table2.ID";
+		assertSqlCanBeParsedAndDeparsed(stmt);
+	}
+	
+	@Test
+	public void testDeleteFromTableUsingInnerJoinToAnotherTableWithAlias() throws JSQLParserException {
+		String stmt = "DELETE gc FROM guide_category AS gc LEFT JOIN guide AS g ON g.id_guide = gc.id_guide WHERE g.title IS NULL LIMIT 5";
+		assertSqlCanBeParsedAndDeparsed(stmt);
+	}
 }


### PR DESCRIPTION
Support for parse delete from table using join to another table like:

DELETE posts
FROM posts
INNER JOIN projects ON projects.project_id = posts.project_id
WHERE projects.client_id = :client_id

This necessitated some changes to the DeleteTest class, specifically:

JSqlParserCC.jjt - changes on grammar of Delete statements.
Delete toString and DeleteDeParser.