### PR TITLE
Support KSQL's WITHIN

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -233,8 +233,8 @@ public class Join extends ASTNodeAccessImpl {
                 type += "SEMI ";
             }
 
-            return type + "JOIN " + rightItem + ((onExpression != null) ? " ON " + onExpression + "" : "")
-                    + ((joinWindow != null) ? " WITHIN " + joinWindow : "")
+            return type + "JOIN " + rightItem + ((joinWindow != null) ? " WITHIN " + joinWindow : "")
+                    + ((onExpression != null) ? " ON " + onExpression + "" : "")
                     + PlainSelect.getFormatedList(usingColumns, "USING", true, true);
         }
 

--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -44,6 +44,7 @@ public class Join extends ASTNodeAccessImpl {
     private FromItem rightItem;
     private Expression onExpression;
     private List<Column> usingColumns;
+    private KSQLJoinWindow joinWindow;
 
     /**
      * Whether is a tab1,tab2 join
@@ -190,6 +191,21 @@ public class Join extends ASTNodeAccessImpl {
         usingColumns = list;
     }
 
+
+    public boolean isWindowJoin() {
+        return joinWindow != null;
+    }
+    /**
+     * Return the "WITHIN" join window (if any)
+     */
+    public KSQLJoinWindow getJoinWindow() {
+        return joinWindow;
+    }
+
+    public void setJoinWindow(KSQLJoinWindow joinWindow) {
+        this.joinWindow = joinWindow;
+    }
+
     @Override
     public String toString() {
         if (isSimple()) {
@@ -218,6 +234,7 @@ public class Join extends ASTNodeAccessImpl {
             }
 
             return type + "JOIN " + rightItem + ((onExpression != null) ? " ON " + onExpression + "" : "")
+                    + ((joinWindow != null) ? " WITHIN " + joinWindow : "")
                     + PlainSelect.getFormatedList(usingColumns, "USING", true, true);
         }
 

--- a/src/main/java/net/sf/jsqlparser/statement/select/KSQLJoinWindow.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/KSQLJoinWindow.java
@@ -25,10 +25,46 @@ import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
 public class KSQLJoinWindow extends ASTNodeAccessImpl {
 
+    public enum TimeUnit {
+        DAY ("DAY"),
+        HOUR ("HOUR"),
+        MINUTE ("MINUTE"),
+        SECOND ("SECOND"),
+        MILLISECOND ("MILLISECOND"),
+        DAYS ("DAYS"),
+        HOURS ("HOURS"),
+        MINUTES ("MINUTES"),
+        SECONDS ("SECONDS"),
+        MILLISECONDS ("MILLISECONDS");
+
+        private String timeUnit;
+
+        TimeUnit(String timeUnit) {
+            this.timeUnit = timeUnit;
+        }
+
+        public String getTimeUnit() {
+            return timeUnit;
+        }
+    }
+
+    private boolean beforeAfter;
     private long duration;
-    private String timeUnit;
+    private TimeUnit timeUnit;
+    private long beforeDuration;
+    private TimeUnit beforeTimeUnit;
+    private long afterDuration;
+    private TimeUnit afterTimeUnit;
 
     public KSQLJoinWindow() {
+    }
+
+    public boolean isBeforeAfterWindow() {
+        return beforeAfter;
+    }
+
+    public void setBeforeAfterWindow(boolean beforeAfter) {
+        this.beforeAfter = beforeAfter;
     }
 
     public long getDuration() {
@@ -39,16 +75,51 @@ public class KSQLJoinWindow extends ASTNodeAccessImpl {
         this.duration = duration;
     }
 
-    public String getTimeUnit() {
+    public TimeUnit getTimeUnit() {
         return timeUnit;
     }
 
-    public void setTimeUnit(String timeUnit) {
+    public void setTimeUnit(TimeUnit timeUnit) {
         this.timeUnit = timeUnit;
+    }
+
+    public long getBeforeDuration() {
+        return beforeDuration;
+    }
+
+    public void setBeforeDuration(long beforeDuration) {
+        this.beforeDuration = beforeDuration;
+    }
+
+    public TimeUnit getBeforeTimeUnit() {
+        return beforeTimeUnit;
+    }
+
+    public void setBeforeTimeUnit(TimeUnit beforeTimeUnit) {
+        this.beforeTimeUnit = beforeTimeUnit;
+    }
+
+    public long getAfterDuration() {
+        return afterDuration;
+    }
+
+    public void setAfterDuration(long afterDuration) {
+        this.afterDuration = afterDuration;
+    }
+
+    public TimeUnit getAfterTimeUnit() {
+        return afterTimeUnit;
+    }
+
+    public void setAfterTimeUnit(TimeUnit afterTimeUnit) {
+        this.afterTimeUnit = afterTimeUnit;
     }
 
     @Override
     public String toString() {
+        if (isBeforeAfterWindow()) {
+            return "(" + beforeDuration + " " + beforeTimeUnit + ", " + afterDuration + " " + afterTimeUnit + ")";
+        }
         return "(" + duration + " " + timeUnit + ")";
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/select/KSQLJoinWindow.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/KSQLJoinWindow.java
@@ -1,0 +1,54 @@
+/*
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2018 JSQLParser
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * #L%
+ */
+package net.sf.jsqlparser.statement.select;
+
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
+public class KSQLJoinWindow extends ASTNodeAccessImpl {
+
+    private long duration;
+    private String timeUnit;
+
+    public KSQLJoinWindow() {
+    }
+
+    public long getDuration() {
+        return duration;
+    }
+
+    public void setDuration(long duration) {
+        this.duration = duration;
+    }
+
+    public String getTimeUnit() {
+        return timeUnit;
+    }
+
+    public void setTimeUnit(String timeUnit) {
+        this.timeUnit = timeUnit;
+    }
+
+    @Override
+    public String toString() {
+        return "(" + duration + " " + timeUnit + ")";
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -27,6 +27,9 @@ import net.sf.jsqlparser.schema.*;
 import net.sf.jsqlparser.statement.select.*;
 import net.sf.jsqlparser.statement.values.ValuesStatement;
 
+import java.util.Iterator;
+import java.util.List;
+
 /**
  * A class to de-parse (that is, tranform from JSqlParser hierarchy into a string) a
  * {@link net.sf.jsqlparser.statement.select.Select}
@@ -378,6 +381,13 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
         if (join.getOnExpression() != null) {
             buffer.append(" ON ");
             join.getOnExpression().accept(expressionVisitor);
+        }
+        if (join.isWindowJoin()) {
+            buffer.append(" WITHIN (");
+            buffer.append(join.getJoinWindow().getDuration());
+            buffer.append(" ");
+            buffer.append(join.getJoinWindow().getTimeUnit());
+            buffer.append(")");
         }
         if (join.getUsingColumns() != null) {
             buffer.append(" USING (");

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -378,13 +378,13 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
 
         FromItem fromItem = join.getRightItem();
         fromItem.accept(this);
-        if (join.getOnExpression() != null) {
-            buffer.append(" ON ");
-            join.getOnExpression().accept(expressionVisitor);
-        }
         if (join.isWindowJoin()) {
             buffer.append(" WITHIN ");
             buffer.append(join.getJoinWindow().toString());
+        }
+        if (join.getOnExpression() != null) {
+            buffer.append(" ON ");
+            join.getOnExpression().accept(expressionVisitor);
         }
         if (join.getUsingColumns() != null) {
             buffer.append(" USING (");

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -383,11 +383,8 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
             join.getOnExpression().accept(expressionVisitor);
         }
         if (join.isWindowJoin()) {
-            buffer.append(" WITHIN (");
-            buffer.append(join.getJoinWindow().getDuration());
-            buffer.append(" ");
-            buffer.append(join.getJoinWindow().getTimeUnit());
-            buffer.append(")");
+            buffer.append(" WITHIN ");
+            buffer.append(join.getJoinWindow().toString());
         }
         if (join.getUsingColumns() != null) {
             buffer.append(" USING (");

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1705,6 +1705,7 @@ Join JoinerExpression() #JoinerExpression:
     Expression onExpression = null;
     Column tableColumn;
     List<Column> columns = null;
+    KSQLJoinWindow joinWindow = null;
 }
 {
     [
@@ -1723,7 +1724,7 @@ Join JoinerExpression() #JoinerExpression:
 
 
     [ 
-    LOOKAHEAD(2) (( <K_ON> onExpression=Expression()  { join.setOnExpression(onExpression); } )
+    LOOKAHEAD(2) (( <K_ON> onExpression=Expression()  { join.setOnExpression(onExpression); } [ <K_WITHIN> "(" joinWindow = JoinWindow() ")" {join.setJoinWindow(joinWindow);}])
         |
         ( <K_USING> "(" tableColumn=Column() { columns = new ArrayList(); columns.add(tableColumn); }
                 ("," tableColumn=Column() { columns.add(tableColumn); } )* ")"
@@ -1734,6 +1735,22 @@ Join JoinerExpression() #JoinerExpression:
       join.setRightItem(right);
     return join; 
   }
+
+}
+
+KSQLJoinWindow JoinWindow():
+{
+    KSQLJoinWindow retval = new KSQLJoinWindow();
+    Token durationToken;
+    Token timeUnitToken;
+}
+{
+    durationToken=<S_LONG> timeUnitToken=<S_IDENTIFIER>
+ {
+    retval.setDuration(Long.parseLong(durationToken.image));
+    retval.setTimeUnit(timeUnitToken.image);
+    return retval;
+ }
 }
 
 Expression WhereClause():

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1724,7 +1724,8 @@ Join JoinerExpression() #JoinerExpression:
 
 
     [ 
-    LOOKAHEAD(2) (( <K_ON> onExpression=Expression()  { join.setOnExpression(onExpression); } [ <K_WITHIN> "(" joinWindow = JoinWindow() ")" {join.setJoinWindow(joinWindow);}])
+    LOOKAHEAD(2) (( <K_ON> onExpression=Expression()  { join.setOnExpression(onExpression); }
+                    [ <K_WITHIN> "(" joinWindow = JoinWindow() ")" {join.setJoinWindow(joinWindow);}])
         |
         ( <K_USING> "(" tableColumn=Column() { columns = new ArrayList(); columns.add(tableColumn); }
                 ("," tableColumn=Column() { columns.add(tableColumn); } )* ")"
@@ -1741,16 +1742,29 @@ Join JoinerExpression() #JoinerExpression:
 KSQLJoinWindow JoinWindow():
 {
     KSQLJoinWindow retval = new KSQLJoinWindow();
-    Token durationToken;
-    Token timeUnitToken;
+    boolean beforeAfter;
+    Token beforeDurationToken = null;
+    Token beforeTimeUnitToken = null;
+    Token afterDurationToken = null;
+    Token afterTimeUnitToken = null;
 }
 {
-    durationToken=<S_LONG> timeUnitToken=<S_IDENTIFIER>
- {
-    retval.setDuration(Long.parseLong(durationToken.image));
-    retval.setTimeUnit(timeUnitToken.image);
-    return retval;
- }
+    (beforeDurationToken=<S_LONG> beforeTimeUnitToken=<S_IDENTIFIER>
+        [ "," afterDurationToken=<S_LONG> afterTimeUnitToken=<S_IDENTIFIER> ]
+    {
+        if (afterDurationToken == null) {
+            retval.setDuration(Long.parseLong(beforeDurationToken.image));
+            retval.setTimeUnit(KSQLJoinWindow.TimeUnit.valueOf(beforeTimeUnitToken.image));
+            retval.setBeforeAfterWindow(false);
+            return retval;
+        }
+        retval.setBeforeDuration(Long.parseLong(beforeDurationToken.image));
+        retval.setBeforeTimeUnit(KSQLJoinWindow.TimeUnit.valueOf(beforeTimeUnitToken.image));
+        retval.setAfterDuration(Long.parseLong(afterDurationToken.image));
+        retval.setAfterTimeUnit(KSQLJoinWindow.TimeUnit.valueOf(afterTimeUnitToken.image));
+        retval.setBeforeAfterWindow(true);
+        return retval;
+    })
 }
 
 Expression WhereClause():

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1724,8 +1724,8 @@ Join JoinerExpression() #JoinerExpression:
 
 
     [ 
-    LOOKAHEAD(2) (( <K_ON> onExpression=Expression()  { join.setOnExpression(onExpression); }
-                    [ <K_WITHIN> "(" joinWindow = JoinWindow() ")" {join.setJoinWindow(joinWindow);}])
+    LOOKAHEAD(2) ([ <K_WITHIN> "(" joinWindow = JoinWindow() ")" {join.setJoinWindow(joinWindow);}]
+                    ( <K_ON> onExpression=Expression()  { join.setOnExpression(onExpression); })
         |
         ( <K_USING> "(" tableColumn=Column() { columns = new ArrayList(); columns.add(tableColumn); }
                 ("," tableColumn=Column() { columns.add(tableColumn); } )* ")"

--- a/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
@@ -21,8 +21,8 @@ public class KSQLTest {
         sql = "SELECT *\n"
                 + "FROM table1 t1\n"
                 + "INNER JOIN table2 t2\n"
-                + "ON t1.id = t2.id\n"
-                + "WITHIN (5 HOURS)\n";
+                + "WITHIN (5 HOURS)\n"
+                + "ON t1.id = t2.id\n";
 
         statement = CCJSqlParserUtil.parse(sql);
 
@@ -49,8 +49,8 @@ public class KSQLTest {
         sql = "SELECT *\n"
                 + "FROM table1 t1\n"
                 + "INNER JOIN table2 t2\n"
-                + "ON t1.id = t2.id\n"
-                + "WITHIN (2 MINUTES, 5 MINUTES)\n";
+                + "WITHIN (2 MINUTES, 5 MINUTES)\n"
+                + "ON t1.id = t2.id\n";
 
         statement = CCJSqlParserUtil.parse(sql);
 

--- a/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
@@ -21,7 +21,7 @@ public class KSQLTest {
                 + "FROM table1 t1\n"
                 + "INNER JOIN table2 t2\n"
                 + "ON t1.id = t2.id\n"
-                + "WITHIN (1 HOURS)\n";
+                + "WITHIN (5 HOURS)\n";
 
         statement = CCJSqlParserUtil.parse(sql);
 
@@ -33,6 +33,8 @@ public class KSQLTest {
         assertEquals("table2", ((Table) plainSelect.getJoins().get(0).getRightItem()).
                 getFullyQualifiedName());
         assertTrue(plainSelect.getJoins().get(0).isWindowJoin());
+        assertEquals(5L, plainSelect.getJoins().get(0).getJoinWindow().getDuration());
+        assertEquals("HOURS", plainSelect.getJoins().get(0).getJoinWindow().getTimeUnit());
         assertStatementCanBeDeparsedAs(select, sql, true);
 
         assertSqlCanBeParsedAndDeparsed(sql, true);

--- a/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
@@ -1,0 +1,42 @@
+package net.sf.jsqlparser.statement.select;
+
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.Statement;
+import org.junit.Test;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static net.sf.jsqlparser.test.TestUtils.assertStatementCanBeDeparsedAs;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class KSQLTest {
+
+    @Test
+    public void testKSQLWindowedJoin() throws Exception {
+        String sql;
+        Statement statement;
+
+        sql = "SELECT *\n"
+                + "FROM table1 t1\n"
+                + "INNER JOIN table2 t2\n"
+                + "ON t1.id = t2.id\n"
+                + "WITHIN (1 HOURS)\n";
+
+        statement = CCJSqlParserUtil.parse(sql);
+
+        System.out.println(statement.toString());
+
+        Select select = (Select) statement;
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertEquals(1, plainSelect.getJoins().size());
+        assertEquals("table2", ((Table) plainSelect.getJoins().get(0).getRightItem()).
+                getFullyQualifiedName());
+        assertTrue(plainSelect.getJoins().get(0).isWindowJoin());
+
+        System.out.println("Danger zone");
+        assertStatementCanBeDeparsedAs(select, sql, true);
+
+        assertSqlCanBeParsedAndDeparsed(sql, true);
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
 import static net.sf.jsqlparser.test.TestUtils.assertStatementCanBeDeparsedAs;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class KSQLTest {
@@ -34,7 +35,38 @@ public class KSQLTest {
                 getFullyQualifiedName());
         assertTrue(plainSelect.getJoins().get(0).isWindowJoin());
         assertEquals(5L, plainSelect.getJoins().get(0).getJoinWindow().getDuration());
-        assertEquals("HOURS", plainSelect.getJoins().get(0).getJoinWindow().getTimeUnit());
+        assertEquals("HOURS", plainSelect.getJoins().get(0).getJoinWindow().getTimeUnit().toString());
+        assertFalse(plainSelect.getJoins().get(0).getJoinWindow().isBeforeAfterWindow());
+        assertStatementCanBeDeparsedAs(select, sql, true);
+
+        assertSqlCanBeParsedAndDeparsed(sql, true);
+    }
+
+    @Test
+    public void testKSQLBeforeAfterWindowedJoin() throws Exception {
+        String sql;
+        Statement statement;
+        sql = "SELECT *\n"
+                + "FROM table1 t1\n"
+                + "INNER JOIN table2 t2\n"
+                + "ON t1.id = t2.id\n"
+                + "WITHIN (2 MINUTES, 5 MINUTES)\n";
+
+        statement = CCJSqlParserUtil.parse(sql);
+
+        System.out.println(statement.toString());
+
+        Select select = (Select) statement;
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertEquals(1, plainSelect.getJoins().size());
+        assertEquals("table2", ((Table) plainSelect.getJoins().get(0).getRightItem()).
+                getFullyQualifiedName());
+        assertTrue(plainSelect.getJoins().get(0).isWindowJoin());
+        assertEquals(2L, plainSelect.getJoins().get(0).getJoinWindow().getBeforeDuration());
+        assertEquals("MINUTES", plainSelect.getJoins().get(0).getJoinWindow().getBeforeTimeUnit().toString());
+        assertEquals(5L, plainSelect.getJoins().get(0).getJoinWindow().getAfterDuration());
+        assertEquals("MINUTES", plainSelect.getJoins().get(0).getJoinWindow().getAfterTimeUnit().toString());
+        assertTrue(plainSelect.getJoins().get(0).getJoinWindow().isBeforeAfterWindow());
         assertStatementCanBeDeparsedAs(select, sql, true);
 
         assertSqlCanBeParsedAndDeparsed(sql, true);

--- a/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
@@ -33,8 +33,6 @@ public class KSQLTest {
         assertEquals("table2", ((Table) plainSelect.getJoins().get(0).getRightItem()).
                 getFullyQualifiedName());
         assertTrue(plainSelect.getJoins().get(0).isWindowJoin());
-
-        System.out.println("Danger zone");
         assertStatementCanBeDeparsedAs(select, sql, true);
 
         assertSqlCanBeParsedAndDeparsed(sql, true);

--- a/src/test/java/net/sf/jsqlparser/test/TestUtils.java
+++ b/src/test/java/net/sf/jsqlparser/test/TestUtils.java
@@ -70,13 +70,8 @@ public class TestUtils {
         assertEquals(buildSqlString(statement, laxDeparsingCheck),
                 buildSqlString(parsed.toString(), laxDeparsingCheck));
 
-        System.out.println("DeParser starting");
         StatementDeParser deParser = new StatementDeParser(new StringBuilder());
         parsed.accept(deParser);
-        System.out.println("DeParser statement: ");
-        System.out.println(buildSqlString(statement, laxDeparsingCheck));
-        System.out.println("DeParser buffer: ");
-        System.out.println(buildSqlString(deParser.getBuffer().toString(), laxDeparsingCheck));
         assertEquals(buildSqlString(statement, laxDeparsingCheck),
                 buildSqlString(deParser.getBuffer().toString(), laxDeparsingCheck));
     }

--- a/src/test/java/net/sf/jsqlparser/test/TestUtils.java
+++ b/src/test/java/net/sf/jsqlparser/test/TestUtils.java
@@ -70,8 +70,13 @@ public class TestUtils {
         assertEquals(buildSqlString(statement, laxDeparsingCheck),
                 buildSqlString(parsed.toString(), laxDeparsingCheck));
 
+        System.out.println("DeParser starting");
         StatementDeParser deParser = new StatementDeParser(new StringBuilder());
         parsed.accept(deParser);
+        System.out.println("DeParser statement: ");
+        System.out.println(buildSqlString(statement, laxDeparsingCheck));
+        System.out.println("DeParser buffer: ");
+        System.out.println(buildSqlString(deParser.getBuffer().toString(), laxDeparsingCheck));
         assertEquals(buildSqlString(statement, laxDeparsingCheck),
                 buildSqlString(deParser.getBuffer().toString(), laxDeparsingCheck));
     }


### PR DESCRIPTION
[KSQL](https://github.com/confluentinc/ksql) supports the 'WITHIN' keyword for stream-stream joins. The syntax is as follows:

```
WITHIN [(before TIMEUNIT, after TIMEUNIT) | N TIMEUNIT]
```

See the [syntax reference](https://docs.confluent.io/current/ksql/docs/developer-guide/syntax-reference.html#create-stream-as-select)

This PR adds support for the WITHIN statement inside a join.