### PR TITLE
Adding basic support for IF conditions in SELECT clause

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -122,6 +122,8 @@ public interface ExpressionVisitor {
 
     void visit(CaseExpression caseExpression);
 
+    void visit(IfExpression ifExpression);
+
     void visit(WhenClause whenClause);
 
     void visit(ExistsExpression existsExpression);

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -239,6 +239,13 @@ public class ExpressionVisitorAdapter implements ExpressionVisitor, ItemsListVis
     }
 
     @Override
+    public void visit(IfExpression ifExpression) {
+        ifExpression.getIfExpression().accept(this);
+        ifExpression.getThenExpression().accept(this);
+        ifExpression.getElseExpression().accept(this);
+    }
+
+    @Override
     public void visit(WhenClause expr) {
         expr.getWhenExpression().accept(this);
         expr.getThenExpression().accept(this);

--- a/src/main/java/net/sf/jsqlparser/expression/IfExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/IfExpression.java
@@ -1,0 +1,71 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2013 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 2.1 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
+/**
+ * IF conditions in SELECT clause.
+ * Example: SELECT IF(a = 0, 5, 6), columnB, columnC from table1;
+ *
+ * @author Tomer Shay (Shimshi)
+ */
+public class IfExpression extends ASTNodeAccessImpl implements Expression {
+
+    private Expression ifExpression;
+    private Expression thenExpression;
+    private Expression elseExpression;
+
+    @Override
+    public void accept(ExpressionVisitor expressionVisitor) {
+        expressionVisitor.visit(this);
+    }
+
+    public Expression getIfExpression() {
+        return ifExpression;
+    }
+
+    public void setIfExpression(Expression ifExpression) {
+        this.ifExpression = ifExpression;
+    }
+
+    public Expression getThenExpression() {
+        return thenExpression;
+    }
+
+    public void setThenExpression(Expression thenExpression) {
+        this.thenExpression = thenExpression;
+    }
+
+    public Expression getElseExpression() {
+        return elseExpression;
+    }
+
+    public void setElseExpression(Expression elseExpression) {
+        this.elseExpression = elseExpression;
+    }
+
+    @Override
+    public String toString() {
+        return "if(" + ifExpression + ", " + thenExpression + ", " + elseExpression + ")";
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -24,41 +24,7 @@ package net.sf.jsqlparser.util;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.sf.jsqlparser.expression.AllComparisonExpression;
-import net.sf.jsqlparser.expression.AnalyticExpression;
-import net.sf.jsqlparser.expression.AnyComparisonExpression;
-import net.sf.jsqlparser.expression.BinaryExpression;
-import net.sf.jsqlparser.expression.CaseExpression;
-import net.sf.jsqlparser.expression.CastExpression;
-import net.sf.jsqlparser.expression.DateTimeLiteralExpression;
-import net.sf.jsqlparser.expression.DateValue;
-import net.sf.jsqlparser.expression.DoubleValue;
-import net.sf.jsqlparser.expression.Expression;
-import net.sf.jsqlparser.expression.ExpressionVisitor;
-import net.sf.jsqlparser.expression.ExtractExpression;
-import net.sf.jsqlparser.expression.Function;
-import net.sf.jsqlparser.expression.HexValue;
-import net.sf.jsqlparser.expression.IntervalExpression;
-import net.sf.jsqlparser.expression.JdbcNamedParameter;
-import net.sf.jsqlparser.expression.JdbcParameter;
-import net.sf.jsqlparser.expression.JsonExpression;
-import net.sf.jsqlparser.expression.KeepExpression;
-import net.sf.jsqlparser.expression.LongValue;
-import net.sf.jsqlparser.expression.MySQLGroupConcat;
-import net.sf.jsqlparser.expression.NotExpression;
-import net.sf.jsqlparser.expression.NullValue;
-import net.sf.jsqlparser.expression.NumericBind;
-import net.sf.jsqlparser.expression.OracleHierarchicalExpression;
-import net.sf.jsqlparser.expression.OracleHint;
-import net.sf.jsqlparser.expression.Parenthesis;
-import net.sf.jsqlparser.expression.RowConstructor;
-import net.sf.jsqlparser.expression.SignedExpression;
-import net.sf.jsqlparser.expression.StringValue;
-import net.sf.jsqlparser.expression.TimeKeyExpression;
-import net.sf.jsqlparser.expression.TimeValue;
-import net.sf.jsqlparser.expression.TimestampValue;
-import net.sf.jsqlparser.expression.UserVariable;
-import net.sf.jsqlparser.expression.WhenClause;
+import net.sf.jsqlparser.expression.*;
 import net.sf.jsqlparser.expression.operators.arithmetic.Addition;
 import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseAnd;
 import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseLeftShift;
@@ -428,6 +394,11 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
         if (caseExpression.getElseExpression() != null) {
             caseExpression.getElseExpression().accept(this);
         }
+    }
+
+    @Override
+    public void visit(IfExpression ifExpression) {
+
     }
 
     /*

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -24,42 +24,7 @@ package net.sf.jsqlparser.util.deparser;
 import java.util.Iterator;
 import java.util.List;
 
-import net.sf.jsqlparser.expression.AllComparisonExpression;
-import net.sf.jsqlparser.expression.AnalyticExpression;
-import net.sf.jsqlparser.expression.AnyComparisonExpression;
-import net.sf.jsqlparser.expression.BinaryExpression;
-import net.sf.jsqlparser.expression.CaseExpression;
-import net.sf.jsqlparser.expression.CastExpression;
-import net.sf.jsqlparser.expression.DateTimeLiteralExpression;
-import net.sf.jsqlparser.expression.DateValue;
-import net.sf.jsqlparser.expression.DoubleValue;
-import net.sf.jsqlparser.expression.Expression;
-import net.sf.jsqlparser.expression.ExpressionVisitor;
-import net.sf.jsqlparser.expression.ExtractExpression;
-import net.sf.jsqlparser.expression.Function;
-import net.sf.jsqlparser.expression.HexValue;
-import net.sf.jsqlparser.expression.IntervalExpression;
-import net.sf.jsqlparser.expression.JdbcNamedParameter;
-import net.sf.jsqlparser.expression.JdbcParameter;
-import net.sf.jsqlparser.expression.JsonExpression;
-import net.sf.jsqlparser.expression.KeepExpression;
-import net.sf.jsqlparser.expression.LongValue;
-import net.sf.jsqlparser.expression.MySQLGroupConcat;
-import net.sf.jsqlparser.expression.NotExpression;
-import net.sf.jsqlparser.expression.NullValue;
-import net.sf.jsqlparser.expression.NumericBind;
-import net.sf.jsqlparser.expression.OracleHierarchicalExpression;
-import net.sf.jsqlparser.expression.OracleHint;
-import net.sf.jsqlparser.expression.Parenthesis;
-import net.sf.jsqlparser.expression.RowConstructor;
-import net.sf.jsqlparser.expression.SignedExpression;
-import net.sf.jsqlparser.expression.StringValue;
-import net.sf.jsqlparser.expression.TimeKeyExpression;
-import net.sf.jsqlparser.expression.TimeValue;
-import net.sf.jsqlparser.expression.TimestampValue;
-import net.sf.jsqlparser.expression.UserVariable;
-import net.sf.jsqlparser.expression.WhenClause;
-import net.sf.jsqlparser.expression.WindowElement;
+import net.sf.jsqlparser.expression.*;
 import net.sf.jsqlparser.expression.operators.arithmetic.Addition;
 import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseAnd;
 import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseLeftShift;
@@ -512,6 +477,11 @@ public class ExpressionDeParser implements ExpressionVisitor, ItemsListVisitor {
         }
 
         buffer.append("END");
+    }
+
+    @Override
+    public void visit(IfExpression ifExpression) {
+        buffer.append(ifExpression.toString());
     }
 
     @Override

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2662,9 +2662,17 @@ IfExpression IfExpression():{
              | LOOKAHEAD(RegularCondition()) ifCondition=RegularCondition()
             | ifCondition=SimpleExpression())
             ","
-            thenExpression=SimpleExpression()
+            (LOOKAHEAD(AndExpression()) thenExpression=AndExpression()
+             | LOOKAHEAD(OrExpression()) thenExpression=OrExpression()
+             | LOOKAHEAD(SQLCondition()) thenExpression=SQLCondition()
+             | LOOKAHEAD(RegularCondition()) thenExpression=RegularCondition()
+            | thenExpression=SimpleExpression())
             ","
-            elseExpression=SimpleExpression()
+            (LOOKAHEAD(AndExpression()) elseExpression=AndExpression()
+             | LOOKAHEAD(OrExpression()) elseExpression=OrExpression()
+             | LOOKAHEAD(SQLCondition()) elseExpression=SQLCondition()
+             | LOOKAHEAD(RegularCondition()) elseExpression=RegularCondition()
+            | elseExpression=SimpleExpression())
         )
     ")"
     {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2364,6 +2364,8 @@ Expression PrimaryExpression():
 
     | retval=CaseWhenExpression()
 
+    | retval=IfExpression()
+
     | "?" { retval = new JdbcParameter(++jdbcParameterIndex, false); } 
 		[ token = <S_LONG> { ((JdbcParameter)retval).setUseFixedIndex(true); ((JdbcParameter)retval).setIndex(Integer.valueOf(token.image)); } ]
 
@@ -2641,6 +2643,34 @@ CastExpression CastExpression():
     {
         retval.setLeftExpression(expression);
         retval.setType(type);
+        return retval;
+    }
+}
+
+IfExpression IfExpression():{
+    IfExpression retval = new IfExpression();
+    Expression ifCondition = null;
+    Expression thenExpression = null;
+    Expression elseExpression = null;
+}
+{
+    <K_IF> "("
+        (
+            (LOOKAHEAD(AndExpression()) ifCondition=AndExpression()
+             | LOOKAHEAD(OrExpression()) ifCondition=OrExpression()
+             | LOOKAHEAD(SQLCondition()) ifCondition=SQLCondition()
+             | LOOKAHEAD(RegularCondition()) ifCondition=RegularCondition()
+            | ifCondition=SimpleExpression())
+            ","
+            thenExpression=SimpleExpression()
+            ","
+            elseExpression=SimpleExpression()
+        )
+    ")"
+    {
+        retval.setIfExpression(ifCondition);
+        retval.setThenExpression(thenExpression);
+        retval.setElseExpression(elseExpression);
         return retval;
     }
 }

--- a/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
@@ -158,8 +158,6 @@ public class ExpressionVisitorAdapterTest {
 
     @Test
     public void testIfExpression() throws JSQLParserException {
-        final LongValue thenValue = null;
-        final LongValue elseValue = null;
         Select select = (Select) CCJSqlParserUtil.parse("select if(a=0, 3, 4) from table1");
         PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
         IfExpression ifExpression = (IfExpression) ((SelectExpressionItem) plainSelect.getSelectItems().get(0)).getExpression();

--- a/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
@@ -21,12 +21,14 @@ package net.sf.jsqlparser.expression;
 import java.util.ArrayList;
 import java.util.List;
 import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
 import net.sf.jsqlparser.expression.operators.relational.InExpression;
 import net.sf.jsqlparser.expression.operators.relational.ItemsList;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SelectExpressionItem;
 import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -152,6 +154,24 @@ public class ExpressionVisitorAdapterTest {
 
         assertEquals(1, columnList.size());
         assertEquals("bar", columnList.get(0));
+    }
+
+    @Test
+    public void testIfExpression() throws JSQLParserException {
+        final LongValue thenValue = null;
+        final LongValue elseValue = null;
+        Select select = (Select) CCJSqlParserUtil.parse("select if(a=0, 3, 4) from table1");
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        IfExpression ifExpression = (IfExpression)((SelectExpressionItem)plainSelect.getSelectItems().get(0)).getExpression();
+        ifExpression.accept(new ExpressionVisitorAdapter() {
+            @Override
+            public void visit(IfExpression expr) {
+                super.visit(expr);
+                assertEquals(true, expr.getIfExpression() instanceof EqualsTo);
+                assertEquals(3, ((LongValue)expr.getThenExpression()).getValue());
+                assertEquals(4, ((LongValue)expr.getElseExpression()).getValue());
+            }
+        });
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
@@ -162,14 +162,14 @@ public class ExpressionVisitorAdapterTest {
         final LongValue elseValue = null;
         Select select = (Select) CCJSqlParserUtil.parse("select if(a=0, 3, 4) from table1");
         PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
-        IfExpression ifExpression = (IfExpression)((SelectExpressionItem)plainSelect.getSelectItems().get(0)).getExpression();
+        IfExpression ifExpression = (IfExpression) ((SelectExpressionItem) plainSelect.getSelectItems().get(0)).getExpression();
         ifExpression.accept(new ExpressionVisitorAdapter() {
             @Override
             public void visit(IfExpression expr) {
                 super.visit(expr);
                 assertEquals(true, expr.getIfExpression() instanceof EqualsTo);
-                assertEquals(3, ((LongValue)expr.getThenExpression()).getValue());
-                assertEquals(4, ((LongValue)expr.getElseExpression()).getValue());
+                assertEquals(3, ((LongValue) expr.getThenExpression()).getValue());
+                assertEquals(4, ((LongValue) expr.getElseExpression()).getValue());
             }
         });
     }

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -2634,6 +2634,22 @@ public class SelectTest extends TestCase {
         assertSqlCanBeParsedAndDeparsed("SELECT if(z, 'a', 'b') AS business_type FROM mytable1");
     }
 
+    public void testIfSimpleConditionInSelect() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT if(a, 'Some Result If True', 'Some Result If False'), cola, colb FROM tbl");
+    }
+
+    public void testIfEqualsToConditionInSelect() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT if(a = 0, 'Some Result If True', 'Some Result If False'), cola, colb FROM tbl");
+    }
+
+    public void testIfLikeExpressionConditionInSelect() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT if(lsname LIKE '%dental%', 7, 0), cola, colb FROM tbl");
+    }
+
+    public void testIfAndConditionInSelect() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT if(count(Target.offer_id) = 1 AND Target.member_id = '0', TARGET_ID_GENERATOR(80099702715, `Target`.`offer_id`), `Target`.`id`), cola, colb FROM tbl");
+    }
+
     public void testProblemIssue437Index() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("select count(id) from p_custom_data ignore index(pri) where tenant_id=28257 and entity_id=92609 and delete_flg=0 and ( (dbc_relation_2 = 52701) and (dbc_relation_2 in ( select id from a_order where tenant_id = 28257 and 1=1 ) ) ) order by id desc, id desc", true);
     }


### PR DESCRIPTION
Adding support for IF conditions in SELECT clause.
Example: SELECT IF(a = 5, 200, 404), columnA, columnB from table.
Supporting different condition types for the first argument - LIKE, AND / OR, etc.