### PR TITLE
support teradata shortcut for Select

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -258,7 +258,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_RIGHT:"RIGHT">
 |   <K_ROW: "ROW"> 
 |   <K_ROWS: "ROWS">
-|   <K_SELECT:"SELECT">
+|   <K_SELECT: ("SELECT" | "SEL")>
 |   <K_SEMI : "SEMI">
 |   <K_SEPARATOR:"SEPARATOR">
 |   <K_SET:"SET">

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -3221,4 +3221,15 @@ public class SelectTest {
     public void testMultiPartNamesIssue608() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT @@session.tx_read_only");
     } 
+
+//    Teradata allows SEL to be used in place of SELECT
+//    Deparse to the non-contracted form
+    @Test
+    public void testSelContraction() throws JSQLParserException {
+        final String statementSrc = "SEL name, age FROM person";
+        final String statementTgt = "SELECT name, age FROM person";
+        Select select = (Select) parserManager.parse(new StringReader(statementSrc));
+        assertStatementCanBeDeparsedAs(select, statementTgt);
+    }
+
 }


### PR DESCRIPTION
Teradata SQL allows the user to use "sel" in place of "select".
Example:
   sel name, status from accounts

I modified JSqlParserCC.jjt to accept the "sel" keyword as synonymous with Select.

The modified code passes all tests

