### PR TITLE
REPLACE VIEW as a synonym to ALTER VIEW

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/create/view/AlterView.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/view/AlterView.java
@@ -35,6 +35,7 @@ public class AlterView implements Statement {
 
     private Table view;
     private SelectBody selectBody;
+    private boolean useReplace = false;
     private List<String> columnNames = null;
 
     @Override
@@ -74,9 +75,23 @@ public class AlterView implements Statement {
         this.columnNames = columnNames;
     }
 
+    public boolean isUseReplace() {
+        return useReplace;
+    }
+
+    public void setUseReplace(boolean useReplace) {
+        this.useReplace = useReplace;
+    }
+
+
     @Override
     public String toString() {
-        StringBuilder sql = new StringBuilder("ALTER ");
+        StringBuilder sql;
+        if(useReplace){
+            sql = new StringBuilder("REPLACE ");
+        }else{
+            sql = new StringBuilder("ALTER ");
+        }
         sql.append("VIEW ");
         sql.append(view);
         if (columnNames != null) {

--- a/src/main/java/net/sf/jsqlparser/util/deparser/AlterViewDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/AlterViewDeParser.java
@@ -52,7 +52,11 @@ public class AlterViewDeParser {
     }
 
     public void deParse(AlterView alterView) {
-        buffer.append("ALTER ");
+        if(alterView.isUseReplace()){
+            buffer.append("REPLACE ");
+        }else{
+            buffer.append("ALTER ");
+        }
         buffer.append("VIEW ").append(alterView.getView().getFullyQualifiedName());
         if (alterView.getColumnNames() != null) {
             buffer.append(PlainSelect.getStringList(alterView.getColumnNames(), true, true));

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -396,6 +396,7 @@ Statement SingleStatement() :
         |
         stm = Delete()
         |
+		LOOKAHEAD(2)
         stm = Replace()
         |
         LOOKAHEAD(2)
@@ -618,7 +619,7 @@ Replace Replace():
     Expression exp = null;
 }
 {
-    <K_REPLACE> [<K_INTO> { replace.setUseIntoTables(true); }] table=Table()
+    ( <K_REPLACE> [LOOKAHEAD(2) <K_INTO> { replace.setUseIntoTables(true); }] table=Table() )
 
     (
         (
@@ -3445,7 +3446,7 @@ AlterView AlterView():
     List<String> columnNames = null;
 }
 {
-    <K_ALTER>
+    ( (<K_ALTER> ) | (<K_REPLACE> {alterView.setUseReplace(true);}) )
     <K_VIEW> view=Table() { alterView.setView(view); }
     [ columnNames = ColumnsNamesList() { alterView.setColumnNames(columnNames); } ]
     <K_AS>

--- a/src/test/java/net/sf/jsqlparser/statement/create/AlterViewTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/AlterViewTest.java
@@ -11,4 +11,10 @@ public class AlterViewTest {
         String stmt = "ALTER VIEW myview AS SELECT * FROM mytab";
         assertSqlCanBeParsedAndDeparsed(stmt);
     }
+
+    @Test
+    public void testReplaceView() throws JSQLParserException {
+        String stmt = "REPLACE VIEW myview AS SELECT * FROM mytab";
+        assertSqlCanBeParsedAndDeparsed(stmt);
+    }
 }


### PR DESCRIPTION
Teradata uses REPLACE VIEW instead of ALTER VIEW