### PR TITLE
Added support for PostgreSQL JSON Functions and Operators.

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -46,6 +46,7 @@ import net.sf.jsqlparser.expression.operators.relational.MinorThanEquals;
 import net.sf.jsqlparser.expression.operators.relational.NotEqualsTo;
 import net.sf.jsqlparser.expression.operators.relational.RegExpMatchOperator;
 import net.sf.jsqlparser.expression.operators.relational.RegExpMySQLOperator;
+import net.sf.jsqlparser.expression.operators.relational.JsonOperator;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.select.SubSelect;
 
@@ -150,6 +151,8 @@ public interface ExpressionVisitor {
 	void visit(RegExpMatchOperator rexpr);
     
     void visit(JsonExpression jsonExpr);
+    
+    void visit(JsonOperator jsonExpr);
 
 	void visit(RegExpMySQLOperator regExpMySQLOperator);
     

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -24,6 +24,7 @@ package net.sf.jsqlparser.expression;
 import net.sf.jsqlparser.expression.operators.arithmetic.*;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
+import net.sf.jsqlparser.expression.operators.relational.JsonOperator;
 import net.sf.jsqlparser.expression.operators.relational.*;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.select.AllColumns;
@@ -346,6 +347,11 @@ public class ExpressionVisitorAdapter implements ExpressionVisitor, ItemsListVis
     @Override
     public void visit(JsonExpression jsonExpr) {
         visit(jsonExpr.getColumn());
+    }
+    
+    @Override
+    public void visit(JsonOperator expr) {
+        visitBinaryExpression(expr);
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/expression/JsonExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/JsonExpression.java
@@ -53,6 +53,7 @@ public class JsonExpression  implements Expression {
     private Column column;
     
     private List<String> idents = new ArrayList<String>();
+    private List<String> operators = new ArrayList<String>();
     
     @Override
     public void accept(ExpressionVisitor expressionVisitor) {
@@ -73,18 +74,27 @@ public class JsonExpression  implements Expression {
 
     public void setIdents(List<String> idents) {
         this.idents = idents;
+        operators = new ArrayList<String>();
+        for (String ident : idents) {
+            operators.add("->");
+        }
     }
     
     public void addIdent(String ident) {
+        addIdent(ident, "->");
+    }
+    
+    public void addIdent(String ident, String operator) {
         idents.add(ident);
+        operators.add(operator);
     }
     
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
         b.append(column.toString());
-        for (String ident : idents) {
-            b.append("->").append(ident);
+        for (int i=0; i<idents.size(); i++){
+            b.append(operators.get(i)).append(idents.get(i));
         }
         return b.toString();
     }

--- a/src/main/java/net/sf/jsqlparser/expression/JsonExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/JsonExpression.java
@@ -19,24 +19,6 @@
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
-/*
- * Copyright (C) 2014 JSQLParser.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
- * MA 02110-1301  USA
- */
 
 package net.sf.jsqlparser.expression;
 
@@ -68,21 +50,21 @@ public class JsonExpression  implements Expression {
         this.column = column;
     }
 
-    public List<String> getIdents() {
-        return idents;
-    }
-
-    public void setIdents(List<String> idents) {
-        this.idents = idents;
-        operators = new ArrayList<String>();
-        for (String ident : idents) {
-            operators.add("->");
-        }
-    }
-    
-    public void addIdent(String ident) {
-        addIdent(ident, "->");
-    }
+//    public List<String> getIdents() {
+//        return idents;
+//    }
+//
+//    public void setIdents(List<String> idents) {
+//        this.idents = idents;
+//        operators = new ArrayList<String>();
+//        for (String ident : idents) {
+//            operators.add("->");
+//        }
+//    }
+//    
+//    public void addIdent(String ident) {
+//        addIdent(ident, "->");
+//    }
     
     public void addIdent(String ident, String operator) {
         idents.add(ident);

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/JsonOperator.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/JsonOperator.java
@@ -1,0 +1,45 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2013 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 2.1 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package net.sf.jsqlparser.expression.operators.relational;
+
+import net.sf.jsqlparser.expression.BinaryExpression;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+
+public class JsonOperator extends BinaryExpression {
+    
+    private String op; //"@>"
+    
+    public JsonOperator(String op){
+        this.op = op;
+    }
+
+	@Override
+	public void accept(ExpressionVisitor expressionVisitor) {
+		expressionVisitor.visit(this);
+	}
+
+	@Override
+	public String getStringExpression() {
+		return op;
+	}
+}
+

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -50,7 +50,7 @@ import net.sf.jsqlparser.statement.drop.Drop;
 import net.sf.jsqlparser.statement.execute.Execute;
 import net.sf.jsqlparser.statement.merge.Merge;
 import net.sf.jsqlparser.statement.truncate.Truncate;
-
+import net.sf.jsqlparser.expression.operators.relational.JsonOperator;
 /**
  * Find all used tables within an select statement.
  */
@@ -447,6 +447,10 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
     public void visit(JsonExpression jsonExpr) {
     }
 
+    @Override
+    public void visit(JsonOperator jsonExpr) {
+    }
+    
     @Override
     public void visit(AllColumns allColumns) {
     }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -29,7 +29,7 @@ import net.sf.jsqlparser.expression.operators.relational.*;
 import net.sf.jsqlparser.schema.*;
 import net.sf.jsqlparser.statement.select.SelectVisitor;
 import net.sf.jsqlparser.statement.select.SubSelect;
-
+import net.sf.jsqlparser.expression.operators.relational.JsonOperator;
 import java.util.Iterator;
 
 /**
@@ -528,6 +528,11 @@ public class ExpressionDeParser implements ExpressionVisitor, ItemsListVisitor {
     @Override
     public void visit(JsonExpression jsonExpr) {
         buffer.append(jsonExpr.toString());
+    }
+    
+    @Override
+    public void visit(JsonOperator jsonExpr) {
+        visitBinaryExpression(jsonExpr, " " + jsonExpr.getStringExpression() + " ");
     }
 
     @Override

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -74,7 +74,6 @@ import net.sf.jsqlparser.statement.select.*;
 import net.sf.jsqlparser.statement.truncate.*;
 import net.sf.jsqlparser.statement.update.*;
 import net.sf.jsqlparser.statement.merge.*;
-
 import java.util.*;
 
 /**
@@ -1729,6 +1728,15 @@ Expression RegularCondition():
 	| "~*" { result = new RegExpMatchOperator(RegExpMatchOperatorType.MATCH_CASEINSENSITIVE); }
 	| "!~" { result = new RegExpMatchOperator(RegExpMatchOperatorType.NOT_MATCH_CASESENSITIVE); }
 	| "!~*" { result = new RegExpMatchOperator(RegExpMatchOperatorType.NOT_MATCH_CASEINSENSITIVE); }
+
+        | "@>" { result = new JsonOperator("@>"); }
+        | "<@" { result = new JsonOperator("<@"); }
+        | "?" { result = new JsonOperator("?"); }
+        | "?|" { result = new JsonOperator("?|"); }
+        | "?&" { result = new JsonOperator("?&"); }
+        | "||" { result = new JsonOperator("||"); }
+        | "-" { result = new JsonOperator("-"); }
+        | "-#" { result = new JsonOperator("-#"); }
 	)
 
 	( LOOKAHEAD(2) <K_PRIOR> rightExpression=ComparisonItem() { oraclePrior = EqualsTo.ORACLE_PRIOR_END; } 
@@ -2228,7 +2236,12 @@ JsonExpression JsonExpression() : {
   Token token;
 }
 {
-    column=Column() ("->" token=<S_CHAR_LITERAL> {result.addIdent(token.image);} )+
+    column=Column() (
+        "->" token=<S_CHAR_LITERAL> {result.addIdent(token.image,"->");} | 
+        "->>" token=<S_CHAR_LITERAL> {result.addIdent(token.image,"->>");} |
+        "#>" token=<S_CHAR_LITERAL> {result.addIdent(token.image,"#>");} |
+        "#>>" token=<S_CHAR_LITERAL> {result.addIdent(token.image,"#>>");}
+    )+
     { 
         result.setColumn(column);
         return result; 

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -1850,6 +1850,24 @@ public class SelectTest extends TestCase {
 
     public void testJsonExpression() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT data->'images'->'thumbnail'->'url' AS thumb FROM instagram");
+        assertSqlCanBeParsedAndDeparsed("SELECT * FROM sales WHERE sale->'items'->>'description' = 'milk'");
+        assertSqlCanBeParsedAndDeparsed("SELECT * FROM sales WHERE sale->'items'->>'quantity' = 12::TEXT");
+        //assertSqlCanBeParsedAndDeparsed("SELECT * FROM sales WHERE CAST(sale->'items'->>'quantity' AS integer)  = 2");
+        assertSqlCanBeParsedAndDeparsed("SELECT SUM(CAST(sale->'items'->>'quantity' AS integer)) AS total_quantity_sold FROM sales");
+        assertSqlCanBeParsedAndDeparsed("SELECT sale->>'items' FROM sales");
+        assertSqlCanBeParsedAndDeparsed("SELECT json_typeof(sale->'items'), json_typeof(sale->'items'->'quantity') FROM sales");
+        
+        
+        //The following staments can be parsed but not deparsed
+        for (String statement : new String[]{
+            "SELECT doc->'site_name' FROM websites WHERE doc @> '{\"tags\":[{\"term\":\"paris\"}, {\"term\":\"food\"}]}'",
+            "SELECT * FROM sales where sale ->'items' @> '[{\"count\":0}]'",
+            "SELECT * FROM sales where sale ->'items' ? 'name'",
+            "SELECT * FROM sales where sale ->'items' -# 'name'"
+        }){
+            Select select = (Select) parserManager.parse(new StringReader(statement));
+            assertStatementCanBeDeparsedAs(select, statement, true);
+        }
     }
 
     public void testSelectInto1() throws JSQLParserException {


### PR DESCRIPTION
I updated several classes to support PostgreSQL JSON Functions and Operators. Sample queries:

`"SELECT * FROM sales WHERE sale->'items'->>'description' = 'milk';"`
`"SELECT` * FROM sales where sale ->'items' @> '[{\"count\":0}]'"

More info on PostgreSQL operators can be found here:
[https://www.postgresql.org/docs/9.5/static/functions-json.html](https://www.postgresql.org/docs/9.5/static/functions-json.html)