### PR TITLE
Support additional Postgres column types for alter table statements

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -146,6 +146,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_SOME:"SOME">
 |   <K_FULL:"FULL">
 |   <K_WITH:"WITH">
+|   <K_WITHOUT:"WITHOUT">
 |   <K_TABLE:"TABLE">
 |   <K_VIEW:"VIEW">
 |   <K_WHERE:"WHERE">
@@ -195,6 +196,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |	<K_REFERENCES:"REFERENCES">
 |   <K_CHECK:"CHECK">
 |	<K_CHARACTER:"CHARACTER">
+|   <K_BIT:"BIT">
 |	<K_VARYING:"VARYING">
 |	<K_START:"START">
 |	<K_CONNECT:"CONNECT">
@@ -246,6 +248,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |	<K_IGNORE : "IGNORE">
 |   <K_SEMI : "SEMI">
 |   <K_DATETIMELITERAL : ("DATE" | "TIME" | "TIMESTAMP") >
+|   <K_ZONE:"ZONE">
 |   <K_TIME_KEY_EXPR : ( "CURRENT_TIMESTAMP" | "CURRENT_TIME" | "CURRENT_DATE" ) ( "()" )?>
 |   <K_DOUBLE : "DOUBLE">
 |   <K_PRECISION : "PRECISION">
@@ -263,6 +266,11 @@ TOKEN : /* Operators */
 |	<OP_MINORTHANEQUALS: "<" (<WHITESPACE>)* "=">
 |	<OP_NOTEQUALSSTANDARD: "<" (<WHITESPACE>)* ">">
 |	<OP_NOTEQUALSBANG: "!=">
+}
+
+TOKEN : /* Date/Time with time zones */
+{
+    <DT_ZONE: <K_DATETIMELITERAL> <WHITESPACE> (<K_WITH> | <K_WITHOUT>) <WHITESPACE> "TIME" <WHITESPACE> <K_ZONE>>
 }
 
 TOKEN : /* Numeric Constants */
@@ -2818,9 +2826,9 @@ ColDataType ColDataType():
     List<Integer> array = new ArrayList<Integer>();
 }
 {
-	( tk=<K_CHARACTER> [tk2=<K_VARYING>] { colDataType.setDataType(tk.image + (tk2!=null?" " + tk2.image:"")); }
+	( (tk=<K_CHARACTER> | tk=<K_BIT>) [tk2=<K_VARYING>] { colDataType.setDataType(tk.image + (tk2!=null?" " + tk2.image:"")); }
 	| tk=<K_DOUBLE> [tk2=<K_PRECISION>] { colDataType.setDataType(tk.image + (tk2!=null?" " + tk2.image:"")); }
-	| ( tk=<S_IDENTIFIER> | tk=<K_DATETIMELITERAL> | tk=<K_INTERVAL> ) { colDataType.setDataType(tk.image); } )
+	| ( tk=<S_IDENTIFIER> | tk=<K_DATETIMELITERAL> | tk=<K_XML> | tk=<K_INTERVAL> | tk=<DT_ZONE> ) { colDataType.setDataType(tk.image); })
 
 	[LOOKAHEAD(2) "(" ( (tk=<S_LONG> | tk=<S_CHAR_LITERAL> | tk=<S_IDENTIFIER> ) { argumentsStringList.add(tk.image); } ["," {/*argumentsStringList.add(",");*/}] )*    ")"]
     [( "[" {tk=null;} [ tk=<S_LONG> ] { array.add(tk!=null?Integer.valueOf(tk.image):null); } "]" )+ { colDataType.setArrayData(array); } ]

--- a/src/test/java/net/sf/jsqlparser/test/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/alter/AlterTest.java
@@ -109,4 +109,24 @@ public class AlterTest extends TestCase {
 		assertEquals("integer", col2DataTypes.get(0).getColDataType().toString());
     }
 
+    public void testAlterTableAddColumnWithZone() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE mytable ADD COLUMN col1 timestamp with time zone");
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE mytable ADD COLUMN col1 timestamp without time zone");
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE mytable ADD COLUMN col1 date with time zone");
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE mytable ADD COLUMN col1 date without time zone");
+
+        Statement stmt = CCJSqlParserUtil.parse("ALTER TABLE mytable ADD COLUMN col1 timestamp with time zone");
+        Alter alter = (Alter) stmt;
+        List<AlterExpression> alterExps = alter.getAlterExpressions();
+        AlterExpression col1Exp = alterExps.get(0);
+        List<ColumnDataType> col1DataTypes = col1Exp.getColDataTypeList();
+        assertEquals("timestamp with time zone", col1DataTypes.get(0).getColDataType().toString());
+    }
+
+    public void testAlterTableAddColumnKeywordTypes() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE mytable ADD COLUMN col1 xml");
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE mytable ADD COLUMN col1 interval");
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE mytable ADD COLUMN col1 bit varying");
+    }
+
 }


### PR DESCRIPTION
Hi again JSqlParser maintainers!

The following types are valid column types for Postgres: 
```
time without time zone
time with time zone
timestamp without time zone
timestamp with time zone
bit varying
xml
interval
```

This PR adds support for those types in `ALTER TABLE` statements, along with tests ensuring that the types can be parsed. I believe that _all_ Postgres types will be supported once this PR is merged. 