### PR TITLE
Enhance AlterExpression grammar:

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -27,6 +27,7 @@ import net.sf.jsqlparser.statement.create.table.Index;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -106,10 +107,14 @@ public class AlterExpression {
     }
 
     public void addColDataType(String columnName, ColDataType colDataType) {
+        addColDataType(new ColumnDataType(columnName, colDataType, null));
+    }
+
+    public void addColDataType(ColumnDataType columnDataType) {
         if (colDataTypeList == null) {
             colDataTypeList = new ArrayList<ColumnDataType>();
         }
-        colDataTypeList.add(new ColumnDataType(columnName, colDataType));
+        colDataTypeList.add(columnDataType);
     }
 
     public List<String> getFkSourceColumns() {
@@ -208,14 +213,16 @@ public class AlterExpression {
         return b.toString();
     }
 
-    public class ColumnDataType {
+    public static class ColumnDataType {
 
         private final String columnName;
         private final ColDataType colDataType;
+        private final List<String> columnSpecs;
 
-        public ColumnDataType(String columnName, ColDataType colDataType) {
+        public ColumnDataType(String columnName, ColDataType colDataType, List<String> columnSpecs) {
             this.columnName = columnName;
             this.colDataType = colDataType;
+            this.columnSpecs = columnSpecs;
         }
 
         public String getColumnName() {
@@ -226,9 +233,24 @@ public class AlterExpression {
             return colDataType;
         }
 
+        public List<String> getColumnSpecs() {
+            if (columnSpecs == null) {
+                return Collections.emptyList();
+            }
+            return Collections.unmodifiableList(columnSpecs);
+        }
+
         @Override
         public String toString() {
-            return columnName + " " + colDataType;
+            return columnName + " " + colDataType + parametersToString();
+        }
+
+        private String parametersToString()
+        {
+            if (columnSpecs == null || columnSpecs.isEmpty()) {
+                return "";
+            }
+            return " " + PlainSelect.getStringList(columnSpecs, false, false);
         }
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterOperation.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterOperation.java
@@ -44,5 +44,5 @@ package net.sf.jsqlparser.statement.alter;
  * @author toben
  */
 public enum AlterOperation {
-    ADD, DROP;
+    ADD, DROP, MODIFY;
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3091,7 +3091,7 @@ AlterExpression AlterExpression():
     (
     ((<K_ADD>    { alterExp.setOperation(AlterOperation.ADD); } | <K_MODIFY> { alterExp.setOperation(AlterOperation.MODIFY); })
     	  (
-        (  (<K_COLUMN>)*
+        (  (<K_COLUMN>)?
             alterExpressionColumnDataType = AlterExpressionColumnDataType() { alterExp.addColDataType(alterExpressionColumnDataType); }
         )
         |

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -204,6 +204,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |	<K_SIBLINGS:"SIBLINGS">
 |	<K_ALTER:"ALTER">
 |	<K_ADD:"ADD">
+|	<K_MODIFY: "MODIFY">
 |	<K_COLUMN:"COLUMN">
 |   <K_NULLS: "NULLS">
 |   <K_FIRST: "FIRST">
@@ -3054,6 +3055,24 @@ Truncate Truncate():
 	}
 }
 
+
+AlterExpression.ColumnDataType AlterExpressionColumnDataType():
+{
+	String columnName = null;
+	ColDataType dataType = null;
+	List<String> columnSpecs = null;
+	List<String> parameter = null;
+}
+{
+	columnName = RelObjectName()
+	dataType = ColDataType() { columnSpecs = new ArrayList(); }
+    ( parameter = CreateParameter() { columnSpecs.addAll(parameter); } )*
+	{
+		return new AlterExpression.ColumnDataType(columnName, dataType, columnSpecs);
+	}
+}
+
+
 AlterExpression AlterExpression():
 {
 	AlterExpression alterExp = new AlterExpression();
@@ -3065,23 +3084,20 @@ AlterExpression AlterExpression():
     ForeignKeyIndex fkIndex = null;
     NamedConstraint index = null;
     Table fkTable = null;
+    AlterExpression.ColumnDataType alterExpressionColumnDataType = null;
 }
 {
 
     (
-    (<K_ADD>
-    	{
-    		alterExp.setOperation(AlterOperation.ADD);
-    	}
+    ((<K_ADD>    { alterExp.setOperation(AlterOperation.ADD); } | <K_MODIFY> { alterExp.setOperation(AlterOperation.MODIFY); })
     	  (
-        (  <K_COLUMN>
-	       sk3 = RelObjectName() dataType=ColDataType()
-            { alterExp.addColDataType(sk3, dataType); }
+        (  (<K_COLUMN>)*
+            alterExpressionColumnDataType = AlterExpressionColumnDataType() { alterExp.addColDataType(alterExpressionColumnDataType); }
         )
         |
         (
-            "(" sk3 = RelObjectName() dataType = ColDataType() { alterExp.addColDataType(sk3, dataType); }
-                ("," sk3 = RelObjectName() dataType = ColDataType() { alterExp.addColDataType(sk3, dataType); } )* ")"
+            "(" alterExpressionColumnDataType = AlterExpressionColumnDataType() { alterExp.addColDataType(alterExpressionColumnDataType); }
+                ("," alterExpressionColumnDataType = AlterExpressionColumnDataType() { alterExp.addColDataType(alterExpressionColumnDataType); } )* ")"
         )
         |
         ( <K_PRIMARY> <K_KEY> columnNames=ColumnsNamesList() { alterExp.setPkColumns(columnNames); } )


### PR DESCRIPTION
1. optional "COLUMN" keyword in ADD alter operation
2. new alter operation: MODIFY
3. add column specs to alter table column definitions
4. unit tests added to AlterTest.java to cover optional "COLUMN" keyword and MODIFY statements and proper parsing of columnSpecs