### PR TITLE
Add support for truncate table

### DIFF
--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -706,7 +706,7 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
 
     @Override
     public void visit(Truncate truncate) {
-        throw new UnsupportedOperationException(NOT_SUPPORTED_YET);
+        visit(truncate.getTable());
     }
 
     @Override

--- a/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
@@ -198,6 +198,14 @@ public class TablesNamesFinderTest {
     }
 
     @Test
+    public void testGetTableListFromTruncate() throws Exception {
+        String sql = "TRUNCATE TABLE MY_TABLE1";
+        List<String> tables = new TablesNamesFinder().getTableList(pm.parse(new StringReader(sql)));
+        assertEquals(1, tables.size());
+        assertTrue(tables.contains("MY_TABLE1"));
+    }
+
+    @Test
     public void testGetTableListFromDeleteWithJoin() throws Exception {
         String sql = "DELETE t1, t2 FROM MY_TABLE1 t1 JOIN MY_TABLE2 t2 ON t1.id = t2.id";
         net.sf.jsqlparser.statement.Statement statement = pm.parse(new StringReader(sql));


### PR DESCRIPTION
Hello @JSQLParser team!

At the very beginning I would like to thank you for supporting this awesome framework! I spent hours to compile ANTLR grammars for MySQL to finally drop it because it was unable to do what I needed. The JSqlParser, from the other hand, did a job marvellously!

This pull request is to fix small problem I found when working with `TablesNamesFinder`.