### PR TITLE
Add support for more Postgres Create Table options

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/create/table/ExcludeConstraint.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/ExcludeConstraint.java
@@ -1,0 +1,58 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2016 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.table;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+
+/**
+ * Table Exclusion Constraint
+ * Eg. 'EXCLUDE WHERE (col1 > 100)'
+ *
+ * @author wrobstory
+ */
+public class ExcludeConstraint extends Index{
+
+    private Expression expression;
+
+    public Expression getExpression() {
+        return expression;
+    }
+
+    public void setExpression(Expression expression) {
+        this.expression = expression;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder exclusionStatement = new StringBuilder("EXCLUDE WHERE ");
+        exclusionStatement.append("(");
+        exclusionStatement.append(expression);
+        exclusionStatement.append(")");
+        return exclusionStatement.toString();
+    }
+
+}

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -253,6 +253,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_DOUBLE : "DOUBLE">
 |   <K_PRECISION : "PRECISION">
 |   <K_TABLESPACE : "TABLESPACE">
+|   <K_EXCLUDE : "EXCLUDE">
 }
 
 TOKEN : /* Stuff */
@@ -2653,6 +2654,7 @@ CreateTable CreateTable():
 	Table fkTable = null;
     Select select = null;
     CheckConstraint checkCs = null;
+    ExcludeConstraint excludeC = null;
 }
 {
 	<K_CREATE>
@@ -2771,6 +2773,13 @@ CreateTable CreateTable():
                        indexes.add(checkCs);
                        }
                 )
+                |
+                    tk=<K_EXCLUDE> {excludeC = new ExcludeConstraint(); Expression exp = null;}
+                    (tk2=<K_WHERE>
+                        ("(" exp = Expression() ")")* {excludeC.setExpression(exp);})
+                    {
+                        indexes.add(excludeC);
+                    }
 				|
 				(
 					columnName=RelObjectName()
@@ -2879,12 +2888,16 @@ List<String> CreateParameter():
 {
 	String retval = "";
 	Token tk = null;
-    Token sign = null;
+    Token tk2 = null;
+    StringBuilder identifier = new StringBuilder("");
+    Expression exp = null;
     List<String> param = new ArrayList<String>();
 }
 {
 		(
-			tk=<S_IDENTIFIER> { param.add(tk.image); }
+            ((tk=<S_IDENTIFIER> { identifier.append(tk.image); }
+                ["." tk2=<S_IDENTIFIER> { identifier.append("."); identifier.append(tk2.image); }])
+                { param.add(identifier.toString()); })
 			|
 			tk=<K_NULL> { param.add(tk.image); }
 			|
@@ -2925,12 +2938,23 @@ List<String> CreateParameter():
             tk=<K_TIME_KEY_EXPR> { param.add(new TimeKeyExpression(tk.image).toString()); }
             |
 			"=" { param.add("="); }
-			|
-            <K_USING> <K_INDEX> <K_TABLESPACE> retval=RelObjectName() { param.add("USING"); param.add("INDEX"); param.add("TABLESPACE"); param.add(retval); }
+            |
+            LOOKAHEAD(3) <K_USING> <K_INDEX> <K_TABLESPACE> retval=RelObjectName() { param.add("USING"); param.add("INDEX"); param.add("TABLESPACE"); param.add(retval); }
             |
             <K_TABLESPACE> retval=RelObjectName() { param.add("TABLESPACE"); param.add(retval); }
             |
 			retval=AList() { param.add(retval); }
+			|
+            <K_CHECK>  ("(" exp = Expression() ")") { param.add("CHECK"); param.add("(" + exp.toString() + ")");}
+            |
+            tk=<K_CONSTRAINT> { param.add(tk.image); }
+            |
+            tk=<K_WITH> { param.add(tk.image); }
+            |
+            tk=<K_EXCLUDE> { param.add(tk.image); }
+            |
+            tk=<K_WHERE> { param.add(tk.image); }
+
 		)
 	{return param;}
 }
@@ -2939,11 +2963,13 @@ String AList():
 {
 	StringBuilder retval = new StringBuilder("(");
 	Token tk = null;
+	Token tk2 = null;
 }
 {
 	 "("
 
-	 ( (tk=<S_LONG> | tk=<S_DOUBLE> | tk=<S_CHAR_LITERAL> | tk=<S_IDENTIFIER>) { retval.append(tk.image); } ["," {retval.append(",");}] )*
+	 ( (tk=<S_LONG> | tk=<S_DOUBLE> | tk=<S_CHAR_LITERAL> | tk=<S_IDENTIFIER>) { retval.append(tk.image); }
+	   [("," {retval.append(",");} | "=" {retval.append("=");})] )*
 
 	")"
 	{

--- a/src/test/java/net/sf/jsqlparser/test/create/CreateTableTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/create/CreateTableTest.java
@@ -220,6 +220,26 @@ public class CreateTableTest extends TestCase {
         assertSqlCanBeParsedAndDeparsed("CREATE TABLE inventory (inventory_id INT PRIMARY KEY, product_id INT, CONSTRAINT fk_inv_product_id FOREIGN KEY (product_id) REFERENCES products(product_id) ON DELETE SET NULL)");
     }
 
+	public void testColumnCheck() throws JSQLParserException {
+		assertSqlCanBeParsedAndDeparsed("CREATE TABLE table1 (col1 INTEGER CHECK (col1 > 100))");
+	}
+
+	public void testTableReferenceWithSchema() throws JSQLParserException {
+		assertSqlCanBeParsedAndDeparsed("CREATE TABLE table1 (col1 INTEGER REFERENCES schema1.table1)");
+	}
+
+	public void testNamedColumnConstraint() throws JSQLParserException {
+		assertSqlCanBeParsedAndDeparsed("CREATE TABLE foo (col1 integer CONSTRAINT no_null NOT NULL)");
+	}
+
+	public void testColumnConstraintWith() throws JSQLParserException {
+		assertSqlCanBeParsedAndDeparsed("CREATE TABLE foo (col1 integer) WITH (fillfactor=70)");
+	}
+
+	public void testExcludeWhereConstraint() throws JSQLParserException {
+		assertSqlCanBeParsedAndDeparsed("CREATE TABLE foo (col1 integer, EXCLUDE WHERE (col1 > 100))");
+	}
+
 	public void testRUBiSCreateList() throws Exception {
 		BufferedReader in = new BufferedReader(new InputStreamReader(CreateTableTest.class.getResourceAsStream("/RUBiS-create-requests.txt")));
 		TablesNamesFinder tablesNamesFinder = new TablesNamesFinder();


### PR DESCRIPTION
Hi JSqlParser maintainers! 

I needed to be able to support more Postgres Create Table syntax options. Specifically, these cases: 
```
CREATE TABLE foo (col1 integer CHECK (col1 > 100));
CREATE TABLE foo (col1 integer REFERENCES bar.col1);
CREATE TABLE foo (col1 integer CONSTRAINT no_null NOT NULL);
CREATE TABLE foo (col1 integer) WITH (fillfactor=70);
CREATE TABLE foo (col1 integer, EXCLUDE WHERE (col1 > 100));
```

This PR adds support + tests for these cases. 

Thanks again for the great library!