### PR TITLE
- added support for simple informix outer joins

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -208,7 +208,9 @@ public class Join extends ASTNodeAccessImpl {
 
     @Override
     public String toString() {
-        if (isSimple()) {
+        if (isSimple() && isOuter()) {
+            return "OUTER " + rightItem;
+        } else if (isSimple()) {
             return "" + rightItem;
         } else {
             String type = "";

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1726,7 +1726,7 @@ Join JoinerExpression() #JoinerExpression:
         | <K_CROSS> { join.setCross(true); } 
     ]
 
-          ( <K_JOIN> | "," { join.setSimple(true); } ) 
+          ( <K_JOIN> | "," { join.setSimple(true); } (<K_OUTER> { join.setOuter(true); } )? ) 
 
         right=FromItem()
 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -963,7 +963,9 @@ public class SelectTest {
         statement = "SELECT * FROM foo AS f LEFT OUTER JOIN (bar AS b RIGHT OUTER JOIN baz AS z ON f.id = z.id) ON f.id = b.id";
         select = (Select) parserManager.parse(new StringReader(statement));
         assertStatementCanBeDeparsedAs(select, statement);
-
+        statement = "SELECT * FROM foo AS f, OUTER bar AS b WHERE f.id = b.id";
+        select = (Select) parserManager.parse(new StringReader(statement));
+        assertStatementCanBeDeparsedAs(select, statement);
     }
 
     @Test


### PR DESCRIPTION
This pull request adds support for simple informix outerjoins.
- e.g. SELECT * FROM foo AS f, OUTER bar AS b WHERE f.id = b.id

See also https://www.ibm.com/support/knowledgecenter/en/SSGU8G_12.1.0/com.ibm.sqlt.doc/ids_sqt_168.htm
