### PR TITLE
support to add jdbc name parameter after LIMIT and TOP keywords

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/Limit.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Limit.java
@@ -21,7 +21,7 @@
  */
 package net.sf.jsqlparser.statement.select;
 
-import net.sf.jsqlparser.expression.JdbcParameter;
+import net.sf.jsqlparser.expression.Expression;
 
 /**
  * A limit clause in the form [LIMIT {[offset,] row_count) | (row_count | ALL)
@@ -29,51 +29,25 @@ import net.sf.jsqlparser.expression.JdbcParameter;
  */
 public class Limit {
 
-	private long offset;
-	private long rowCount;
-	private JdbcParameter rowCountJdbcParameter;
-	private JdbcParameter offsetJdbcParameter;
+	private Expression rowCount;
+	private Expression offset;
 	private boolean limitAll;
     private boolean limitNull = false;
 
-	public long getOffset() {
+	public Expression getOffset() {
 		return offset;
 	}
 
-	public long getRowCount() {
+	public Expression getRowCount() {
 		return rowCount;
 	}
 
-	public void setOffset(long l) {
+	public void setOffset(Expression l) {
 		offset = l;
 	}
 
-	public void setRowCount(long l) {
+	public void setRowCount(Expression l) {
 		rowCount = l;
-	}
-
-	public JdbcParameter getRowCountJdbcParameter() {
-		return rowCountJdbcParameter;
-	}
-
-	public void setRowCountJdbcParameter(JdbcParameter rowCountJdbcParameter) {
-		this.rowCountJdbcParameter = rowCountJdbcParameter;
-	}
-
-	public JdbcParameter getOffsetJdbcParameter() {
-		return offsetJdbcParameter;
-	}
-
-	public void setOffsetJdbcParameter(JdbcParameter offsetJdbcParameter) {
-		this.offsetJdbcParameter = offsetJdbcParameter;
-	}
-
-	public boolean isRowCountJdbcParameter(){
-		return null != this.rowCountJdbcParameter;
-	}
-
-	public boolean isOffsetJdbcParameter(){
-		return null != this.offsetJdbcParameter;
 	}
 
 	/**
@@ -100,11 +74,11 @@ public class Limit {
 		if (limitNull) {
             retVal += "NULL";
         } else {
-            if (offset > 0 || null != offsetJdbcParameter) {
-                retVal += (null != offsetJdbcParameter ? offsetJdbcParameter : Long.toString(offset)) + ", ";
+            if (null != offset) {
+                retVal += offset + ", ";
     		}
-            if ( rowCount >= 0 || null != rowCountJdbcParameter) {
-                retVal += (null !=rowCountJdbcParameter ? rowCountJdbcParameter : Long.toString(rowCount));
+            if (null != rowCount) {
+                retVal += rowCount;
             }
         }
 		

--- a/src/main/java/net/sf/jsqlparser/util/deparser/LimitDeparser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/LimitDeparser.java
@@ -36,15 +36,11 @@ public class LimitDeparser {
         if (limit.isLimitNull()) {
             buffer.append("NULL");
         } else {
-            if (null != limit.getOffsetJdbcParameter()) {
-                buffer.append(limit.getOffsetJdbcParameter()).append(", ");
-            } else if (limit.getOffset() != 0) {
+            if (null != limit.getOffset()) {
                 buffer.append(limit.getOffset()).append(", ");
             }
             
-            if (null != limit.getRowCountJdbcParameter()) {
-                buffer.append(limit.getRowCountJdbcParameter());
-            } else if (limit.getRowCount() >= 0) {
+            if (null != limit.getRowCount()) {
                 buffer.append(limit.getRowCount());
             }
         }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1446,7 +1446,6 @@ OrderByElement OrderByElement():
 Limit LimitWithOffset():
 {
 	Limit limit = new Limit();
-	limit.setRowCount(-1l);
 	Token token = null;
 }
 {
@@ -1455,17 +1454,21 @@ Limit LimitWithOffset():
 				// mysql-> LIMIT offset,row_count
 				<K_LIMIT>
 					 (
-					 	token=<S_LONG> { limit.setOffset(Long.parseLong(token.image)); }
+					 	token=<S_LONG> { limit.setOffset(new LongValue(token.image)); }
 					 	|
-					 	"?" { limit.setOffsetJdbcParameter(new JdbcParameter()); } [ LOOKAHEAD(2) token = <S_LONG> { limit.getOffsetJdbcParameter().setIndex(Integer.valueOf(token.image)); } ]
+					 	"?" { limit.setOffset(new JdbcParameter()); } [ LOOKAHEAD(2) token = <S_LONG> { ((JdbcParameter)limit.getOffset()).setIndex(Integer.valueOf(token.image)); } ]
+					 	|
+					 	":" { limit.setOffset(new JdbcNamedParameter()); } [ LOOKAHEAD(2) token = <S_IDENTIFIER> { ((JdbcNamedParameter)limit.getOffset()).setName(token.image); } ]
 
 					 )
 					 ","
 
 				(
-				token=<S_LONG> { limit.setRowCount(Long.parseLong(token.image)); }
+				token=<S_LONG> { limit.setRowCount(new LongValue(token.image)); }
 				|
-				 "?" { limit.setRowCountJdbcParameter(new JdbcParameter()); } [ LOOKAHEAD(2) token = <S_LONG> { limit.getRowCountJdbcParameter().setIndex(Integer.valueOf(token.image)); } ]
+				 "?" { limit.setRowCount(new JdbcParameter()); } [ LOOKAHEAD(2) token = <S_LONG> { ((JdbcParameter)limit.getRowCount()).setIndex(Integer.valueOf(token.image)); } ]
+				 |
+                 ":" { limit.setRowCount(new JdbcNamedParameter()); } [ LOOKAHEAD(2) token = <S_IDENTIFIER> { ((JdbcNamedParameter)limit.getRowCount()).setName(token.image); } ]
 				)
 			|
 			limit = PlainLimit()
@@ -1478,16 +1481,17 @@ Limit LimitWithOffset():
 Limit PlainLimit():
 {
 	Limit limit = new Limit();
-	limit.setRowCount(-1l);
 	Token token = null;
 }
 {
 	// mysql-postgresql-> LIMIT (row_count | ALL | NULL)
 	<K_LIMIT>
 	 (
-	 	token=<S_LONG> { limit.setRowCount(Long.parseLong(token.image)); }
+	 	token=<S_LONG> { limit.setRowCount(new LongValue(token.image)); }
 	 	|
-	 	"?" { limit.setRowCountJdbcParameter(new JdbcParameter()); } [ LOOKAHEAD(2) token = <S_LONG> { limit.getRowCountJdbcParameter().setIndex(Integer.valueOf(token.image)); } ]
+	 	"?" { limit.setRowCount(new JdbcParameter()); } [ LOOKAHEAD(2) token = <S_LONG> { ((JdbcParameter)limit.getRowCount()).setIndex(Integer.valueOf(token.image)); } ]
+	 	|
+        ":" { limit.setRowCount(new JdbcNamedParameter()); } [ LOOKAHEAD(2) token = <S_IDENTIFIER> { ((JdbcNamedParameter)limit.getRowCount()).setName(token.image); } ]
 	 	|
 	 	<K_ALL> { limit.setLimitAll(true);}
 	 	|
@@ -1551,7 +1555,9 @@ Top Top():
 	(
 	 	token=<S_LONG>                      { top.setExpression(new LongValue(token.image)); }
 	   |
-	 	"?"                                 { top.setExpression(new JdbcParameter()); }
+	 	"?"                                 { top.setExpression(new JdbcParameter()); } [ LOOKAHEAD(2) token = <S_LONG> { ((JdbcParameter)(top.getExpression())).setIndex(Integer.valueOf(token.image)); } ]
+	   |
+	   ":"                                  { top.setExpression(new JdbcNamedParameter()); } [ LOOKAHEAD(2) token = <S_IDENTIFIER> { ((JdbcNamedParameter)top.getExpression()).setName(token.image); } ]
 	   |
 	   "("
             expr=AdditiveExpression()   { top.setExpression(expr); }


### PR DESCRIPTION
This is a enhancement fix for bug #288, now **limit** can work with jdbc index parameter and jdbc name parameter. 
I also create some test cases for this.

     SELECT * FROM mytable WHERE mytable.col = 9 LIMIT :some_name, 2
     SELECT * FROM mytable WHERE mytable.col = 9 LIMIT 1, :some_name
     SELECT * FROM mytable WHERE mytable.col = 9 LIMIT :name1, :name2
     SELECT * FROM mytable WHERE mytable.col = 9 LIMIT ?1, :name1
     SELECT * FROM mytable WHERE mytable.col = 9 LIMIT :name1, ?1

and the same with **Top**

     SELECT TOP ?1 * FROM mytable WHERE mytable.col = 9
     select top :name1 foo from bar
     select top ? foo from bar
