### PR TITLE
Introduce support for mysql index hints (fixing issue #374)

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/MySQLIndexHint.java
+++ b/src/main/java/net/sf/jsqlparser/expression/MySQLIndexHint.java
@@ -25,27 +25,28 @@ import java.util.List;
 
 public class MySQLIndexHint  {
 
-	private final String action;
-	private final String indexQualifier;
-	private final List<String> indexNames;
+    private final String action;
+    private final String indexQualifier;
+    private final List<String> indexNames;
 
-	public MySQLIndexHint(String action, String indexQualifier, List<String> indexNames) {
-		this.action = action;
-		this.indexQualifier = indexQualifier;
-		this.indexNames = indexNames;
-	}
+    public MySQLIndexHint(String action, String indexQualifier, List<String> indexNames) {
+        this.action = action;
+        this.indexQualifier = indexQualifier;
+        this.indexNames = indexNames;
+    }
 
-	@Override
-	public String toString() {
-		// use|ignore|force key|index (index1,...,indexN)
-		StringBuilder buffer = new StringBuilder();
-		buffer.append(" ").append(action).append(" ").append(indexQualifier).append(" (");
-		for (int i = 0; i < indexNames.size(); i++) {
-			if (i > 0)
-				buffer.append(",");
-			buffer.append(indexNames.get(i));
-		}
-		buffer.append(")");
-		return buffer.toString();
-	}
+    @Override
+    public String toString() {
+        // use|ignore|force key|index (index1,...,indexN)
+        StringBuilder buffer = new StringBuilder();
+        buffer.append(" ").append(action).append(" ").append(indexQualifier).append(" (");
+        for (int i = 0; i < indexNames.size(); i++) {
+            if (i > 0) {
+                buffer.append(",");
+            }
+            buffer.append(indexNames.get(i));
+        }
+        buffer.append(")");
+        return buffer.toString();
+    }
 }

--- a/src/main/java/net/sf/jsqlparser/expression/MySQLIndexHint.java
+++ b/src/main/java/net/sf/jsqlparser/expression/MySQLIndexHint.java
@@ -1,0 +1,51 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2017 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import java.util.List;
+
+public class MySQLIndexHint  {
+
+	private final String action;
+	private final String indexQualifier;
+	private final List<String> indexNames;
+
+	public MySQLIndexHint(String action, String indexQualifier, List<String> indexNames) {
+		this.action = action;
+		this.indexQualifier = indexQualifier;
+		this.indexNames = indexNames;
+	}
+
+	@Override
+	public String toString() {
+		// use|ignore|force key|index (index1,...,indexN)
+		StringBuilder buffer = new StringBuilder();
+		buffer.append(" ").append(action).append(" ").append(indexQualifier).append(" (");
+		for (int i = 0; i < indexNames.size(); i++) {
+			if (i > 0)
+				buffer.append(",");
+			buffer.append(indexNames.get(i));
+		}
+		buffer.append(")");
+		return buffer.toString();
+	}
+}

--- a/src/main/java/net/sf/jsqlparser/schema/Table.java
+++ b/src/main/java/net/sf/jsqlparser/schema/Table.java
@@ -36,6 +36,7 @@ public class Table extends ASTNodeAccessImpl implements FromItem, MultiPartName 
 
     private Alias alias;
     private Pivot pivot;
+    private MySQLIndexHint hint;
 
     public Table() {
     }
@@ -133,10 +134,19 @@ public class Table extends ASTNodeAccessImpl implements FromItem, MultiPartName 
         this.pivot = pivot;
     }
 
+    public MySQLIndexHint getIndexHint() {
+        return hint;
+    }
+
+    public void setHint(MySQLIndexHint hint) {
+        this.hint = hint;
+    }
+
     @Override
     public String toString() {
         return getFullyQualifiedName()
                 + ((pivot != null) ? " " + pivot : "")
-                + ((alias != null) ? alias.toString() : "");
+                + ((alias != null) ? alias.toString() : "")
+                + ((hint != null) ? hint.toString() : "");
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -232,6 +232,10 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
         if (alias != null) {
             buffer.append(alias);
         }
+        MySQLIndexHint indexHint = tableName.getIndexHint();
+        if (indexHint != null) {
+            buffer.append(indexHint);
+        }
     }
 
     @Override

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -263,6 +263,8 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_NOVALIDATE : "NOVALIDATE">
 |   <K_ENABLE : "ENABLE">
 |   <K_DISABLE : "DISABLE">
+|   <K_USE : "USE">
+|   <K_FORCE : "FORCE">
 }
 
 TOKEN : /* Stuff */
@@ -1077,6 +1079,38 @@ Alias Alias():
    { return new Alias(name,useAs); }
 }
 
+MySQLIndexHint MySQLIndexHint():
+{
+	Token actionToken = null;
+	Token indexToken = null;
+	String indexName = null;
+	List<String> indexNameList = new ArrayList<String>();
+}
+{
+	(actionToken = <K_USE>
+	| actionToken = <K_IGNORE>
+	| actionToken = <K_FORCE> )
+	(indexToken = <K_INDEX>
+	| indexToken = <K_KEY>)
+	"("
+	indexName = Identifier() { indexNameList.add(indexName); }
+	("," indexName= Identifier() { indexNameList.add(indexName); })*
+	")"
+	{
+		return new MySQLIndexHint(actionToken.image, indexToken.image, indexNameList);
+	}
+}
+
+String Identifier():
+{
+	Token tk = null;
+}
+{
+	(tk=<S_IDENTIFIER>
+    | tk=<S_QUOTED_IDENTIFIER>)
+    { return tk.image; }
+}
+
 FunctionItem FunctionItem():
 {
     Alias alias = null;
@@ -1224,6 +1258,7 @@ FromItem FromItem():
     FromItem fromItem = null;
     Pivot pivot = null;
     Alias alias = null;
+    MySQLIndexHint indexHint = null;
 }
 {
     (
@@ -1251,6 +1286,13 @@ FromItem FromItem():
             )
             [(LOOKAHEAD(2) pivot=PivotXml()|pivot=Pivot()) { fromItem.setPivot(pivot); } ]
             [ alias=Alias() { fromItem.setAlias(alias); } ]
+            [
+                LOOKAHEAD(2)
+                indexHint=MySQLIndexHint() {
+                    if (fromItem instanceof Table)
+						((Table) fromItem).setHint(indexHint);
+                }
+            ]
         )
     )
     {

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -2578,4 +2578,22 @@ public class SelectTest extends TestCase {
 //    public void testSubSelectFailsIssue394_2() throws JSQLParserException {
 //        assertSqlCanBeParsedAndDeparsed("select * from all");
 //    }
+
+    public void testMysqlIndexHints() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT column FROM testtable AS t0 USE INDEX (index1)");
+        assertSqlCanBeParsedAndDeparsed("SELECT column FROM testtable AS t0 IGNORE INDEX (index1)");
+        assertSqlCanBeParsedAndDeparsed("SELECT column FROM testtable AS t0 FORCE INDEX (index1)");
+    }
+
+    public void testMysqlIndexHintsWithJoins() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT column FROM table0 t0 INNER JOIN table1 t1 USE INDEX (index1)");
+        assertSqlCanBeParsedAndDeparsed("SELECT column FROM table0 t0 INNER JOIN table1 t1 IGNORE INDEX (index1)");
+        assertSqlCanBeParsedAndDeparsed("SELECT column FROM table0 t0 INNER JOIN table1 t1 FORCE INDEX (index1)");
+    }
+
+    public void testMysqlMultipleIndexHints() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT column FROM testtable AS t0 USE INDEX (index1,index2)");
+        assertSqlCanBeParsedAndDeparsed("SELECT column FROM testtable AS t0 IGNORE INDEX (index1,index2)");
+        assertSqlCanBeParsedAndDeparsed("SELECT column FROM testtable AS t0 FORCE INDEX (index1,index2)");
+    }
 }


### PR DESCRIPTION
Introduce support for MySQL style index hints (defined in mysql docs [here](https://dev.mysql.com/doc/refman/5.7/en/index-hints.html) ).

Index hints immediately follow the table and optional correlation alias in the target table and join clauses like:
`SELECT t.field FROM table t USE INDEX (index_name) WHERE ...`
...or in joins like:
`SELECT t2.field FROM table t INNER JOIN table_2 t2 IGNORE INDEX (index_name) WHERE ...`

This commit checks for the optionally present index hint as part of the `Table` definition, and I tried to make it as small and minimally invasive as possible.

This fixes issue #374 (which was specifically logged for `FORCE INDEX`) and handles the other flavors of mysql index hinting.

Thanks!