### PR TITLE
Add support for "NOT LIKE ..." expressions

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2077,9 +2077,18 @@ Expression LikeExpression() :
     Expression rightExpression = null;
 }
 {
-    leftExpression=SimpleExpression()
-    [<K_NOT> { result.setNot(true); } ] ( <K_LIKE> | <K_ILIKE> { result.setCaseInsensitive(true); } ) rightExpression=SimpleExpression()
-    [<K_ESCAPE> token=<S_CHAR_LITERAL> { result.setEscape((new StringValue(token.image)).getValue()); }]
+    (
+        (
+            leftExpression=SimpleExpression()
+            [<K_NOT> { result.setNot(true); } ] ( <K_LIKE> | <K_ILIKE> { result.setCaseInsensitive(true); } ) rightExpression=SimpleExpression()
+            [<K_ESCAPE> token=<S_CHAR_LITERAL> { result.setEscape((new StringValue(token.image)).getValue()); }]
+        )
+        |
+        (
+            [<K_NOT> { result.setNot(true); } ] leftExpression=SimpleExpression() ( <K_LIKE> | <K_ILIKE> { result.setCaseInsensitive(true); } ) rightExpression=SimpleExpression()
+            [<K_ESCAPE> token=<S_CHAR_LITERAL> { result.setEscape((new StringValue(token.image)).getValue()); }]
+        )
+    )
     {
         result.setLeftExpression(leftExpression);
         result.setRightExpression(rightExpression);

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -1192,6 +1192,24 @@ public class SelectTest extends TestCase {
         assertEquals("test2", ((LikeExpression) plainSelect.getWhere()).getEscape());
     }
 
+    public void testNotLike() throws JSQLParserException {
+        String statement = "SELECT * FROM tab1 WHERE a NOT LIKE 'test'";
+        Select select = (Select) parserManager.parse(new StringReader(statement));
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertEquals("test", ((StringValue) ((LikeExpression) plainSelect.getWhere()).
+                getRightExpression()).getValue());
+        assertEquals(true, (boolean) ((LikeExpression) plainSelect.getWhere()).isNot());
+    }
+
+    public void testNotLikeWithNotBeforeExpression() throws JSQLParserException {
+        String statement = "SELECT * FROM tab1 WHERE NOT a LIKE 'test'";
+        Select select = (Select) parserManager.parse(new StringReader(statement));
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertEquals("test", ((StringValue) ((LikeExpression) plainSelect.getWhere()).
+                getRightExpression()).getValue());
+        assertEquals(true, (boolean) ((LikeExpression) plainSelect.getWhere()).isNot());
+    }
+
     public void testIlike() throws JSQLParserException {
         String statement = "SELECT col1 FROM table1 WHERE col1 ILIKE '%hello%'";
         assertSqlCanBeParsedAndDeparsed(statement);


### PR DESCRIPTION
The parser is able to parse expressions such as "a NOT LIKE '%pattern%'", but is not able to parse expressions where the NOT part is before the entire expression.
For example: "NOT a LIKE '%pattern%'.

When parsing the latter, the error is:
Caused by: net.sf.jsqlparser.parser.ParseException: Encountered " "LIKE" "LIKE "" at line 1, column 32.
Was expecting one of: ...

The reason this is important is both because these syntaxes are both valid, and also because the deparser uses the second method.
Therefore, if you parse a query with the first type of expression, then deparse it and parse again, you'll get the same error.