### PR TITLE
make the CreateTable deparser use the accept/visit schema instead of …

### DIFF
--- a/src/main/java/net/sf/jsqlparser/util/deparser/CreateTableDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/CreateTableDeParser.java
@@ -27,6 +27,8 @@ import net.sf.jsqlparser.statement.create.table.ColumnDefinition;
 import net.sf.jsqlparser.statement.create.table.CreateTable;
 import net.sf.jsqlparser.statement.create.table.Index;
 import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+
 
 /**
  * A class to de-parse (that is, tranform from JSqlParser hierarchy into a string) a
@@ -35,6 +37,7 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
 public class CreateTableDeParser {
 
     private StringBuilder buffer;
+    private StatementDeParser statementDeParser;
 
     /**
      * @param buffer the buffer that will be filled with the select
@@ -42,6 +45,12 @@ public class CreateTableDeParser {
     public CreateTableDeParser(StringBuilder buffer) {
         this.buffer = buffer;
     }
+
+    public CreateTableDeParser(StatementDeParser statementDeParser, StringBuilder buffer) {
+        this.buffer = buffer;
+        this.statementDeParser = statementDeParser;
+    }
+
 
     public void deParse(CreateTable createTable) {
         buffer.append("CREATE ");
@@ -64,7 +73,8 @@ public class CreateTableDeParser {
             if (createTable.isSelectParenthesis()) {
                 buffer.append("(");
             }
-            buffer.append(createTable.getSelect().toString());
+            Select sel = createTable.getSelect();
+            sel.accept(this.statementDeParser);
             if (createTable.isSelectParenthesis()) {
                 buffer.append(")");
             }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -70,7 +70,7 @@ public class StatementDeParser implements StatementVisitor {
 
     @Override
     public void visit(CreateTable createTable) {
-        CreateTableDeParser createTableDeParser = new CreateTableDeParser(buffer);
+        CreateTableDeParser createTableDeParser = new CreateTableDeParser(this, buffer);
         createTableDeParser.deParse(createTable);
     }
 


### PR DESCRIPTION
…the toString path

I was writing a utility which would report, for every select item, the alias and definition of the field.
This was working for an INSERT statement, but reported nothing for a CREATE TABLE statement.

After some digging, I discovered that the CREATE TABLE deparser does not use the
accept/visit scheme, but instead uses a parallel toString SQL generation path for an embedded Select statement.
So the Select statement in a CREATE TABLE statement is not available via visit/accept for custom SQL generation, reporting, etc.
This is inconsistent with Select, Insert, etc.

I fixed the problem by replacing the toString call with an accept call.