### PR TITLE
Add support for MySQL SQL_NO_CACHE

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
@@ -60,6 +60,7 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
     private boolean useBrackets = false;
     private Wait wait;
     private boolean mySqlSqlCalcFoundRows = false;
+    private boolean sqlNoCacheFlag = false;
 
     public boolean isUseBrackets() {
         return useBrackets;
@@ -313,6 +314,9 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
         if (top != null) {
             sql.append(top).append(" ");
         }
+        if (sqlNoCacheFlag) {
+            sql.append("SQL_NO_CACHE").append(" ");
+        }
         if (mySqlSqlCalcFoundRows) {
             sql.append("SQL_CALC_FOUND_ROWS").append(" ");
         }
@@ -465,7 +469,15 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
         this.mySqlSqlCalcFoundRows = mySqlCalcFoundRows;
     }
 
+    public void setMySqlSqlNoCache(boolean sqlNoCacheFlagSet) {
+        this.sqlNoCacheFlag = sqlNoCacheFlagSet;
+    }
+
     public boolean getMySqlSqlCalcFoundRows() {
         return this.mySqlSqlCalcFoundRows;
+    }
+
+    public boolean getMySqlSqlNoCache() {
+        return this.sqlNoCacheFlag;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -97,6 +97,10 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
             buffer.append(top).append(" ");
         }
 
+        if (plainSelect.getMySqlSqlNoCache()) {
+            buffer.append("SQL_NO_CACHE").append(" ");
+        }
+
         if (plainSelect.getMySqlSqlCalcFoundRows()) {
             buffer.append("SQL_CALC_FOUND_ROWS").append(" ");
         }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -274,6 +274,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_UPSERT:"UPSERT">
 |   <K_USE : "USE">
 |   <K_SQL_CALC_FOUND_ROWS: "SQL_CALC_FOUND_ROWS">
+|   <K_SQL_NO_CACHE: "SQL_NO_CACHE">
 |   <K_USING:"USING">
 |   <K_VALIDATE : "VALIDATE">
 |   <K_VALUE:"VALUE">
@@ -1107,6 +1108,10 @@ PlainSelect PlainSelect() #PlainSelect:
         |
             (
                 <K_SQL_CALC_FOUND_ROWS> { plainSelect.setMySqlSqlCalcFoundRows(true); }
+            )
+        |
+            (
+                <K_SQL_NO_CACHE> { plainSelect.setMySqlSqlNoCache(true); }
             )
     ]
 

--- a/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/test/select/SelectTest.java
@@ -2153,6 +2153,11 @@ public class SelectTest extends TestCase {
         }
     }
 
+    public void testSqlNoCache() throws JSQLParserException {
+        String stmt = "SELECT SQL_NO_CACHE sales.date FROM sales";
+        assertSqlCanBeParsedAndDeparsed(stmt);
+    }
+
     public void testSelectInto1() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT * INTO user_copy FROM user");
     }


### PR DESCRIPTION
Adding support for MySQL's SQL_NO_CACHE flag.
When the flag is used, the MySQL server does not use the query cache. It neither checks the query cache to see whether the result is already cached, nor does it cache the query result.

docs: https://dev.mysql.com/doc/refman/5.7/en/query-cache-in-select.html