### PR TITLE
Support for postgres overlap operator && added, natural left/right/fu…

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -44,6 +44,7 @@ import net.sf.jsqlparser.expression.operators.relational.Matches;
 import net.sf.jsqlparser.expression.operators.relational.MinorThan;
 import net.sf.jsqlparser.expression.operators.relational.MinorThanEquals;
 import net.sf.jsqlparser.expression.operators.relational.NotEqualsTo;
+import net.sf.jsqlparser.expression.operators.relational.DoubleAnd;//Added by mathew on 21st Nov 2016
 import net.sf.jsqlparser.expression.operators.relational.RegExpMatchOperator;
 import net.sf.jsqlparser.expression.operators.relational.RegExpMySQLOperator;
 import net.sf.jsqlparser.expression.operators.relational.JsonOperator;
@@ -109,6 +110,8 @@ public interface ExpressionVisitor {
 	void visit(MinorThanEquals minorThanEquals);
 
 	void visit(NotEqualsTo notEqualsTo);
+	
+	void visit(DoubleAnd doubleAnd);//Added by mathew on 21st Nov 2016
 
 	void visit(Column tableColumn);
 

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -45,6 +45,8 @@ import net.sf.jsqlparser.expression.operators.relational.MinorThan;
 import net.sf.jsqlparser.expression.operators.relational.MinorThanEquals;
 import net.sf.jsqlparser.expression.operators.relational.NotEqualsTo;
 import net.sf.jsqlparser.expression.operators.relational.DoubleAnd;//Added by mathew on 21st Nov 2016
+import net.sf.jsqlparser.expression.operators.relational.Contains;//Added by mathew on 21st Nov 2016
+import net.sf.jsqlparser.expression.operators.relational.ContainedBy;//Added by mathew on 21st Nov 2016
 import net.sf.jsqlparser.expression.operators.relational.RegExpMatchOperator;
 import net.sf.jsqlparser.expression.operators.relational.RegExpMySQLOperator;
 import net.sf.jsqlparser.expression.operators.relational.JsonOperator;
@@ -112,6 +114,10 @@ public interface ExpressionVisitor {
 	void visit(NotEqualsTo notEqualsTo);
 	
 	void visit(DoubleAnd doubleAnd);//Added by mathew on 21st Nov 2016
+	
+	void visit(Contains contains);//Added by mathew on 21st Nov 2016
+
+	void visit(ContainedBy containedBy);//Added by mathew on 21st Nov 2016
 
 	void visit(Column tableColumn);
 

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -204,6 +204,12 @@ public class ExpressionVisitorAdapter implements ExpressionVisitor, ItemsListVis
     public void visit(NotEqualsTo expr) {
         visitBinaryExpression(expr);
     }
+    
+    /*Added by mathew on 21st Nov 2016*/
+    @Override
+    public void visit(DoubleAnd expr) {
+        visitBinaryExpression(expr);
+    }
 
     @Override
     public void visit(Column column) {

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -210,6 +210,19 @@ public class ExpressionVisitorAdapter implements ExpressionVisitor, ItemsListVis
     public void visit(DoubleAnd expr) {
         visitBinaryExpression(expr);
     }
+    
+    /*Added by mathew on 21st Nov 2016*/
+    @Override
+    public void visit(Contains expr) {
+        visitBinaryExpression(expr);
+    }
+
+    /*Added by mathew on 21st Nov 2016*/
+    @Override
+    public void visit(ContainedBy expr) {
+        visitBinaryExpression(expr);
+    }
+
 
     @Override
     public void visit(Column column) {

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/ContainedBy.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/ContainedBy.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2013 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 2.1 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+/*Added by Mathew on 21st Nov 2016*/
+package net.sf.jsqlparser.expression.operators.relational;
+
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+
+public class ContainedBy extends ComparisonOperator {
+
+    public ContainedBy() {
+        super("<&");
+    }
+
+    public ContainedBy(String operator) {
+        super(operator);
+    }
+
+    @Override
+    public void accept(ExpressionVisitor expressionVisitor) {
+        expressionVisitor.visit(this);
+    }
+}
+

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/Contains.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/Contains.java
@@ -1,0 +1,42 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2013 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 2.1 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+/*Added by Mathew on 21st Nov 2016*/
+package net.sf.jsqlparser.expression.operators.relational;
+
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+
+public class Contains extends ComparisonOperator {
+
+    public Contains() {
+        super("&>");
+    }
+
+    public Contains(String operator) {
+        super(operator);
+    }
+
+    @Override
+    public void accept(ExpressionVisitor expressionVisitor) {
+        expressionVisitor.visit(this);
+    }
+}
+

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/DoubleAnd.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/DoubleAnd.java
@@ -1,0 +1,41 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2013 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 2.1 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+/*Added by Mathew on 1st Aug 2016*/
+package net.sf.jsqlparser.expression.operators.relational;
+
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+
+public class DoubleAnd extends ComparisonOperator {
+
+    public DoubleAnd() {
+        super("&&");
+    }
+
+    public DoubleAnd(String operator) {
+        super(operator);
+    }
+
+    @Override
+    public void accept(ExpressionVisitor expressionVisitor) {
+        expressionVisitor.visit(this);
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -266,6 +266,22 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
     public void visit(DoubleAnd doubleAnd) {
         visitBinaryExpression(doubleAnd);
     }
+    
+    /* Added by Mathew on 21st Nov 2016
+     * 
+     */
+    @Override
+    public void visit(Contains contains) {
+        visitBinaryExpression(contains);
+    }
+    
+    /* Added by Mathew on 21st Nov 2016
+     * 
+     */
+    @Override
+    public void visit(ContainedBy containedBy) {
+        visitBinaryExpression(containedBy);
+    }
 
     @Override
     public void visit(NullValue nullValue) {

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -258,6 +258,14 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
     public void visit(NotEqualsTo notEqualsTo) {
         visitBinaryExpression(notEqualsTo);
     }
+    
+    /* Added by Mathew on 21st Nov 2016
+     * 
+     */
+    @Override
+    public void visit(DoubleAnd doubleAnd) {
+        visitBinaryExpression(doubleAnd);
+    }
 
     @Override
     public void visit(NullValue nullValue) {

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -242,6 +242,20 @@ public class ExpressionDeParser implements ExpressionVisitor, ItemsListVisitor {
          visitOldOracleJoinBinaryExpression(doubleAnd, " " + doubleAnd.getStringExpression() + " ");
 
      }
+    
+    /*Added by Mathew on November 21st 2016*/
+    @Override
+     public void visit(Contains contains) {
+         visitOldOracleJoinBinaryExpression(contains, " " + contains.getStringExpression() + " ");
+
+     }
+    
+    /*Added by Mathew on November 21st 2016*/
+    @Override
+     public void visit(ContainedBy containedBy) {
+         visitOldOracleJoinBinaryExpression(containedBy, " " + containedBy.getStringExpression() + " ");
+
+     }
 
     @Override
     public void visit(NullValue nullValue) {

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -235,6 +235,13 @@ public class ExpressionDeParser implements ExpressionVisitor, ItemsListVisitor {
         visitOldOracleJoinBinaryExpression(notEqualsTo, " " + notEqualsTo.getStringExpression() + " ");
 
     }
+    
+    /*Added by Mathew on November 21st 2016*/
+    @Override
+     public void visit(DoubleAnd doubleAnd) {
+         visitOldOracleJoinBinaryExpression(doubleAnd, " " + doubleAnd.getStringExpression() + " ");
+
+     }
 
     @Override
     public void visit(NullValue nullValue) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -267,6 +267,8 @@ TOKEN : /* Operators */
 |	<OP_NOTEQUALSSTANDARD: "<" (<WHITESPACE>)* ">">
 |	<OP_NOTEQUALSBANG: "!=">
 | 	<OP_DOUBLEAND: "&&"> /*added by mathew on 21st Nov 2016*/
+| 	<OP_CONTAINS: "&>"> /*added by mathew on 21st Nov 2016*/
+| 	<OP_CONTAINEDBY: "<&"> /*added by mathew on 21st Nov 2016*/
 }
 
 TOKEN : /* Date/Time with time zones */
@@ -1727,6 +1729,8 @@ Expression RegularCondition():
 	| token=<OP_NOTEQUALSSTANDARD> { result = new NotEqualsTo(token.image); }
 	| token=<OP_NOTEQUALSBANG> { result = new NotEqualsTo(token.image); }
 	| token=<OP_DOUBLEAND> { result = new DoubleAnd(token.image); }
+	| token=<OP_CONTAINS> { result = new DoubleAnd(token.image); }
+	| token=<OP_CONTAINEDBY> { result = new DoubleAnd(token.image); }
 	| "@@" { result = new Matches(); }
 	| "~" { result = new RegExpMatchOperator(RegExpMatchOperatorType.MATCH_CASESENSITIVE); }
 	| <K_REGEXP> [ <K_BINARY> { binary=true; } ] { result = new RegExpMySQLOperator(binary?RegExpMatchOperatorType.MATCH_CASESENSITIVE:RegExpMatchOperatorType.MATCH_CASEINSENSITIVE); }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -266,6 +266,7 @@ TOKEN : /* Operators */
 |	<OP_MINORTHANEQUALS: "<" (<WHITESPACE>)* "=">
 |	<OP_NOTEQUALSSTANDARD: "<" (<WHITESPACE>)* ">">
 |	<OP_NOTEQUALSBANG: "!=">
+| 	<OP_DOUBLEAND: "&&"> /*added by mathew on 21st Nov 2016*/
 }
 
 TOKEN : /* Date/Time with time zones */
@@ -1333,7 +1334,9 @@ Join JoinerExpression():
   		   | <K_FULL> { join.setFull(true); } 
            ) [ <K_OUTER> { join.setOuter(true); } ]
         | <K_INNER> { join.setInner(true); }
-        | <K_NATURAL> { join.setNatural(true); }
+        | <K_NATURAL> { join.setNatural(true); }  
+        [(<K_LEFT> { join.setLeft(true); } | <K_RIGHT> { join.setRight(true); }| <K_FULL> { join.setFull(true); })  <K_OUTER> { join.setOuter(true); } ]
+        /* line above added by mathew on 21 Nov 2016*/
 		| <K_CROSS> { join.setCross(true); } 
     ]
 
@@ -1723,6 +1726,7 @@ Expression RegularCondition():
 	| token=<OP_MINORTHANEQUALS> { result = new MinorThanEquals(token.image); }
 	| token=<OP_NOTEQUALSSTANDARD> { result = new NotEqualsTo(token.image); }
 	| token=<OP_NOTEQUALSBANG> { result = new NotEqualsTo(token.image); }
+	| token=<OP_DOUBLEAND> { result = new DoubleAnd(token.image); }
 	| "@@" { result = new Matches(); }
 	| "~" { result = new RegExpMatchOperator(RegExpMatchOperatorType.MATCH_CASESENSITIVE); }
 	| <K_REGEXP> [ <K_BINARY> { binary=true; } ] { result = new RegExpMySQLOperator(binary?RegExpMatchOperatorType.MATCH_CASESENSITIVE:RegExpMatchOperatorType.MATCH_CASEINSENSITIVE); }

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -1847,6 +1847,11 @@ public class SelectTest extends TestCase {
         assertSqlCanBeParsedAndDeparsed("SELECT * FROM foo WHERE a != b");
         assertSqlCanBeParsedAndDeparsed("SELECT * FROM foo WHERE a <> b");
     }
+    
+    /*Added by Mathew on 21st Nov 2016*/
+    public void testDoubleAnd() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT * FROM foo WHERE a && b");
+    }
 
     public void testJsonExpression() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT data->'images'->'thumbnail'->'url' AS thumb FROM instagram");

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -1852,6 +1852,16 @@ public class SelectTest extends TestCase {
     public void testDoubleAnd() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT * FROM foo WHERE a && b");
     }
+    
+    /*Added by Mathew on 21st Nov 2016*/
+    public void testContains() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT * FROM foo WHERE a &> b");
+    }
+    
+    /*Added by Mathew on 21st Nov 2016*/
+    public void testContainedBy() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT * FROM foo WHERE a <& b");
+    }
 
     public void testJsonExpression() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT data->'images'->'thumbnail'->'url' AS thumb FROM instagram");


### PR DESCRIPTION
Here are the changes that are currently made 

i) DoubleAnd/Overrlap operator (&&) - supported by latest DB versions, eg. postgres
overlap takes two arrays as its operands and returns true iff they have elements in common.

list of files changed
src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
src/test/java/net/sf/jsqlparser/test/select/SelectTest.java

src/main/java/net/sf/jsqlparser/expression/operators/relational/DoubleAnd.java (new java file)

ii)  NATURAL LEFT/RIGHT/FULL OUTER JOIN - Currently the parser supports only the inner one, NATURAL JOIN