### PR TITLE
support named parameters

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -347,6 +347,14 @@ public class ExpressionVisitorAdapter implements ExpressionVisitor, ItemsListVis
     }
 
     @Override
+    public void visit(NamedExpressionList namedExpressionList) {
+        for (Expression expr : namedExpressionList.getExpressions()) {
+            expr.accept(this);
+        }
+    }
+
+
+    @Override
     public void visit(MultiExpressionList multiExprList) {
         for (ExpressionList list : multiExprList.getExprList()) {
             visit(list);

--- a/src/main/java/net/sf/jsqlparser/expression/Function.java
+++ b/src/main/java/net/sf/jsqlparser/expression/Function.java
@@ -22,6 +22,7 @@
 package net.sf.jsqlparser.expression;
 
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.expression.operators.relational.NamedExpressionList;
 import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
 /**
@@ -31,6 +32,7 @@ public class Function extends ASTNodeAccessImpl implements Expression {
 
     private String name;
     private ExpressionList parameters;
+    private NamedExpressionList namedParameters;
     private boolean allColumns = false;
     private boolean distinct = false;
     private boolean isEscaped = false;
@@ -96,6 +98,20 @@ public class Function extends ASTNodeAccessImpl implements Expression {
     }
 
     /**
+     * the parameters might be named parameters, e.g. substring('foobar' from 2 for 3)
+     *
+     * @return the list of named parameters of the function (if any, else null)
+     */
+
+    public NamedExpressionList getNamedParameters() {
+        return namedParameters;
+    }
+
+    public void setNamedParameters(NamedExpressionList list) {
+        namedParameters = list;
+    }
+
+    /**
      * Return true if it's in the form "{fn function_body() }"
      *
      * @return true if it's java-escaped
@@ -128,12 +144,16 @@ public class Function extends ASTNodeAccessImpl implements Expression {
     public String toString() {
         String params;
 
-        if (parameters != null) {
-            params = parameters.toString();
-            if (isDistinct()) {
-                params = params.replaceFirst("\\(", "(DISTINCT ");
-            } else if (isAllColumns()) {
-                params = params.replaceFirst("\\(", "(ALL ");
+        if (parameters != null || namedParameters != null) {
+            if(parameters != null){
+                params = parameters.toString();
+                if (isDistinct()) {
+                    params = params.replaceFirst("\\(", "(DISTINCT ");
+                } else if (isAllColumns()) {
+                    params = params.replaceFirst("\\(", "(ALL ");
+                }
+            } else{
+                params = namedParameters.toString();
             }
         } else if (isAllColumns()) {
             params = "(*)";

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/ItemsListVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/ItemsListVisitor.java
@@ -29,5 +29,7 @@ public interface ItemsListVisitor {
 
     void visit(ExpressionList expressionList);
 
+    void visit(NamedExpressionList namedExpressionList);
+
     void visit(MultiExpressionList multiExprList);
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/ItemsListVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/ItemsListVisitorAdapter.java
@@ -31,6 +31,11 @@ public class ItemsListVisitorAdapter implements ItemsListVisitor {
     }
 
     @Override
+    public void visit(NamedExpressionList namedExpressionList) {
+
+    }
+
+    @Override
     public void visit(ExpressionList expressionList) {
 
     }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/NamedExpressionList.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/NamedExpressionList.java
@@ -1,0 +1,91 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2013 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 2.1 of the 
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public 
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package net.sf.jsqlparser.expression.operators.relational;
+
+import java.util.Arrays;
+import java.util.List;
+
+import net.sf.jsqlparser.expression.Expression;
+
+/**
+ * A list of named expressions, as in 
+ * as in select substr('xyzzy' from 2 for 3)
+ */
+public class NamedExpressionList implements ItemsList {
+
+    private List<Expression> expressions;
+    private List<String> names;
+
+    public NamedExpressionList() {
+    }
+
+    public NamedExpressionList(List<Expression> expressions) {
+        this.expressions = expressions;
+    }
+    
+    public NamedExpressionList(Expression ... expressions) {
+        this.expressions = Arrays.asList(expressions);
+    }
+
+    public List<Expression> getExpressions() {
+        return expressions;
+    }
+
+    public List<String> getNames() {
+        return names;
+    }
+
+
+    public void setExpressions(List<Expression> list) {
+        expressions = list;
+    }
+
+    public void setNames(List<String> list) {
+        names = list;
+    }
+
+
+    @Override
+    public void accept(ItemsListVisitor itemsListVisitor) {
+        itemsListVisitor.visit(this);
+    }
+
+    @Override
+    public String toString() {
+
+        StringBuilder ret = new StringBuilder();
+        ret.append("(");
+        for(int i=0; i<expressions.size(); i++){
+            if(i>0){
+                ret.append(" ");
+            }
+            if(! names.get(i).equals("")){
+                ret.append(names.get(i)).append(" ").append(expressions.get(i));
+            }else{
+                ret.append(expressions.get(i));
+            }
+        }
+        ret.append(")");
+
+        return ret.toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -76,6 +76,7 @@ import net.sf.jsqlparser.expression.operators.relational.Between;
 import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
 import net.sf.jsqlparser.expression.operators.relational.ExistsExpression;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.expression.operators.relational.NamedExpressionList;
 import net.sf.jsqlparser.expression.operators.relational.GreaterThan;
 import net.sf.jsqlparser.expression.operators.relational.GreaterThanEquals;
 import net.sf.jsqlparser.expression.operators.relational.InExpression;
@@ -402,6 +403,13 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
     @Override
     public void visit(ExpressionList expressionList) {
         for (Expression expression : expressionList.getExpressions()) {
+            expression.accept(this);
+        }
+    }
+
+    @Override
+    public void visit(NamedExpressionList namedExpressionList) {
+        for (Expression expression : namedExpressionList.getExpressions()) {
             expression.accept(this);
         }
     }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/InsertDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/InsertDeParser.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.expression.operators.relational.NamedExpressionList;
 import net.sf.jsqlparser.expression.operators.relational.ItemsListVisitor;
 import net.sf.jsqlparser.expression.operators.relational.MultiExpressionList;
 import net.sf.jsqlparser.schema.Column;
@@ -172,6 +173,12 @@ public class InsertDeParser implements ItemsListVisitor {
             }
         }
         buffer.append(")");
+    }
+
+// not used in a top-level insert statement
+    @Override
+    public void visit(NamedExpressionList NamedExpressionList) {
+
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ReplaceDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ReplaceDeParser.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.expression.operators.relational.NamedExpressionList;
 import net.sf.jsqlparser.expression.operators.relational.ItemsListVisitor;
 import net.sf.jsqlparser.expression.operators.relational.MultiExpressionList;
 import net.sf.jsqlparser.schema.Column;
@@ -123,6 +124,11 @@ public class ReplaceDeParser implements ItemsListVisitor {
             }
         }
         buffer.append(")");
+    }
+
+// NamedExpressionList not use by top-level Replace
+    @Override
+    public void visit(NamedExpressionList namedExpressionList) {
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/deparser/UpsertDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/UpsertDeParser.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.expression.operators.relational.NamedExpressionList;
 import net.sf.jsqlparser.expression.operators.relational.ItemsListVisitor;
 import net.sf.jsqlparser.expression.operators.relational.MultiExpressionList;
 import net.sf.jsqlparser.schema.Column;
@@ -147,6 +148,11 @@ public class UpsertDeParser implements ItemsListVisitor {
             }
         }
         buffer.append(")");
+    }
+
+// not used by top-level upsert
+    @Override
+    public void visit(NamedExpressionList namedExpressionList) {
     }
 
     @Override

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -148,6 +148,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_BETWEEN:"BETWEEN">
 |   <K_BINARY: "BINARY">  
 |   <K_BIT:"BIT">
+|   <K_BOTH:"BOTH">
 |   <K_BY:"BY">
 |   <K_BYTE: "BYTE">
 |   <K_CALL : "CALL">
@@ -215,6 +216,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_KEY:"KEY">
 |   <K_LAST: "LAST">
 |   <K_LATERAL:"LATERAL">
+|   <K_LEADING:"LEADING">
 |   <K_LEFT:"LEFT">
 |   <K_LIKE:"LIKE">
 |   <K_LIMIT:"LIMIT">
@@ -244,6 +246,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_PARTITION:"PARTITION">
 |   <K_PERCENT:"PERCENT">
 |   <K_PIVOT:"PIVOT">
+|   <K_PLACING:"PLACING">
 |   <K_PRECEDING: "PRECEDING">
 |   <K_PRECISION : "PRECISION">
 |   <K_PRIMARY:"PRIMARY">
@@ -274,6 +277,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_TEMPORARY:"TEMPORARY">
 |   <K_TIME_KEY_EXPR : ( "CURRENT_TIMESTAMP" | "CURRENT_TIME" | "CURRENT_DATE" ) ( "()" )?>
 |   <K_TOP:"TOP">
+|   <K_TRAILING:"TRAILING">
 |   <K_TRUNCATE:"TRUNCATE">
 |   <K_UNBOUNDED: "UNBOUNDED"> 
 |   <K_UNION:"UNION">
@@ -1025,6 +1029,7 @@ String RelObjectNameWithoutValue() :
 	  | tk=<K_UNSIGNED>
       | tk=<K_TEMP> | tk=<K_TEMPORARY> | tk=<K_ISNULL> 
 	  | tk=<K_ZONE>
+/*      | tk=<K_PLACING> | tk=<K_BOTH> | tk=<K_LEADING> | tk=<K_TRAILING> */
       )
 
     { return tk.image; }
@@ -2312,6 +2317,73 @@ ExpressionList SimpleExpressionList():
     }
 }
 
+// trim( [leading|trailing|both] expr from expr)
+// The [leading|trailing|both] token has already been consumed
+NamedExpressionList NamedExpressionList1():
+{
+    NamedExpressionList retval = new NamedExpressionList();
+    List<Expression> expressions = new ArrayList<Expression>();
+    List<String> names = new ArrayList<String>();
+    Expression expr1 = null;
+    Expression expr2 = null;
+    Expression expr3 = null;
+    Expression expr4 = null;
+	String name = "";
+    Token tk1 = null;
+    Token tk2 = null;
+    Token tk3 = null;
+    Token tk4 = null;
+}
+{
+    ( 
+     expr1=SimpleExpression()  (tk2=<K_FROM>|tk2=<K_IN>|tk2=<K_PLACING>) expr2=SimpleExpression() { expressions.add(expr1); names.add(tk2.image); expressions.add(expr2);}
+    )
+
+    {
+        retval.setNames(names);
+        retval.setExpressions(expressions);
+        return retval;
+    }
+}
+
+// substring(expr1 from expr2)
+// substring(expr1 from expr2 for expr3)
+// trim(expr1 from expr2)
+// position(expr1 in expr2)
+// overlay(expr1 placing expr2 from expr3)
+// overlay(expr1 placing expr2 from expr3 for expr4)
+// expr1 has already been consumed
+NamedExpressionList NamedExpressionList2():
+{
+    NamedExpressionList retval = new NamedExpressionList();
+    List<Expression> expressions = new ArrayList<Expression>();
+    List<String> names = new ArrayList<String>();
+    Expression expr1 = null;
+    Expression expr2 = null;
+    Expression expr3 = null;
+    Expression expr4 = null;
+	String name = "";
+    Token tk1 = null;
+    Token tk2 = null;
+    Token tk3 = null;
+    Token tk4 = null;
+}
+{
+    ( 
+        expr2=SimpleExpression() { names.add(""); expressions.add(expr2);}
+     ( (tk3=<K_FOR>|tk3=<K_FROM>) expr3=SimpleExpression() {names.add(tk3.image); expressions.add(expr3);} 
+       ( (tk4=<K_FOR>) expr4=SimpleExpression() {names.add(tk4.image); expressions.add(expr4);} )?
+     )?
+    )
+
+    {
+        retval.setNames(names);
+        retval.setExpressions(expressions);
+        return retval;
+    }
+}
+
+
 ExpressionList SimpleExpressionListAtLeastTwoItems():
 {
     ExpressionList retval = new ExpressionList();
@@ -2922,9 +2994,14 @@ Function Function() #Function:
     Function retval = new Function();
     String funcName = null;
     String tmp = null;
+    List<Expression> expressions = new ArrayList<Expression>();
     ExpressionList expressionList = null;
+    NamedExpressionList namedExpressionList = null;
     KeepExpression keep = null;
     SubSelect expr = null;
+    Token tk1 = null;
+    Token tk2 = null;
+    Expression expr1 = null;
 }
 {
     ["{fn" { retval.setEscaped(true); } ]
@@ -2932,8 +3009,20 @@ Function Function() #Function:
     funcName=RelObjectNameExt()
 
     [ "." tmp=RelObjectNameExt() { funcName+= "." + tmp; } ["." tmp=RelObjectNameExt() { funcName+= "." + tmp; }]]
-    "(" [ [<K_DISTINCT> { retval.setDistinct(true); } | <K_ALL> { retval.setAllColumns(true); }] (LOOKAHEAD(3) expressionList=SimpleExpressionList() | "*" { retval.setAllColumns(true); }
-        | expr = SubSelect() { expr.setUseBrackets(false); expressionList = new ExpressionList(expr); } ) ] ")"
+    "(" [ [<K_DISTINCT> { retval.setDistinct(true); } | <K_ALL> { retval.setAllColumns(true); }]
+// The addition of functions with named parameters (see NamedExpressionList1, NamedExpressionList2) complicates
+// the parsing of the paramter lists.  JavaCC needs factorization here so that the tokens which indicate branch points
+// are exposed.
+        ( LOOKAHEAD(4)
+        ( (tk1=<K_BOTH>|tk1=<K_LEADING>|tk1=<K_TRAILING>) namedExpressionList=NamedExpressionList1() {namedExpressionList.getNames().add(0,tk1.image);})
+
+        | ( expr1=SimpleExpression() ( ((tk2=<K_FROM>|tk2=<K_IN>|tk2=<K_PLACING>) namedExpressionList=NamedExpressionList2() {namedExpressionList.getNames().set(0,tk2.image); namedExpressionList.getNames().add(0, ""); namedExpressionList.getExpressions().add(0, expr1);}) 
+          | ("," expressionList=SimpleExpressionList() {expressionList.getExpressions().add(0,expr1);}  )? ) )
+
+        | "*" { retval.setAllColumns(true); }
+        |  expr = SubSelect() { expr.setUseBrackets(false); expressionList = new ExpressionList(expr); } 
+        )
+        ] ")"
 
     [ "." tmp=RelObjectName() { retval.setAttribute(tmp); }]
 
@@ -2941,7 +3030,16 @@ Function Function() #Function:
 
     ["}"]
     {
+        if(expr1 != null && expressionList==null && namedExpressionList == null){
+// If the function has a single parameter, it is consumed before the choice point between
+// named vs. simple expression list.  Put it in a simple ExpressionList here.
+            expressions = new ArrayList<Expression>();
+            expressions.add(expr1);
+            expressionList = new ExpressionList();
+            expressionList.setExpressions(expressions);
+        }
         retval.setParameters(expressionList);
+        retval.setNamedParameters(namedExpressionList);
         retval.setName(funcName);
         retval.setKeep(keep);
         linkAST(retval,jjtThis);

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -975,6 +975,10 @@ public class SelectTest {
                 getName());
         assertStatementCanBeDeparsedAs(select, statement);
 
+        statement = "SELECT substring(id, 2, 3), substring(id from 2 for 3), substring(id from 2), trim(BOTH ' ' from 'foo bar '), trim(LEADING ' ' from 'foo bar '), trim(TRAILING ' ' from 'foo bar '), trim(' ' from 'foo bar '), position('foo' in 'bar'), overlay('foo' placing 'bar' from 1), overlay('foo' placing 'bar' from 1 for 2) FROM my table";
+        select = (Select) parserManager.parse(new StringReader(statement));
+        assertStatementCanBeDeparsedAs(select, statement);
+
         statement = "SELECT MAX(id), AVG(pro) AS myavg FROM mytable WHERE mytable.col = 9 GROUP BY pro";
         select = (Select) parserManager.parse(new StringReader(statement));
         plainSelect = (PlainSelect) select.getSelectBody();


### PR DESCRIPTION
Some standard SQL functions, especially string functions, use keywords to separate parameters.
I have encountered 
For example,
SELECT 
  substring(id, 2, 3),
  substring(id from 2 for 3),
  substring(id from 2),
  trim(BOTH ' ' from 'foo bar '),
  trim(LEADING ' ' from 'foo bar '),
  trim(TRAILING ' ' from 'foo bar '),
  trim(' ' from 'foo bar '),
  position('foo' in 'bar'),
  overlay('foo' placing 'bar' from 1),
  overlay('foo' placing 'bar' from 1 for 2)
FROM mytable

This pull request adds support for these functions.
I have added a test for these named parameters in SelectTest.java
The code passes all tests.