### PR TITLE
Add support for x'HEX' and X'HEX' Numeric Constants in SQLite

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -318,7 +318,7 @@ TOKEN : /* Numeric Constants */
             )>
   |     < S_LONG: ( <DIGIT> )+ >
   |     < #DIGIT: ["0" - "9"] >
-  |     < S_HEX: ("x'" ( <HEX_VALUE> )+ "'" | "0x" ( <HEX_VALUE> )+ ) >
+  |     < S_HEX: (["x","X"] "'" ( <HEX_VALUE> )+ "'" | "0x" ( <HEX_VALUE> )+ ) >
   |     < #HEX_VALUE: ["0"-"9","A"-"F"]  >
 }
 


### PR DESCRIPTION
Currently, only x'HEX' numeric constants are supported. SQLite supports X'HEX' as well, as "string literals containing hexadecimal data"