### PR TITLE
Linking structures to their AST nodes to have access to their positions

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/AllComparisonExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/AllComparisonExpression.java
@@ -21,9 +21,10 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 import net.sf.jsqlparser.statement.select.SubSelect;
 
-public class AllComparisonExpression implements Expression {
+public class AllComparisonExpression extends ASTNodeAccessImpl implements Expression {
 
     private final SubSelect subSelect;
 

--- a/src/main/java/net/sf/jsqlparser/expression/AnalyticExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/AnalyticExpression.java
@@ -21,6 +21,7 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 import net.sf.jsqlparser.statement.select.OrderByElement;
 
 import java.util.List;
@@ -35,7 +36,7 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
  *
  * @author tw
  */
-public class AnalyticExpression implements Expression {
+public class AnalyticExpression extends ASTNodeAccessImpl implements Expression {
 
     private ExpressionList partitionExpressionList;
     private List<OrderByElement> orderByElements;

--- a/src/main/java/net/sf/jsqlparser/expression/AnyComparisonExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/AnyComparisonExpression.java
@@ -21,6 +21,7 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 import net.sf.jsqlparser.statement.select.SubSelect;
 
 /**
@@ -28,7 +29,7 @@ import net.sf.jsqlparser.statement.select.SubSelect;
  *
  * @author toben
  */
-public class AnyComparisonExpression implements Expression {
+public class AnyComparisonExpression extends ASTNodeAccessImpl implements Expression {
 
     private final SubSelect subSelect;
     private final AnyType anyType;

--- a/src/main/java/net/sf/jsqlparser/expression/BinaryExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/BinaryExpression.java
@@ -21,11 +21,13 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  * A basic class for binary expressions, that is expressions having a left member and a right member
  * which are in turn expressions.
  */
-public abstract class BinaryExpression implements Expression {
+public abstract class BinaryExpression extends ASTNodeAccessImpl implements Expression {
 
     private Expression leftExpression;
     private Expression rightExpression;

--- a/src/main/java/net/sf/jsqlparser/expression/CaseExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/CaseExpression.java
@@ -23,6 +23,7 @@ package net.sf.jsqlparser.expression;
 
 import java.util.List;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 
 /**
@@ -56,7 +57,7 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
  *
  * @author Havard Rast Blok
  */
-public class CaseExpression implements Expression {
+public class CaseExpression extends ASTNodeAccessImpl implements Expression {
 
     private Expression switchExpression;
     private List<WhenClause> whenClauses;

--- a/src/main/java/net/sf/jsqlparser/expression/CastExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/CastExpression.java
@@ -21,13 +21,14 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 import net.sf.jsqlparser.statement.create.table.ColDataType;
 
 /**
  *
  * @author tw
  */
-public class CastExpression implements Expression {
+public class CastExpression extends ASTNodeAccessImpl implements Expression {
 
     private Expression leftExpression;
     private ColDataType type;

--- a/src/main/java/net/sf/jsqlparser/expression/DateTimeLiteralExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/DateTimeLiteralExpression.java
@@ -39,11 +39,13 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  *
  * @author toben
  */
-public class DateTimeLiteralExpression implements Expression {
+public class DateTimeLiteralExpression extends ASTNodeAccessImpl implements Expression {
 
     private String value;
     private DateTime type;

--- a/src/main/java/net/sf/jsqlparser/expression/DateValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/DateValue.java
@@ -21,12 +21,14 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 import java.sql.Date;
 
 /**
  * A Date in the form {d 'yyyy-mm-dd'}
  */
-public class DateValue implements Expression {
+public class DateValue extends ASTNodeAccessImpl implements Expression {
 
     private Date value;
 

--- a/src/main/java/net/sf/jsqlparser/expression/DoubleValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/DoubleValue.java
@@ -21,10 +21,12 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  * Every number with a point or a exponential format is a DoubleValue
  */
-public class DoubleValue implements Expression {
+public class DoubleValue extends ASTNodeAccessImpl implements Expression {
 
     private double value;
     private String stringValue;

--- a/src/main/java/net/sf/jsqlparser/expression/Expression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/Expression.java
@@ -21,7 +21,9 @@
  */
 package net.sf.jsqlparser.expression;
 
-public interface Expression {
+import net.sf.jsqlparser.parser.ASTNodeAccess;
+
+public interface Expression extends ASTNodeAccess {
 
     void accept(ExpressionVisitor expressionVisitor);
 }

--- a/src/main/java/net/sf/jsqlparser/expression/ExtractExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExtractExpression.java
@@ -21,13 +21,15 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  * Extract value from date/time expression. The name stores the part - name to get from the
  * following date/time expression.
  *
  * @author tw
  */
-public class ExtractExpression implements Expression {
+public class ExtractExpression extends ASTNodeAccessImpl implements Expression {
 
     private String name;
     private Expression expression;

--- a/src/main/java/net/sf/jsqlparser/expression/HexValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/HexValue.java
@@ -21,10 +21,12 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  * Every number with a point or a exponential format is a DoubleValue
  */
-public class HexValue implements Expression {
+public class HexValue extends ASTNodeAccessImpl implements Expression {
 
     private String stringValue;
 

--- a/src/main/java/net/sf/jsqlparser/expression/IntervalExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/IntervalExpression.java
@@ -21,11 +21,13 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  *
  * @author wumpz
  */
-public class IntervalExpression implements Expression {
+public class IntervalExpression extends ASTNodeAccessImpl implements Expression {
 
     private String parameter = null;
     private String intervalType = null;

--- a/src/main/java/net/sf/jsqlparser/expression/JdbcNamedParameter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/JdbcNamedParameter.java
@@ -21,11 +21,13 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  *
  * @author aud
  */
-public class JdbcNamedParameter implements Expression {
+public class JdbcNamedParameter extends ASTNodeAccessImpl implements Expression {
 
     private String name;
 

--- a/src/main/java/net/sf/jsqlparser/expression/JdbcParameter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/JdbcParameter.java
@@ -21,10 +21,12 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  * A '?' in a statement or a ?<number> e.g. ?4
  */
-public class JdbcParameter implements Expression {
+public class JdbcParameter extends ASTNodeAccessImpl implements Expression {
 
     private Integer index;
     private boolean useFixedIndex = false;

--- a/src/main/java/net/sf/jsqlparser/expression/JsonExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/JsonExpression.java
@@ -23,13 +23,15 @@ package net.sf.jsqlparser.expression;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 import net.sf.jsqlparser.schema.Column;
 
 /**
  *
  * @author toben
  */
-public class JsonExpression implements Expression {
+public class JsonExpression extends ASTNodeAccessImpl implements Expression {
 
     private Column column;
 

--- a/src/main/java/net/sf/jsqlparser/expression/KeepExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/KeepExpression.java
@@ -21,6 +21,7 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 import net.sf.jsqlparser.statement.select.OrderByElement;
 
 import java.util.List;
@@ -33,7 +34,7 @@ import java.util.List;
  *
  * @author tw
  */
-public class KeepExpression implements Expression {
+public class KeepExpression extends ASTNodeAccessImpl implements Expression {
 
     private String name;
     private List<OrderByElement> orderByElements;

--- a/src/main/java/net/sf/jsqlparser/expression/LongValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/LongValue.java
@@ -21,12 +21,14 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 import java.math.BigInteger;
 
 /**
  * Every number without a point or an exponential format is a LongValue.
  */
-public class LongValue implements Expression {
+public class LongValue extends ASTNodeAccessImpl implements Expression {
 
     private String stringValue;
 

--- a/src/main/java/net/sf/jsqlparser/expression/MySQLGroupConcat.java
+++ b/src/main/java/net/sf/jsqlparser/expression/MySQLGroupConcat.java
@@ -41,6 +41,7 @@ package net.sf.jsqlparser.expression;
 
 import java.util.List;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 
@@ -48,7 +49,7 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
  *
  * @author toben
  */
-public class MySQLGroupConcat implements Expression {
+public class MySQLGroupConcat extends ASTNodeAccessImpl implements Expression {
 
     private ExpressionList expressionList;
     private boolean distinct = false;

--- a/src/main/java/net/sf/jsqlparser/expression/NotExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/NotExpression.java
@@ -21,10 +21,12 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  * It represents a "-" or "+" before an expression
  */
-public class NotExpression implements Expression {
+public class NotExpression extends ASTNodeAccessImpl implements Expression {
 
     private Expression expression;
 

--- a/src/main/java/net/sf/jsqlparser/expression/NullValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/NullValue.java
@@ -21,10 +21,12 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  * A "NULL" in a sql statement
  */
-public class NullValue implements Expression {
+public class NullValue extends ASTNodeAccessImpl implements Expression {
 
     @Override
     public void accept(ExpressionVisitor expressionVisitor) {

--- a/src/main/java/net/sf/jsqlparser/expression/NumericBind.java
+++ b/src/main/java/net/sf/jsqlparser/expression/NumericBind.java
@@ -21,11 +21,13 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  *
  * @author aud
  */
-public class NumericBind implements Expression {
+public class NumericBind extends ASTNodeAccessImpl implements Expression {
 
     private int bindId;
 

--- a/src/main/java/net/sf/jsqlparser/expression/OracleHierarchicalExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/OracleHierarchicalExpression.java
@@ -21,11 +21,13 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  *
  * @author toben
  */
-public class OracleHierarchicalExpression implements Expression {
+public class OracleHierarchicalExpression extends ASTNodeAccessImpl implements Expression {
 
     private Expression startExpression;
     private Expression connectExpression;

--- a/src/main/java/net/sf/jsqlparser/expression/OracleHint.java
+++ b/src/main/java/net/sf/jsqlparser/expression/OracleHint.java
@@ -21,6 +21,8 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -29,7 +31,7 @@ import java.util.regex.Pattern;
  *
  * @author valdo
  */
-public class OracleHint implements Expression {
+public class OracleHint extends ASTNodeAccessImpl implements Expression {
 
     private static final Pattern SINGLE_LINE = Pattern.compile("--\\+ *([^ ].*[^ ])");
     private static final Pattern MULTI_LINE = Pattern.

--- a/src/main/java/net/sf/jsqlparser/expression/Parenthesis.java
+++ b/src/main/java/net/sf/jsqlparser/expression/Parenthesis.java
@@ -21,10 +21,12 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  * It represents an expression like "(" expression ")"
  */
-public class Parenthesis implements Expression {
+public class Parenthesis extends ASTNodeAccessImpl implements Expression {
 
     private Expression expression;
     private boolean not = false;

--- a/src/main/java/net/sf/jsqlparser/expression/RowConstructor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/RowConstructor.java
@@ -22,13 +22,14 @@
 package net.sf.jsqlparser.expression;
 
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
 /**
  * Rowconstructor.
  *
  * @author tw
  */
-public class RowConstructor implements Expression {
+public class RowConstructor extends ASTNodeAccessImpl implements Expression {
 
     private ExpressionList exprList;
     private String name = null;

--- a/src/main/java/net/sf/jsqlparser/expression/SignedExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/SignedExpression.java
@@ -21,10 +21,12 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  * It represents a "-" or "+" before an expression
  */
-public class SignedExpression implements Expression {
+public class SignedExpression extends ASTNodeAccessImpl implements Expression {
 
     private char sign;
     private Expression expression;

--- a/src/main/java/net/sf/jsqlparser/expression/StringValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/StringValue.java
@@ -21,10 +21,12 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  * A string as in 'example_string'
  */
-public class StringValue implements Expression {
+public class StringValue extends ASTNodeAccessImpl implements Expression {
 
     private String value = "";
 

--- a/src/main/java/net/sf/jsqlparser/expression/TimeKeyExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/TimeKeyExpression.java
@@ -21,7 +21,9 @@
  */
 package net.sf.jsqlparser.expression;
 
-public class TimeKeyExpression implements Expression {
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
+public class TimeKeyExpression extends ASTNodeAccessImpl implements Expression {
 
     private String stringValue;
 

--- a/src/main/java/net/sf/jsqlparser/expression/TimeValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/TimeValue.java
@@ -21,12 +21,14 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 import java.sql.Time;
 
 /**
  * A Time in the form {t 'hh:mm:ss'}
  */
-public class TimeValue implements Expression {
+public class TimeValue extends ASTNodeAccessImpl implements Expression {
 
     private Time value;
 

--- a/src/main/java/net/sf/jsqlparser/expression/TimestampValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/TimestampValue.java
@@ -21,12 +21,14 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 import java.sql.Timestamp;
 
 /**
  * A Timestamp in the form {ts 'yyyy-mm-dd hh:mm:ss.f . . .'}
  */
-public class TimestampValue implements Expression {
+public class TimestampValue extends ASTNodeAccessImpl implements Expression {
 
     private Timestamp value;
     private char quotation = '\'';

--- a/src/main/java/net/sf/jsqlparser/expression/UserVariable.java
+++ b/src/main/java/net/sf/jsqlparser/expression/UserVariable.java
@@ -21,12 +21,14 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  * Simple uservariables like @test.
  *
  * @author aud
  */
-public class UserVariable implements Expression {
+public class UserVariable extends ASTNodeAccessImpl implements Expression {
 
     private String name;
     private boolean doubleAdd = false;

--- a/src/main/java/net/sf/jsqlparser/expression/WhenClause.java
+++ b/src/main/java/net/sf/jsqlparser/expression/WhenClause.java
@@ -21,12 +21,14 @@
  */
 package net.sf.jsqlparser.expression;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  * A clause of following syntax: WHEN condition THEN expression. Which is part of a CaseExpression.
  *
  * @author Havard Rast Blok
  */
-public class WhenClause implements Expression {
+public class WhenClause extends ASTNodeAccessImpl implements Expression {
 
     private Expression whenExpression;
     private Expression thenExpression;

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/Between.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/Between.java
@@ -23,11 +23,12 @@ package net.sf.jsqlparser.expression.operators.relational;
 
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
 /**
  * A "BETWEEN" expr1 expr2 statement
  */
-public class Between implements Expression {
+public class Between extends ASTNodeAccessImpl implements Expression {
 
     private Expression leftExpression;
     private boolean not = false;

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/ExistsExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/ExistsExpression.java
@@ -23,8 +23,9 @@ package net.sf.jsqlparser.expression.operators.relational;
 
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
-public class ExistsExpression implements Expression {
+public class ExistsExpression extends ASTNodeAccessImpl implements Expression {
 
     private Expression rightExpression;
     private boolean not = false;

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/InExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/InExpression.java
@@ -23,8 +23,9 @@ package net.sf.jsqlparser.expression.operators.relational;
 
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
-public class InExpression implements Expression, SupportsOldOracleJoinSyntax {
+public class InExpression extends ASTNodeAccessImpl implements Expression, SupportsOldOracleJoinSyntax {
 
     private Expression leftExpression;
     private ItemsList leftItemsList;

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsNullExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsNullExpression.java
@@ -23,8 +23,9 @@ package net.sf.jsqlparser.expression.operators.relational;
 
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
-public class IsNullExpression implements Expression {
+public class IsNullExpression extends ASTNodeAccessImpl implements Expression {
 
     private Expression leftExpression;
     private boolean not = false;

--- a/src/main/java/net/sf/jsqlparser/statement/select/AllColumns.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/AllColumns.java
@@ -21,10 +21,12 @@
  */
 package net.sf.jsqlparser.statement.select;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
 /**
  * All the columns (as in "SELECT * FROM ...")
  */
-public class AllColumns implements SelectItem {
+public class AllColumns extends ASTNodeAccessImpl implements SelectItem {
 
     public AllColumns() {
     }

--- a/src/main/java/net/sf/jsqlparser/statement/select/AllTableColumns.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/AllTableColumns.java
@@ -24,9 +24,10 @@ package net.sf.jsqlparser.statement.select;
 /**
  * All the columns of a table (as in "SELECT TableName.* FROM ...")
  */
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 import net.sf.jsqlparser.schema.*;
 
-public class AllTableColumns implements SelectItem {
+public class AllTableColumns extends ASTNodeAccessImpl implements SelectItem {
 
     private Table table;
 

--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -24,12 +24,13 @@ package net.sf.jsqlparser.statement.select;
 import java.util.List;
 
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 import net.sf.jsqlparser.schema.Column;
 
 /**
  * A join clause
  */
-public class Join {
+public class Join extends ASTNodeAccessImpl {
 
     private boolean outer = false;
     private boolean right = false;

--- a/src/main/java/net/sf/jsqlparser/statement/select/Limit.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Limit.java
@@ -22,11 +22,12 @@
 package net.sf.jsqlparser.statement.select;
 
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
 /**
  * A limit clause in the form [LIMIT {[offset,] row_count) | (row_count | ALL) OFFSET offset}]
  */
-public class Limit {
+public class Limit extends ASTNodeAccessImpl {
 
     private Expression rowCount;
     private Expression offset;

--- a/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
@@ -25,6 +25,7 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.OracleHierarchicalExpression;
 import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,7 +35,7 @@ import java.util.List;
 /**
  * The core of a "SELECT" statement (no UNION, no ORDER BY)
  */
-public class PlainSelect implements SelectBody {
+public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
 
     private Distinct distinct = null;
     private List<SelectItem> selectItems;

--- a/src/main/java/net/sf/jsqlparser/statement/select/SelectExpressionItem.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/SelectExpressionItem.java
@@ -23,11 +23,12 @@ package net.sf.jsqlparser.statement.select;
 
 import net.sf.jsqlparser.expression.Alias;
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
 /**
  * An expression as in "SELECT expr1 AS EXPR"
  */
-public class SelectExpressionItem implements SelectItem {
+public class SelectExpressionItem extends ASTNodeAccessImpl implements SelectItem {
 
     private Expression expression;
     private Alias alias;

--- a/src/main/java/net/sf/jsqlparser/statement/select/SelectItem.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/SelectItem.java
@@ -21,11 +21,13 @@
  */
 package net.sf.jsqlparser.statement.select;
 
+import net.sf.jsqlparser.parser.ASTNodeAccess;
+
 /**
  * Anything between "SELECT" and "FROM"<BR>
  * (that is, any column or expression etc to be retrieved with the query)
  */
-public interface SelectItem {
+public interface SelectItem extends ASTNodeAccess {
 
     void accept(SelectItemVisitor selectItemVisitor);
 }

--- a/src/main/java/net/sf/jsqlparser/statement/select/SetOperation.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/SetOperation.java
@@ -21,6 +21,7 @@
  */
 package net.sf.jsqlparser.statement.select;
 
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 import net.sf.jsqlparser.statement.select.SetOperationList.SetOperationType;
 
 /**
@@ -28,7 +29,7 @@ import net.sf.jsqlparser.statement.select.SetOperationList.SetOperationType;
  *
  * @author tw
  */
-public abstract class SetOperation {
+public abstract class SetOperation extends ASTNodeAccessImpl {
 
     private SetOperationType type;
 

--- a/src/main/java/net/sf/jsqlparser/statement/select/SubSelect.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/SubSelect.java
@@ -28,11 +28,12 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.expression.operators.relational.ItemsList;
 import net.sf.jsqlparser.expression.operators.relational.ItemsListVisitor;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
 /**
  * A subselect followed by an optional alias.
  */
-public class SubSelect implements FromItem, Expression, ItemsList {
+public class SubSelect extends ASTNodeAccessImpl implements FromItem, Expression, ItemsList {
 
     private SelectBody selectBody;
     private Alias alias;

--- a/src/main/java/net/sf/jsqlparser/util/cnfexpression/MultipleExpression.java
+++ b/src/main/java/net/sf/jsqlparser/util/cnfexpression/MultipleExpression.java
@@ -26,13 +26,14 @@ import java.util.List;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.expression.NullValue;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
 /**
  * This is a helper class that mainly used for handling the CNF conversion.
  * @author messfish
  *
  */
-public abstract class MultipleExpression implements Expression {
+public abstract class MultipleExpression extends ASTNodeAccessImpl implements Expression {
 
     private final List<Expression> childlist;
     

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1116,6 +1116,7 @@ PlainSelect PlainSelect():
         plainSelect.setFromItem(fromItem);
         if (joins != null && joins.size() > 0)
             plainSelect.setJoins(joins);
+        linkAST(plainSelect,jjtThis);
         return plainSelect;
     }
 }
@@ -1140,7 +1141,7 @@ SelectBody SetOperationList():
             (("(" select=SelectBody() ")" { bracket=true;} ) 
                     | select=PlainSelect() { bracket=false;} ) {selects.add(select);brackets.add(bracket); }
             (
-                ((<K_UNION> { UnionOp union = new UnionOp();operations.add(union); } [ <K_ALL> { union.setAll(true); } | <K_DISTINCT> { union.setDistinct(true); } ])
+                ((<K_UNION> { UnionOp union = new UnionOp();linkAST(union,jjtThis);operations.add(union); } [ <K_ALL> { union.setAll(true); } | <K_DISTINCT> { union.setDistinct(true); } ])
                 | <K_INTERSECT> { operations.add(new IntersectOp()); }
                 | <K_MINUS> { operations.add(new MinusOp()); }
                 | <K_EXCEPT> { operations.add(new ExceptOp()); }
@@ -1227,6 +1228,7 @@ SelectItem SelectItem():
     selectItem=SelectExpressionItem() 
     )
     {
+        linkAST(selectItem,jjtThis);
         return selectItem;
     }
 }
@@ -1589,6 +1591,7 @@ Join JoinerExpression():
           { join.setUsingColumns(columns); }   ))
       ]
   {
+      linkAST(join,jjtThis);
       join.setRightItem(right);
     return join; 
   }
@@ -1713,6 +1716,7 @@ Limit LimitWithOffset():
             limit = PlainLimit()
         )
     {
+        linkAST(limit,jjtThis);
         return limit;
     }
 }
@@ -1737,6 +1741,7 @@ Limit PlainLimit():
          <K_NULL> { limit.setLimitNull(true); }
      )
     {
+        linkAST(limit,jjtThis);
         return limit;
     }
 }
@@ -2006,7 +2011,10 @@ Expression RegularCondition():
             ((SupportsOldOracleJoinSyntax)result).setOraclePriorPosition(oraclePrior);
     }
 
-    { return result; }
+    {
+        linkAST(result,jjtThis);
+        return result;
+    }
 }
 
 Expression SQLCondition():
@@ -2083,6 +2091,7 @@ Expression LikeExpression() :
     {
         result.setLeftExpression(leftExpression);
         result.setRightExpression(rightExpression);
+        linkAST(result,jjtThis);
         return result;
     }
 }
@@ -2402,7 +2411,7 @@ Expression PrimaryExpression():
 
     | LOOKAHEAD(3) "(" retval=SubSelect() ")"
 
-    | token=<S_CHAR_LITERAL> { retval = new StringValue(token.image); }
+    | token=<S_CHAR_LITERAL> { retval = new StringValue(token.image); linkAST(retval,jjtThis); }
 
     | "{d" token=<S_CHAR_LITERAL> "}"  { retval = new DateValue(token.image); }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1002,7 +1002,6 @@ Table Table() #Table :
         final Server server = new Server(serverName);
         final Database database = new Database(server, databaseName);
         Table table = new Table(database, schemaName, tableName);
-        linkAST(table,jjtThis);
         return table;
     }
 }
@@ -1039,7 +1038,7 @@ SelectBody SelectBody():
     { return selectBody; }
 }
 
-PlainSelect PlainSelect():
+PlainSelect PlainSelect() #PlainSelect:
 {
     PlainSelect plainSelect = new PlainSelect();
     List<SelectItem> selectItems = null;
@@ -1121,7 +1120,7 @@ PlainSelect PlainSelect():
     }
 }
 
-SelectBody SetOperationList():
+SelectBody SetOperationList() #SetOperationList:
 {
     SetOperationList list = new SetOperationList();
     List<OrderByElement> orderByElements = null;
@@ -1217,7 +1216,7 @@ SelectExpressionItem SelectExpressionItem():
              [alias=Alias() { selectExpressionItem.setAlias(alias); }] { return selectExpressionItem; }
 }
 
-SelectItem SelectItem():
+SelectItem SelectItem() #SelectItem:
 {
     SelectItem selectItem = null;
 }
@@ -1559,7 +1558,7 @@ List JoinsList():
     { return joinsList; }
 }
 
-Join JoinerExpression():
+Join JoinerExpression() #JoinerExpression:
 {
     Join join = new Join();
     FromItem right = null;
@@ -1685,7 +1684,7 @@ OrderByElement OrderByElement():
     }
 }
 
-Limit LimitWithOffset():
+Limit LimitWithOffset() #LimitWithOffset:
 {
     Limit limit = new Limit();
     Token token = null;
@@ -1721,7 +1720,7 @@ Limit LimitWithOffset():
     }
 }
 
-Limit PlainLimit():
+Limit PlainLimit() #PlainLimit:
 {
     Limit limit = new Limit();
     Token token = null;
@@ -1950,7 +1949,7 @@ Expression Condition():
     { return result; }
 }
 
-Expression RegularCondition():
+Expression RegularCondition() #RegularCondition:
 {
     Expression result = null;
     Expression leftExpression;
@@ -2078,7 +2077,7 @@ Expression Between() :
     }
 }
 
-Expression LikeExpression() :
+Expression LikeExpression() #LikeExpression:
 {
     LikeExpression result = new LikeExpression();
     Expression leftExpression = null;
@@ -2357,7 +2356,7 @@ Expression BitwiseXor():
     { return result; }
 }
 
-Expression PrimaryExpression():
+Expression PrimaryExpression() #PrimaryExpression:
 {
     Expression retval = null;
     CastExpression castExpr = null;


### PR DESCRIPTION
This far there were only 3 types of structures linked to their AST nodes. Now adding some more expressions and literals to their AST node to have access to their token's position in the query.
Why this can be useful? If you're using JSqlParser to eventually present a query that was modified or maybe show different parts of it in different colors. In that case, you'll have to know the exact position of each of the tokens.

Regarding memory consumption - I have a test set of ~2000 real world queries that I'm testing my changes with. I'm running 100 iterations of that set to make sure nothing changes over time and relatively high volume.
Running the tests on a machine with low resources (1 CPU & 1GB RAM), to make sure there is no excessive use of memory - if something works on that machine, it provides a good indication it will work on strong production environment.