### PR TITLE
Add support for casting to signed integer

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -295,6 +295,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_SQL_CALC_FOUND_ROWS: "SQL_CALC_FOUND_ROWS">
 |   <K_SQL_NO_CACHE: "SQL_NO_CACHE">
 |   <K_USING:"USING">
+|   <K_SIGNED:"SIGNED">
 |   <K_UNSIGNED:"UNSIGNED">
 |   <K_VALIDATE : "VALIDATE">
 |   <K_VALUE:"VALUE">
@@ -3445,6 +3446,7 @@ ColDataType ColDataType():
 		| ( tk=<S_IDENTIFIER> | tk=<K_DATETIMELITERAL> | tk=<K_XML> | tk=<K_INTERVAL> | tk=<DT_ZONE> | tk=<K_CHAR> )  
 				{ colDataType.setDataType(tk.image); }
 		| tk=<K_UNSIGNED> tk2=<S_IDENTIFIER> {colDataType.setDataType(tk.image + " " + tk2.image);}
+		| tk=<K_SIGNED> tk2=<S_IDENTIFIER> {colDataType.setDataType(tk.image + " " + tk2.image);}
 	)
 
     [LOOKAHEAD(2) "(" {tk2 =null;} ( (tk=<S_LONG> [ tk2=<K_BYTE> | tk2=<K_CHAR> ] | tk=<S_CHAR_LITERAL> | tk=<S_IDENTIFIER> ) 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -2799,6 +2799,11 @@ public class SelectTest {
     }
 
     @Test
+    public void testCastToSignedInteger() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT CAST(contact_id AS SIGNED INTEGER) FROM contact WHERE contact_id = 20");
+    }
+
+    @Test
     public void testWhereIssue240_notBoolean() {
         try {
             CCJSqlParserUtil.parse("SELECT count(*) FROM mytable WHERE 5");


### PR DESCRIPTION
Example:
SELECT CAST(contact_id AS SIGNED INTEGER) FROM contact WHERE contact_id = 20;

Casting to a SIGNED INTEGER isn't supported while casting to other types like UNSIGNED INTEGER is supported. Now allowing SIGNED INTEGER in a CAST operation as well.