### PR TITLE
Added support for RLIKE expressions

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -245,6 +245,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_RECURSIVE:"RECURSIVE">
 |   <K_REFERENCES:"REFERENCES">
 |   <K_REGEXP: "REGEXP">
+|   <K_RLIKE: "RLIKE">
 |   <K_REPLACE:"REPLACE">
 |   <K_RESTRICT: "RESTRICT">
 |   <K_RETURNING: "RETURNING"> 
@@ -1973,6 +1974,7 @@ Expression RegularCondition():
     | "@@" { result = new Matches(); }
     | "~" { result = new RegExpMatchOperator(RegExpMatchOperatorType.MATCH_CASESENSITIVE); }
     | <K_REGEXP> [ <K_BINARY> { binary=true; } ] { result = new RegExpMySQLOperator(binary?RegExpMatchOperatorType.MATCH_CASESENSITIVE:RegExpMatchOperatorType.MATCH_CASEINSENSITIVE); }
+    | <K_RLIKE> [ <K_BINARY> { binary=true; } ] { result = new RegExpMySQLOperator(binary?RegExpMatchOperatorType.MATCH_CASESENSITIVE:RegExpMatchOperatorType.MATCH_CASEINSENSITIVE); }
     | "~*" { result = new RegExpMatchOperator(RegExpMatchOperatorType.MATCH_CASEINSENSITIVE); }
     | "!~" { result = new RegExpMatchOperator(RegExpMatchOperatorType.NOT_MATCH_CASESENSITIVE); }
     | "!~*" { result = new RegExpMatchOperator(RegExpMatchOperatorType.NOT_MATCH_CASEINSENSITIVE); }

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -1974,6 +1974,12 @@ public class SelectTest extends TestCase {
         assertSqlCanBeParsedAndDeparsed(stmt);
     }
 
+    public void testRlike() throws JSQLParserException {
+        String stmt = "SELECT * FROM mytable WHERE first_name RLIKE '^Ste(v|ph)en$'";
+        Statement st = CCJSqlParserUtil.parse(stmt);
+        assertStatementCanBeDeparsedAs(st, "SELECT * FROM mytable WHERE first_name REGEXP '^Ste(v|ph)en$'");
+    }
+
     public void testBooleanFunction1() throws JSQLParserException {
         String stmt = "SELECT * FROM mytable WHERE test_func(col1)";
         assertSqlCanBeParsedAndDeparsed(stmt);


### PR DESCRIPTION
RLIKE is a synonym of REGEXP, therefore should be treated the same.
https://dev.mysql.com/doc/refman/5.7/en/regexp.html