### PR TITLE
Function boolean param

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2329,6 +2329,20 @@ ExpressionList SimpleExpressionList():
     }
 }
 
+ExpressionList SimpleExpressionListIncludingBoolean():
+{
+    ExpressionList retval = new ExpressionList();
+    List<Expression> expressions = new ArrayList<Expression>();
+    Expression expr = null;
+}
+{
+    expr=SimpleExpressionIncludingBoolean() { expressions.add(expr); } ("," expr=SimpleExpressionIncludingBoolean() { expressions.add(expr); })*
+    {
+        retval.setExpressions(expressions);
+        return retval;
+    }
+}
+
 ExpressionList SimpleExpressionListAtLeastTwoItems():
 {
     ExpressionList retval = new ExpressionList();
@@ -2385,6 +2399,55 @@ Expression AnyComparisonExpression() :
    {
       return retval;
    }
+}
+
+Expression SimpleExpressionIncludingBoolean():
+{
+    Expression retval = null;
+}
+{
+  (
+        retval=BooleanBinaryExpression()
+  )
+
+   {
+      return retval;
+   }
+}
+
+Expression BooleanBinaryExpression():
+{
+    Expression result = null;
+    Expression leftExpression = null;
+    Expression rightExpression = null;
+}
+{
+    (
+      leftExpression=ConcatExpression()
+    )
+      { result = leftExpression; }
+    (
+    
+	    LOOKAHEAD(2) (
+	    	">" { result = new GreaterThan(); }
+		    | "<" { result = new MinorThan(); }
+		    | "=" { result = new EqualsTo(); }
+		    | token=<OP_GREATERTHANEQUALS> { result = new GreaterThanEquals(token.image); }
+		    | token=<OP_MINORTHANEQUALS> { result = new MinorThanEquals(token.image); }
+		    | token=<OP_NOTEQUALSSTANDARD> { result = new NotEqualsTo(token.image); }
+		    | token=<OP_NOTEQUALSBANG> { result = new NotEqualsTo(token.image); }
+	    )
+
+        rightExpression=ConcatExpression()
+
+        {
+            BinaryExpression binExp = (BinaryExpression) result;
+            binExp.setLeftExpression(leftExpression);
+            binExp.setRightExpression(rightExpression);
+            leftExpression = result;
+        }
+    )*
+    { return result; }
 }
 
 Expression SimpleExpression():
@@ -2949,7 +3012,7 @@ Function Function() #Function:
     funcName=RelObjectNameExt()
 
     [ "." tmp=RelObjectNameExt() { funcName+= "." + tmp; } ["." tmp=RelObjectNameExt() { funcName+= "." + tmp; }]]
-    "(" [ [<K_DISTINCT> { retval.setDistinct(true); } | <K_ALL> { retval.setAllColumns(true); }] (LOOKAHEAD(3) expressionList=SimpleExpressionList() | "*" { retval.setAllColumns(true); }
+    "(" [ [<K_DISTINCT> { retval.setDistinct(true); } | <K_ALL> { retval.setAllColumns(true); }] (LOOKAHEAD(3) expressionList=SimpleExpressionListIncludingBoolean() | "*" { retval.setAllColumns(true); }
         | expr = SubSelect() { expr.setUseBrackets(false); expressionList = new ExpressionList(expr); } ) ] ")"
 
     [ "." tmp=RelObjectName() { retval.setAttribute(tmp); }]

--- a/src/test/java/net/sf/jsqlparser/parser/FunctionWithBooleanParamTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/FunctionWithBooleanParamTest.java
@@ -1,0 +1,60 @@
+package net.sf.jsqlparser.parser;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import net.sf.jsqlparser.expression.Expression;
+
+/**
+ * Test some cases linked to a boolean (condition) argument as function parameter.
+ * 
+ * @author Denis Fulachier
+ *
+ */
+public class FunctionWithBooleanParamTest {
+
+    public FunctionWithBooleanParamTest() {}
+
+    @Test
+    public void testParseOpLowerTotally() throws Exception {
+        Expression result = CCJSqlParserUtil.parseExpression("if(a<b, c, d)");
+        assertEquals("if(a < b, c, d)", result.toString());
+    }
+
+    @Test
+    public void testParseOpLowerOrEqual() throws Exception {
+        Expression result = CCJSqlParserUtil.parseExpression("if(a+x<=b+y, c, d)");
+        assertEquals("if(a + x <= b + y, c, d)", result.toString());
+    }
+    
+    @Test
+    public void testParseOpGreaterTotally() throws Exception {
+        Expression result = CCJSqlParserUtil.parseExpression("if(a>b, c, d)");
+        assertEquals("if(a > b, c, d)", result.toString());
+    }
+    
+    @Test
+    public void testParseOpGreaterOrEqual() throws Exception {
+        Expression result = CCJSqlParserUtil.parseExpression("if(a>=b, c, d)");
+        assertEquals("if(a >= b, c, d)", result.toString());
+    }
+    
+    @Test
+    public void testParseOpEqual() throws Exception {
+        Expression result = CCJSqlParserUtil.parseExpression("if(a=b, c, d)");
+        assertEquals("if(a = b, c, d)", result.toString());
+    }
+
+    @Test
+    public void testParseOpNotEqualStandard() throws Exception {
+        Expression result = CCJSqlParserUtil.parseExpression("if(a<>b, c, d)");
+        assertEquals("if(a <> b, c, d)", result.toString());
+    }
+
+    @Test
+    public void testParseOpNotEqualBang() throws Exception {
+        Expression result = CCJSqlParserUtil.parseExpression("if(a!=b, c, d)");
+        assertEquals("if(a != b, c, d)", result.toString());
+    }
+}


### PR DESCRIPTION
Hello,
First congratulation for this simple-to-use and efficient API. This is a very powerfull tool.
I faced to the "famous" issue with boolean expression in function call (typically: "if(a<b, c, d)").
It does not seem to be so easy to fix, due to grammar complexity. I faced issue with the "ALL" optional clause we can found in both condition and function call parsing branches.
I propose a first quick fix, taking into account only simple boolean expressions (<, >, etc. simple operators.). 
Modified JavaCC grammar, plus a unitary test.

This fix addresses at least the following tickets: #301, #511, #555.