### PR TITLE
add support for && operator

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -140,6 +140,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_ALL:"ALL">
 |   <K_ALTER:"ALTER">
 |   <K_AND:"AND">
+|   <K_AND_OPERATOR:"&&">
 |   <K_ANY:"ANY">
 |   <K_AS: "AS">
 |   <K_ASC:"ASC">
@@ -1985,7 +1986,7 @@ Expression AndExpression() :
     { result = left; }
 
     (
-         <K_AND>
+         (<K_AND> | <K_AND_OPERATOR>)
         (
         LOOKAHEAD(Condition())
             right=Condition()

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -3166,4 +3166,11 @@ public class SelectTest {
     public void testNestedCast() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT acolumn::bit (64)::bigint FROM mytable");
     }
+
+    @Test
+    public void testAndOperator() throws JSQLParserException {
+        String stmt = "SELECT name from customers where name = 'John' && lastname = 'Doh'";
+        Statement parsed = parserManager.parse(new StringReader(stmt));
+        assertStatementCanBeDeparsedAs(parsed, "SELECT name FROM customers WHERE name = 'John' AND lastname = 'Doh'");
+    }
 }


### PR DESCRIPTION
MySQL allows to use the `&&` operator as an alias to the AND operator.
https://dev.mysql.com/doc/refman/8.0/en/logical-operators.html#operator_and

Example:
`SELECT col FROM tbl WHERE tbl.pid = 2 && tbl.status = 1`