### PR TITLE
Update Alter to support Postgres ADD/DROP expressions

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -1,0 +1,235 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2016 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package net.sf.jsqlparser.statement.alter;
+
+
+import net.sf.jsqlparser.statement.create.table.ColDataType;
+import net.sf.jsqlparser.statement.create.table.Index;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ * @author toben & wrobstory
+ */
+public class AlterExpression {
+
+    private AlterOperation operation;
+    private String columnName;
+    //private ColDataType dataType;
+
+    private List<ColumnDataType> colDataTypeList;
+
+    private List<String> pkColumns;
+    private List<String> ukColumns;
+    private String ukName;
+    private Index index = null;
+    private String constraintName;
+    private boolean onDeleteRestrict;
+    private boolean onDeleteSetNull;
+    private boolean onDeleteCascade;
+    private List<String> fkColumns;
+    private String fkSourceTable;
+    private List<String> fkSourceColumns;
+
+    public AlterOperation getOperation() {
+        return operation;
+    }
+
+    public void setOperation(AlterOperation operation) {
+        this.operation = operation;
+    }
+
+    public boolean isOnDeleteCascade() {
+        return onDeleteCascade;
+    }
+
+    public void setOnDeleteCascade(boolean onDeleteCascade) {
+        this.onDeleteCascade = onDeleteCascade;
+    }
+
+    public boolean isOnDeleteRestrict() {
+        return onDeleteRestrict;
+    }
+
+    public void setOnDeleteRestrict(boolean onDeleteRestrict) {
+        this.onDeleteRestrict = onDeleteRestrict;
+    }
+
+    public boolean isOnDeleteSetNull() {
+        return onDeleteSetNull;
+    }
+
+    public void setOnDeleteSetNull(boolean onDeleteSetNull) {
+        this.onDeleteSetNull = onDeleteSetNull;
+    }
+
+    public List<String> getFkColumns() {
+        return fkColumns;
+    }
+
+    public void setFkColumns(List<String> fkColumns) {
+        this.fkColumns = fkColumns;
+    }
+
+    public String getFkSourceTable() {
+        return fkSourceTable;
+    }
+
+    public void setFkSourceTable(String fkSourceTable) {
+        this.fkSourceTable = fkSourceTable;
+    }
+
+    public List<ColumnDataType> getColDataTypeList() {
+        return colDataTypeList;
+    }
+
+    public void addColDataType(String columnName, ColDataType colDataType) {
+        if (colDataTypeList == null) {
+            colDataTypeList = new ArrayList<ColumnDataType>();
+        }
+        colDataTypeList.add(new ColumnDataType(columnName, colDataType));
+    }
+
+    public List<String> getFkSourceColumns() {
+        return fkSourceColumns;
+    }
+
+    public void setFkSourceColumns(List<String> fkSourceColumns) {
+        this.fkSourceColumns = fkSourceColumns;
+    }
+
+    public String getColumnName() {
+        return columnName;
+    }
+
+    public void setColumnName(String columnName) {
+        this.columnName = columnName;
+    }
+
+    public String getConstraintName() {
+        return this.constraintName;
+    }
+
+    public void setConstraintName(final String constraintName) {
+        this.constraintName = constraintName;
+    }
+
+    public List<String> getPkColumns() {
+        return pkColumns;
+    }
+
+    public void setPkColumns(List<String> pkColumns) {
+        this.pkColumns = pkColumns;
+    }
+
+    public List<String> getUkColumns() {
+        return ukColumns;
+    }
+
+    public void setUkColumns(List<String> ukColumns) {
+        this.ukColumns = ukColumns;
+    }
+
+    public String getUkName() {
+        return ukName;
+    }
+
+    public void setUkName(String ukName) {
+        this.ukName = ukName;
+    }
+
+    public Index getIndex() {
+        return index;
+    }
+
+    public void setIndex(Index index) {
+        this.index = index;
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder b = new StringBuilder();
+
+        b.append(operation).append(" ");
+
+        if (columnName != null) {
+            b.append("COLUMN ").append(columnName);
+        } else if (getColDataTypeList() != null) {
+            if (colDataTypeList.size() > 1) {
+                b.append("(");
+            } else b.append("COLUMN ");
+            b.append(PlainSelect.getStringList(colDataTypeList));
+            if (colDataTypeList.size() > 1) {
+                b.append(")");
+            }
+        } else if (constraintName != null) {
+            b.append("CONSTRAINT ").append(constraintName);
+        } else if (pkColumns != null) {
+            b.append("PRIMARY KEY (").append(PlainSelect.getStringList(pkColumns)).append(")");
+        } else if (ukColumns != null) {
+            b.append("UNIQUE KEY ").append(ukName).append(" (").append(PlainSelect.getStringList(ukColumns)).append(")");
+        } else if (fkColumns != null) {
+            b.append("FOREIGN KEY (").append(PlainSelect.getStringList(fkColumns)).append(") REFERENCES ").append(fkSourceTable).append(" (").append(
+                    PlainSelect.getStringList(fkSourceColumns)).append(")");
+            if (isOnDeleteCascade()) {
+                b.append(" ON DELETE CASCADE");
+            } else if (isOnDeleteRestrict()) {
+                b.append(" ON DELETE RESTRICT");
+            } else if (isOnDeleteSetNull()) {
+                b.append(" ON DELETE SET NULL");
+            }
+        } else if (index != null) {
+            b.append(index);
+        }
+
+        return b.toString();
+    }
+
+    public class ColumnDataType {
+
+        private final String columnName;
+        private final ColDataType colDataType;
+
+        public ColumnDataType(String columnName, ColDataType colDataType) {
+            this.columnName = columnName;
+            this.colDataType = colDataType;
+        }
+
+        public String getColumnName() {
+            return columnName;
+        }
+
+        public ColDataType getColDataType() {
+            return colDataType;
+        }
+
+        @Override
+        public String toString() {
+            return columnName + " " + colDataType;
+        }
+    }
+
+}

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2994,10 +2994,9 @@ Truncate Truncate():
 	}
 }
 
-Alter AlterTable():
+AlterExpression AlterExpression():
 {
-	Alter alter = new Alter();
-	Table table;
+	AlterExpression alterExp = new AlterExpression();
 	Token tk;
 	Token tk2 = null;
     String sk3 = null;
@@ -3008,39 +3007,39 @@ Alter AlterTable():
     Table fkTable = null;
 }
 {
-	<K_ALTER> <K_TABLE> table=Table() { alter.setTable(table); } 
+
     (
     (<K_ADD>
     	{
-    		alter.setOperation(AlterOperation.ADD);
+    		alterExp.setOperation(AlterOperation.ADD);
     	}
     	  (
         (  <K_COLUMN>
 	       sk3 = RelObjectName() dataType=ColDataType()
-            { alter.addColDataType(sk3, dataType); }
-        )
-        |
-        (  
-            "(" sk3 = RelObjectName() dataType = ColDataType() { alter.addColDataType(sk3, dataType); }
-                ("," sk3 = RelObjectName() dataType = ColDataType() { alter.addColDataType(sk3, dataType); } )* ")"
-        )
-        |
-        ( <K_PRIMARY> <K_KEY> columnNames=ColumnsNamesList() { alter.setPkColumns(columnNames); } )
-        |
-        ( <K_UNIQUE> <K_KEY> (tk=<S_IDENTIFIER>	| tk=<S_QUOTED_IDENTIFIER>) columnNames=ColumnsNamesList() { alter.setUkName(tk.image); alter.setUkColumns(columnNames); } )
-        |
-//following two choices regarding foreign keys should be merged
-        ( <K_FOREIGN> <K_KEY> columnNames=ColumnsNamesList() { alter.setFkColumns(columnNames); }
-             <K_REFERENCES> tk=<S_IDENTIFIER> columnNames=ColumnsNamesList() 
-                    { alter.setFkSourceTable(tk.image); alter.setFkSourceColumns(columnNames); }
-            [<K_ON> <K_DELETE>
-                            (<K_CASCADE> { alter.setOnDeleteCascade(true); }
-                            | <K_RESTRICT> { alter.setOnDeleteRestrict(true); }
-                            | <K_SET> <K_NULL> { alter.setOnDeleteSetNull(true); } ) ]
+            { alterExp.addColDataType(sk3, dataType); }
         )
         |
         (
-            <K_CONSTRAINT> sk3=RelObjectName() 
+            "(" sk3 = RelObjectName() dataType = ColDataType() { alterExp.addColDataType(sk3, dataType); }
+                ("," sk3 = RelObjectName() dataType = ColDataType() { alterExp.addColDataType(sk3, dataType); } )* ")"
+        )
+        |
+        ( <K_PRIMARY> <K_KEY> columnNames=ColumnsNamesList() { alterExp.setPkColumns(columnNames); } )
+        |
+        ( <K_UNIQUE> <K_KEY> (tk=<S_IDENTIFIER>	| tk=<S_QUOTED_IDENTIFIER>) columnNames=ColumnsNamesList() { alterExp.setUkName(tk.image); alterExp.setUkColumns(columnNames); } )
+        |
+//following two choices regarding foreign keys should be merged
+        ( <K_FOREIGN> <K_KEY> columnNames=ColumnsNamesList() { alterExp.setFkColumns(columnNames); }
+             <K_REFERENCES> tk=<S_IDENTIFIER> columnNames=ColumnsNamesList()
+                    { alterExp.setFkSourceTable(tk.image); alterExp.setFkSourceColumns(columnNames); }
+            [<K_ON> <K_DELETE>
+                            (<K_CASCADE> { alterExp.setOnDeleteCascade(true); }
+                            | <K_RESTRICT> { alterExp.setOnDeleteRestrict(true); }
+                            | <K_SET> <K_NULL> { alterExp.setOnDeleteSetNull(true); } ) ]
+        )
+        |
+        (
+            <K_CONSTRAINT> sk3=RelObjectName()
 
             ( ( tk=<K_FOREIGN> tk2=<K_KEY>
                 columnNames=ColumnsNamesList()
@@ -3054,18 +3053,18 @@ Alter AlterTable():
                 {
                     fkIndex.setTable(fkTable);
                     fkIndex.setReferencedColumnNames(columnNames);
-                    alter.setIndex(fkIndex);
+                    alterExp.setIndex(fkIndex);
                 }
             )
             |
-            ( tk=<K_PRIMARY> tk2=<K_KEY> 
+            ( tk=<K_PRIMARY> tk2=<K_KEY>
                 columnNames=ColumnsNamesList()
                 {
                     index = new NamedConstraint();
                     index.setName(sk3);
                     index.setType(tk.image + " " + tk2.image);
                     index.setColumnsNames(columnNames);
-                    alter.setIndex(index);
+                    alterExp.setIndex(index);
                 }
             )
             |
@@ -3074,7 +3073,7 @@ Alter AlterTable():
                 CheckConstraint checkCs = new CheckConstraint();
                 checkCs.setName(sk3);
                 checkCs.setExpression(exp);
-                alter.setIndex(checkCs);
+                alterExp.setIndex(checkCs);
             }
            ) )
         )
@@ -3083,25 +3082,45 @@ Alter AlterTable():
     |
     (<K_DROP>
       {
-    		alter.setOperation(AlterOperation.DROP);
+    		alterExp.setOperation(AlterOperation.DROP);
     	}
     	 (
 			 (  <K_COLUMN>
 			 (tk=<S_IDENTIFIER>	| tk=<S_QUOTED_IDENTIFIER>)
 					 {
-							alter.setColumnName(tk.image);
+							alterExp.setColumnName(tk.image);
 					 }
 			 )
 			 |
        (  <K_CONSTRAINT>
        (tk=<S_IDENTIFIER>	| tk=<S_QUOTED_IDENTIFIER>)
            {
-              alter.setConstraintName(tk.image);
+              alterExp.setConstraintName(tk.image);
            }
        )
        )
     )
     )
+
+    {
+        return alterExp;
+    }
+}
+
+
+Alter AlterTable():
+{
+	Alter alter = new Alter();
+	Table table;
+    AlterExpression alterExp;
+
+}
+{
+	<K_ALTER> <K_TABLE> table=Table() { alter.setTable(table); }
+	 ( alterExp=AlterExpression() { alter.addAlterExpression(alterExp); }
+	   ("," alterExp=AlterExpression() { alter.addAlterExpression(alterExp); } )*
+	 )
+
     {
 		return alter;
 	}

--- a/src/test/java/net/sf/jsqlparser/test/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/alter/AlterTest.java
@@ -7,7 +7,8 @@ import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.alter.Alter;
-import net.sf.jsqlparser.statement.alter.Alter.ColumnDataType;
+import net.sf.jsqlparser.statement.alter.AlterExpression;
+import net.sf.jsqlparser.statement.alter.AlterExpression.ColumnDataType;
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
 
 public class AlterTest extends TestCase {
@@ -21,20 +22,21 @@ public class AlterTest extends TestCase {
 		assertTrue(stmt instanceof Alter);
 		Alter alter = (Alter)stmt;
 		assertEquals("mytable",alter.getTable().getFullyQualifiedName());
-        List<ColumnDataType> list = alter.getColDataTypeList();
-        assertNotNull(list);
-		assertEquals("mycolumn", list.get(0).getColumnName());
-		assertEquals("varchar (255)", list.get(0).getColDataType().toString());
+        AlterExpression alterExp = alter.getAlterExpressions().get(0);
+        assertNotNull(alterExp);
+        List<ColumnDataType> colDataTypes = alterExp.getColDataTypeList();
+		assertEquals("mycolumn", colDataTypes.get(0).getColumnName());
+		assertEquals("varchar (255)", colDataTypes.get(0).getColDataType().toString());
 	}
     
     public void testAlterTablePrimaryKey() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE animals ADD PRIMARY KEY (id)");
     }
-    
+
     public void testAlterTableUniqueKey() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE `schema_migrations` ADD UNIQUE KEY `unique_schema_migrations` (`version`)");
     }
-    
+
     public void testAlterTableForgeignKey() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE test ADD FOREIGN KEY (user_id) REFERENCES ra_user (id) ON DELETE CASCADE");
     }
@@ -42,15 +44,15 @@ public class AlterTest extends TestCase {
 	public void testAlterTableAddConstraint() throws JSQLParserException {
 		assertSqlCanBeParsedAndDeparsed("ALTER TABLE RESOURCELINKTYPE ADD CONSTRAINT FK_RESOURCELINKTYPE_PARENTTYPE_PRIMARYKEY FOREIGN KEY (PARENTTYPE_PRIMARYKEY) REFERENCES RESOURCETYPE(PRIMARYKEY)");
 	}
-    
+
     public void testAlterTableForgeignKey2() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE test ADD FOREIGN KEY (user_id) REFERENCES ra_user (id)");
     }
-    
+
     public void testAlterTableForgeignKey3() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE test ADD FOREIGN KEY (user_id) REFERENCES ra_user (id) ON DELETE RESTRICT");
     }
-    
+
     public void testAlterTableForgeignKey4() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE test ADD FOREIGN KEY (user_id) REFERENCES ra_user (id) ON DELETE SET NULL");
     }
@@ -59,10 +61,22 @@ public class AlterTest extends TestCase {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE test DROP COLUMN YYY");
     }
 
+	public void testAlterTableDropColumn2() throws JSQLParserException {
+		assertSqlCanBeParsedAndDeparsed("ALTER TABLE mytable DROP COLUMN col1, DROP COLUMN col2");
+
+		Statement stmt = CCJSqlParserUtil.parse("ALTER TABLE mytable DROP COLUMN col1, DROP COLUMN col2");
+		Alter alter = (Alter)stmt;
+		List<AlterExpression> alterExps = alter.getAlterExpressions();
+		AlterExpression col1Exp = alterExps.get(0);
+		AlterExpression col2Exp = alterExps.get(1);
+		assertEquals("col1", col1Exp.getColumnName());
+		assertEquals("col2", col2Exp.getColumnName());
+	}
+
     public void testAlterTableDropConstraint() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE test DROP CONSTRAINT YYY");
     }
-    
+
     public void testAlterTablePK() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE `Author` ADD CONSTRAINT `AuthorPK` PRIMARY KEY (`ID`)");
     }
@@ -74,8 +88,25 @@ public class AlterTest extends TestCase {
     public void testAlterTableAddColumn2() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE animals ADD (col1 integer, col2 integer)");
     }
-    
+
     public void testAlterTableAddColumn3() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE mytable ADD COLUMN mycolumn varchar (255)");
     }
+
+    public void testAlterTableAddColumn4() throws JSQLParserException {
+		assertSqlCanBeParsedAndDeparsed("ALTER TABLE mytable ADD COLUMN col1 varchar (255), ADD COLUMN col2 integer");
+
+		Statement stmt = CCJSqlParserUtil.parse("ALTER TABLE mytable ADD COLUMN col1 varchar (255), ADD COLUMN col2 integer");
+		Alter alter = (Alter)stmt;
+		List<AlterExpression> alterExps = alter.getAlterExpressions();
+		AlterExpression col1Exp = alterExps.get(0);
+		AlterExpression col2Exp = alterExps.get(1);
+		List<ColumnDataType> col1DataTypes = col1Exp.getColDataTypeList();
+		List<ColumnDataType> col2DataTypes = col2Exp.getColDataTypeList();
+		assertEquals("col1", col1DataTypes.get(0).getColumnName());
+		assertEquals("col2", col2DataTypes.get(0).getColumnName());
+		assertEquals("varchar (255)", col1DataTypes.get(0).getColDataType().toString());
+		assertEquals("integer", col2DataTypes.get(0).getColDataType().toString());
+    }
+
 }


### PR DESCRIPTION
Hi JsqlParser maintainers!

Postgres currently supports multiple ADD/DROP expressions in a single ALTER statement: https://www.postgresql.org/docs/9.5/static/sql-altertable.html with a syntax like 
```sql
ALTER TABLE mytable ADD COLUMN col1 varchar (255), ADD COLUMN col2 integer;
```

This PR adds support for multiple expressions. The highlights: 
* Most of the logic that previously lived in the `Alter` class now lives in the `AlterExpression` class, and the `Alter` class is more or less a container for multiple `AlterExpression`s. 
* Each `AlterExpression.toString` call will return the entire expression, and the `Alter` class builds the statement by stacking these expression strings. 
* The .jjt file has been updated to move most of the `Alter` logic into `AlterExpression` as well, and now `Alter` basically just builds these expressions: https://github.com/JSQLParser/JSqlParser/compare/master...wrobstory:PR_alter-expressions?expand=1#diff-6ae5229b13d3feb0f9fdd13137ab69e4R3121
* All of the current `AlterTest` namespace passes and I added a couple more tests to ensure the multiple-expression parsing works. 

