### PR TITLE
Allow single quotes around aliases in SELECT clause

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -957,6 +957,22 @@ String RelObjectName() :
     { return tk.image; }
 }
 
+String RelObjectNameOrQuotedString() :
+{    Token tk = null; }
+{
+    (tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER>
+              | tk=<K_CAST> | tk=<K_DO> | tk=<K_EXTRACT> | tk=<K_FIRST> | tk=<K_FOLLOWING>
+              | tk=<K_LAST> | tk=<K_MATERIALIZED> | tk=<K_NULLS> | tk=<K_PARTITION> | tk=<K_RANGE>
+              | tk=<K_ROW> | tk=<K_ROWS> | tk=<K_SIBLINGS> | tk=<K_VALUE> | tk=<K_XML>
+              | tk=<K_COLUMN> | tk=<K_REPLACE> | tk=<K_TRUNCATE> | tk=<K_KEY> | tk=<K_ANY>
+              | tk=<K_OPEN> | tk=<K_OVER> | tk=<K_VALUES> | tk=<K_PERCENT> | tk=<K_PRIOR>
+              | tk=<K_SEPARATOR> | tk=<K_NO> | tk=<K_ACTION> | tk=<K_CASCADE> | tk=<K_END>
+              | tk=<K_TABLE> | tk=<K_DATETIMELITERAL> | tk=<K_COMMIT> | tk=<K_PRECISION>
+              | tk=<K_INSERT> | tk=<S_CHAR_LITERAL>)
+
+    { return tk.image; }
+}
+
 /*
 Extended usage of object names.
 */
@@ -1213,7 +1229,7 @@ SelectExpressionItem SelectExpressionItem():
 }
 {
      expression=SimpleExpression() { selectExpressionItem = new SelectExpressionItem(); selectExpressionItem.setExpression(expression); }
-             [alias=Alias() { selectExpressionItem.setAlias(alias); }] { return selectExpressionItem; }
+             [alias=SelectAlias() { selectExpressionItem.setAlias(alias); }] { return selectExpressionItem; }
 }
 
 SelectItem SelectItem():
@@ -1241,6 +1257,14 @@ AllTableColumns AllTableColumns():
         return new AllTableColumns(table);
     }
 
+}
+
+Alias SelectAlias():
+{ String name = null;
+  boolean useAs = false; }
+{
+    [<K_AS> { useAs = true; } ] name=RelObjectNameOrQuotedString()
+   { return new Alias(name,useAs); }
 }
 
 Alias Alias():

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -1282,6 +1282,11 @@ public class SelectTest extends TestCase {
         assertSqlCanBeParsedAndDeparsed(statement);
     }
 
+    public void testSelectAliasInSingleQuotes() throws JSQLParserException {
+        String statement = "SELECT mycolumn AS 'My Column Name' FROM mytable";
+        assertSqlCanBeParsedAndDeparsed(statement);
+    }
+
     public void testSelectAliasWithoutAs() throws JSQLParserException {
         String statement = "SELECT mycolumn \"My Column Name\" FROM mytable";
         assertSqlCanBeParsedAndDeparsed(statement);


### PR DESCRIPTION
MySQL supports single quotes around aliases (in addition to double quotes and backticks). They are only allowed in aliases in the SELECT clause. In other cases, only backticks are supported.

From the documentation:
_"The identifier quote character is the backtick (`).
"In the select list of a query, a quoted column alias can be specified using identifier or string quoting characters"._

https://dev.mysql.com/doc/refman/5.7/en/identifiers.html
The example in the documentation shows an alias with single quotes around it as valid - search for 'two' in the url above.

The following query is valid in MySQL, but JSqlParser currently fails when parsing it:
`SELECT mycolumn AS 'My Column Name' FROM mytable`