### PR TITLE
Potential solve for #200

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1701,9 +1701,8 @@ Expression Condition():
 	(LOOKAHEAD(RegularCondition()) result=RegularCondition()
 	| LOOKAHEAD(SQLCondition()) result=SQLCondition()
 	| LOOKAHEAD(Function()) result=Function()
-	| <K_NOT> result=Column() { result = new NotExpression(result); }
-    | result=Column()
-	| LOOKAHEAD({ "0".equals(getToken(1).image) || "1".equals(getToken(1).image) }) token=<S_LONG> { result = new LongValue(token.image); }
+	| <K_NOT> result=SimpleExpression() { result = new NotExpression(result); }
+    | result=SimpleExpression()
 	)
 
 	{ return result; }
@@ -2179,6 +2178,8 @@ Expression PrimaryExpression():
 
 	| "{ts" token=<S_CHAR_LITERAL> "}" { retval = new TimestampValue(token.image); }
 
+	| retval = Column()
+
 	| retval = IntervalExpression()
 )
 
@@ -2443,19 +2444,11 @@ Expression CaseWhenExpression() #CaseWhenExpression:
 	<K_CASE>
 	(
     	    ( clause=WhenThenSearchCondition() { whenClauses.add(clause); } )+
-             [<K_ELSE> (
-				LOOKAHEAD(RegularCondition()) elseExp=RegularCondition()
-				| LOOKAHEAD(SQLCondition()) elseExp=SQLCondition()
-				| elseExp=SimpleExpression()
-			)]
+             [<K_ELSE> elseExp=Expression()]
 		|
 		    (LOOKAHEAD(RegularCondition()) switchExp=RegularCondition() | switchExp=BitwiseAndOr())
              ( clause=WhenThenValue() { whenClauses.add(clause); } )+
-             [<K_ELSE>  (
-				LOOKAHEAD(RegularCondition()) elseExp=RegularCondition()
-				| LOOKAHEAD(SQLCondition()) elseExp=SQLCondition()
-				| elseExp=SimpleExpression()
-			)]
+             [<K_ELSE> elseExp=Expression()]
 	)
     <K_END>
     {
@@ -2473,11 +2466,7 @@ WhenClause WhenThenSearchCondition():
 	Expression thenExp = null;
 }
 {
-	<K_WHEN> whenExp=Expression() <K_THEN> (
-		LOOKAHEAD(RegularCondition()) thenExp=RegularCondition()
-		| LOOKAHEAD(SQLCondition()) thenExp=SQLCondition()
-		| thenExp=SimpleExpression()
-	)
+	<K_WHEN> whenExp=Expression() <K_THEN> thenExp=Expression()
 	{
 	   whenThen.setWhenExpression(whenExp);
 	   whenThen.setThenExpression(thenExp);
@@ -2492,11 +2481,7 @@ WhenClause WhenThenValue():
 	Expression thenExp = null;
 }
 {
-	<K_WHEN> whenExp=PrimaryExpression() <K_THEN> (
-		LOOKAHEAD(RegularCondition()) thenExp=RegularCondition()
-		| LOOKAHEAD(SQLCondition()) thenExp=SQLCondition()
-		| thenExp=SimpleExpression()
-	)
+	<K_WHEN> whenExp=PrimaryExpression() <K_THEN> thenExp=Expression()
 	{
 	   whenThen.setWhenExpression(whenExp);
 	   whenThen.setThenExpression(thenExp);

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1698,8 +1698,8 @@ Expression Condition():
     Token token;
 }
 {
-	(LOOKAHEAD(SQLCondition()) result=SQLCondition()
-	| LOOKAHEAD(RegularCondition()) result=RegularCondition()
+	(LOOKAHEAD(RegularCondition()) result=RegularCondition()
+	| LOOKAHEAD(SQLCondition()) result=SQLCondition()
 	| LOOKAHEAD(Function()) result=Function()
 	| <K_NOT> result=Column() { result = new NotExpression(result); }
     | result=Column()
@@ -1783,6 +1783,7 @@ Expression SQLCondition():
 	| LOOKAHEAD(Between()) result=Between()
 	| LOOKAHEAD(IsNullExpression()) result=IsNullExpression()
 	| LOOKAHEAD(ExistsExpression()) result=ExistsExpression()
+	| LOOKAHEAD(CaseWhenExpression()) result = CaseWhenExpression()
 	|  result=LikeExpression()
 	)
 	{ return result; }
@@ -2442,11 +2443,19 @@ Expression CaseWhenExpression() #CaseWhenExpression:
 	<K_CASE>
 	(
     	    ( clause=WhenThenSearchCondition() { whenClauses.add(clause); } )+
-             [<K_ELSE> elseExp=SimpleExpression()]
+             [<K_ELSE> (
+				LOOKAHEAD(RegularCondition()) elseExp=RegularCondition()
+				| LOOKAHEAD(SQLCondition()) elseExp=SQLCondition()
+				| elseExp=SimpleExpression()
+			)]
 		|
 		    (LOOKAHEAD(RegularCondition()) switchExp=RegularCondition() | switchExp=BitwiseAndOr())
              ( clause=WhenThenValue() { whenClauses.add(clause); } )+
-             [<K_ELSE> elseExp=SimpleExpression()]
+             [<K_ELSE>  (
+				LOOKAHEAD(RegularCondition()) elseExp=RegularCondition()
+				| LOOKAHEAD(SQLCondition()) elseExp=SQLCondition()
+				| elseExp=SimpleExpression()
+			)]
 	)
     <K_END>
     {
@@ -2464,7 +2473,11 @@ WhenClause WhenThenSearchCondition():
 	Expression thenExp = null;
 }
 {
-	<K_WHEN> whenExp=Expression() <K_THEN> thenExp=SimpleExpression()
+	<K_WHEN> whenExp=Expression() <K_THEN> (
+		LOOKAHEAD(RegularCondition()) thenExp=RegularCondition()
+		| LOOKAHEAD(SQLCondition()) thenExp=SQLCondition()
+		| thenExp=SimpleExpression()
+	)
 	{
 	   whenThen.setWhenExpression(whenExp);
 	   whenThen.setThenExpression(thenExp);
@@ -2479,7 +2492,11 @@ WhenClause WhenThenValue():
 	Expression thenExp = null;
 }
 {
-	<K_WHEN> whenExp=PrimaryExpression() <K_THEN> thenExp=SimpleExpression()
+	<K_WHEN> whenExp=PrimaryExpression() <K_THEN> (
+		LOOKAHEAD(RegularCondition()) thenExp=RegularCondition()
+		| LOOKAHEAD(SQLCondition()) thenExp=SQLCondition()
+		| thenExp=SimpleExpression()
+	)
 	{
 	   whenThen.setWhenExpression(whenExp);
 	   whenThen.setThenExpression(thenExp);

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -2318,15 +2318,6 @@ public class SelectTest extends TestCase {
         assertSqlCanBeParsedAndDeparsed("SELECT count(*) FROM mytable WHERE 0");
     }
 
-    public void testWhereIssue240_notBoolean() {
-        try {
-            CCJSqlParserUtil.parse("SELECT count(*) FROM mytable WHERE 5");
-            fail("should not be parsed");
-        } catch (JSQLParserException ex) {
-
-        }
-    }
-
     public void testWhereIssue240_true() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT count(*) FROM mytable WHERE true");
     }
@@ -2458,5 +2449,9 @@ public class SelectTest extends TestCase {
 
     public void testCaseExpressionNestedConditionIssue200() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT * FROM t1 WHERE CASE WHEN t1.a = 1 THEN CASE WHEN t1.b = 2 THEN t1.c = 3 ELSE t1.c = 5 END ELSE t1.b = 3 END");
+    }
+
+    public void testCaseExpressionHoldsAndIssue200() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT * FROM t1 WHERE CASE WHEN t1.a = 1 THEN '2017-02-27' NOT IN ('2017-02-19', '2017-02-26', '2017-02-12', '2017-02-05') AND '2017-02-27' BETWEEN to_date AND from_date END");
     }
 }

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -2451,4 +2451,12 @@ public class SelectTest extends TestCase {
     public void testKeyWorkReplaceIssue393() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT replace(\"aaaabbb\", 4, 4, \"****\")");
     }
+
+    public void testCaseExpressionAsConditionIssue200() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT * FROM t1 WHERE CASE WHEN t1.a = 1 THEN t1.b = 2 ELSE t1.b = 3 END");
+    }
+
+    public void testCaseExpressionNestedConditionIssue200() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT * FROM t1 WHERE CASE WHEN t1.a = 1 THEN CASE WHEN t1.b = 2 THEN t1.c = 3 ELSE t1.c = 5 END ELSE t1.b = 3 END");
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -2454,4 +2454,8 @@ public class SelectTest extends TestCase {
     public void testCaseExpressionHoldsAndIssue200() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT * FROM t1 WHERE CASE WHEN t1.a = 1 THEN '2017-02-27' NOT IN ('2017-02-19', '2017-02-26', '2017-02-12', '2017-02-05') AND '2017-02-27' BETWEEN to_date AND from_date END");
     }
+    
+    public void testCaseExpressionWithMoreCondsIssue200() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT * FROM t1 WHERE t2.name = t1.leave_type AND t2.is_lwp = 1 AND t1.docstatus = 1 AND t1.employee = 'EMP-0001' AND CASE WHEN t1.a = 1 THEN '2017-02-27' NOT IN ('2017-02-19', '2017-02-26', '2017-02-12', '2017-02-05') AND '2017-02-27' BETWEEN to_date AND from_date WHEN t2.include_holiday THEN '2017-02-27' BETWEEN from_date AND to_date END");
+    }
 }


### PR DESCRIPTION
Hi,

I've changed around the grammar a bit in order to support CASE WHENs being used as Conditions on their own (see #200). This means that the THENs and ELSEs have to be able to contain full expressions. One of the problems that made this not work was that Condition() would be okay with turning into a Column or a 0 or 1. I've removed this and added Conditions becoming SimpleExpressions. This does however mean that it will accept any SimpleExpression in place of a condition, for instance:
```
SELECT * FROM t1 WHERE 5
```
or
```
SELECT * FROM t1 WHERE a + b
```

Which is also why I removed one of the tests what ensure this is not parse-able. I would argue that while it may indeed not be valid SQL (depending on the DB's implementation), it is no harm if it is actually parse-able. What do you think of this?