### PR TITLE
Fix to issue #694 (spurious NOT in NOT LIKE elements within the WITH clause)

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/BinaryExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/BinaryExpression.java
@@ -68,7 +68,7 @@ public abstract class BinaryExpression extends ASTNodeAccessImpl implements Expr
 
     @Override
     public String toString() {
-        return (not ? "NOT " : "") + getLeftExpression() + " " + getStringExpression() + " " + getRightExpression();
+        return getLeftExpression() + " " + getStringExpression() + " " + getRightExpression();
     }
 
     public abstract String getStringExpression();


### PR DESCRIPTION
Removes a spurious NOT from the BinaryExpression toString() element.  All the Maven tests pass.