### PR TITLE
fix parsing and rendering of Truncate

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/truncate/Truncate.java
+++ b/src/main/java/net/sf/jsqlparser/statement/truncate/Truncate.java
@@ -56,7 +56,7 @@ public class Truncate implements Statement {
 
     @Override
     public String toString() {
-        if(cascade==true){
+        if(cascade){
             return "TRUNCATE TABLE " + table+" CASCADE";
         }
         return "TRUNCATE TABLE " + table;

--- a/src/main/java/net/sf/jsqlparser/statement/truncate/Truncate.java
+++ b/src/main/java/net/sf/jsqlparser/statement/truncate/Truncate.java
@@ -31,6 +31,7 @@ import net.sf.jsqlparser.statement.StatementVisitor;
 public class Truncate implements Statement {
 
     private Table table;
+    boolean cascade;  // to support TRUNCATE TABLE ... CASCADE
 
     @Override
     public void accept(StatementVisitor statementVisitor) {
@@ -45,8 +46,19 @@ public class Truncate implements Statement {
         this.table = table;
     }
 
+    public boolean getCascade(){
+        return cascade;
+    }
+
+    public void setCascade(boolean c){
+        cascade=c;
+    }
+
     @Override
     public String toString() {
+        if(cascade==true){
+            return "TRUNCATE TABLE " + table+" CASCADE";
+        }
         return "TRUNCATE TABLE " + table;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -144,6 +144,11 @@ public class StatementDeParser implements StatementVisitor {
 
     @Override
     public void visit(Truncate truncate) {
+        buffer.append("TRUNCATE TABLE ");
+        buffer.append(truncate.getTable());
+        if(truncate.getCascade()){
+            buffer.append(" CASCADE");
+        }
     }
 
     @Override

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3448,7 +3448,7 @@ Truncate Truncate():
 }
 {
     <K_TRUNCATE> <K_TABLE>
-    table=Table() { truncate.setTable(table); }
+	table=Table() { truncate.setTable(table); truncate.setCascade(false); } [ <K_CASCADE> {truncate.setCascade(true);} ]
     {
         return truncate;
     }

--- a/src/test/java/net/sf/jsqlparser/statement/truncate/TruncateTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/truncate/TruncateTest.java
@@ -2,6 +2,9 @@ package net.sf.jsqlparser.statement.truncate;
 
 import java.io.StringReader;
 
+import static net.sf.jsqlparser.test.TestUtils.*;
+import net.sf.jsqlparser.*;
+
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
@@ -23,5 +26,20 @@ public class TruncateTest {
         truncate = (Truncate) parserManager.parse(new StringReader(statement));
         assertEquals("mytab", truncate.getTable().getName());
         assertEquals(toStringStatement.toUpperCase(), truncate.toString().toUpperCase());
+
+        statement = "TRUNCATE TABLE mytab CASCADE";
+        truncate = (Truncate) parserManager.parse(new StringReader(statement));
+        assertEquals(statement, truncate.toString());
     }
+
+    @Test
+    public void testTruncateDeparse() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("TRUNCATE TABLE foo");
+    }
+
+    @Test
+    public void testTruncateCascadeDeparse() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("TRUNCATE TABLE foo CASCADE");
+    }
+
 }


### PR DESCRIPTION
- the method for rendering a Truncate command in StatementDeParser.java is empty.  This can cause problems, e.g. I wrote a program to split a file of SQL statements into individual statements and the TRUNCATE commands were missing.  I filled in the module.

- The parser does not accept a CASCADE directive in a TRUNCATE DDL.  I modified the parser to accept CASCADE, added code to Truncate.java to record the CASCADE directive and added code to the toString method to render the CASCADE if present.

example SQL (postgres):
   truncate table global_uids CASCADE;

The modified code passes all test