### PR TITLE
added support for simple informix outer joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Also I would like to know about needed examples or documentation stuff.
 
 ## Extensions in the latest SNAPSHOT version 2.0
 
+* allowed conditions within **then** and **else** of a **case** statement
+    * **SELECT * FROM mytable WHERE CASE WHEN a = 1 THEN b IN (1,2,3) ELSE c IN (1,2,3) END**
 * **change of parsing** for not within condition: outer not is represented now by NotExpression
 * support of named parameters for execute: **EXEC procedure @param = 'foo'**
 * support multivalue set statement

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Also I would like to know about needed examples or documentation stuff.
 
 ## Extensions in the latest SNAPSHOT version 2.0
 
+* support multivalue set statement
 * support of **describe**
 * support of **explain**
 * support of prefix **_utf8'strings'**

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Also I would like to know about needed examples or documentation stuff.
 
 ## Extensions in the latest SNAPSHOT version 2.0
 
+* support of named parameters for execute: **EXEC procedure @param = 'foo'**
 * support multivalue set statement
 * support of **describe**
 * support of **explain**

--- a/src/main/java/net/sf/jsqlparser/statement/SetStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/SetStatement.java
@@ -39,55 +39,84 @@
  */
 package net.sf.jsqlparser.statement;
 
+import java.util.ArrayList;
+import java.util.List;
 import net.sf.jsqlparser.expression.Expression;
 
 /**
  *
  * @author toben
  */
-public class SetStatement implements Statement {
+public final class SetStatement implements Statement {
 
-    private String name;
-    private Expression expression;
-    private boolean useEqual;
+    private final List<NameExpr> values = new ArrayList<>();
 
     public SetStatement(String name, Expression expression) {
-        this.name = name;
-        this.expression = expression;
+        add(name, expression, true);
+    }
+
+    public void add(String name, Expression expression, boolean useEqual) {
+        values.add(new NameExpr(name, expression, useEqual));
     }
 
     public boolean isUseEqual() {
-        return useEqual;
+        return values.get(0).useEqual;
     }
 
     public SetStatement setUseEqual(boolean useEqual) {
-        this.useEqual = useEqual;
+        values.get(0).useEqual = useEqual;
         return this;
     }
 
     public String getName() {
-        return name;
+        return values.get(0).name;
     }
 
     public void setName(String name) {
-        this.name = name;
+        values.get(0).name = name;
     }
 
     public Expression getExpression() {
-        return expression;
+        return values.get(0).expression;
     }
 
     public void setExpression(Expression expression) {
-        this.expression = expression;
+        values.get(0).expression = expression;
+    }
+
+    private String toString(NameExpr ne) {
+        return "SET " + ne.name + (ne.useEqual ? " = " : " ") + ne.expression.toString();
     }
 
     @Override
     public String toString() {
-        return "SET " + name + (useEqual ? " = " : " ") + expression.toString();
+        StringBuilder b = new StringBuilder("SET ");
+
+        for (NameExpr ne : values) {
+            if (b.length() != 4) {
+                b.append(", ");
+            }
+            b.append(toString(ne));
+        }
+
+        return b.toString();
     }
 
     @Override
     public void accept(StatementVisitor statementVisitor) {
         statementVisitor.visit(this);
+    }
+
+    static class NameExpr {
+
+        private String name;
+        private Expression expression;
+        private boolean useEqual;
+
+        public NameExpr(String name, Expression expr, boolean useEqual) {
+            this.name = name;
+            this.expression = expr;
+            this.useEqual = useEqual;
+        }
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/SetStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/SetStatement.java
@@ -2,7 +2,7 @@
  * #%L
  * JSQLParser library
  * %%
- * Copyright (C) 2004 - 2015 JSQLParser
+ * Copyright (C) 2004 - 2019 JSQLParser
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -18,24 +18,6 @@
  * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
- */
- /*
- * Copyright (C) 2015 JSQLParser.
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
- * MA 02110-1301  USA
  */
 package net.sf.jsqlparser.statement;
 
@@ -59,33 +41,65 @@ public final class SetStatement implements Statement {
         values.add(new NameExpr(name, expression, useEqual));
     }
 
-    public boolean isUseEqual() {
-        return values.get(0).useEqual;
+    public void remove(int idx) {
+        values.remove(idx);
     }
 
-    public SetStatement setUseEqual(boolean useEqual) {
-        values.get(0).useEqual = useEqual;
+    public int getCount() {
+        return values.size();
+    }
+
+    public boolean isUseEqual(int idx) {
+        return values.get(idx).useEqual;
+    }
+
+    public boolean isUseEqual() {
+        return isUseEqual(0);
+    }
+
+    public SetStatement setUseEqual(int idx, boolean useEqual) {
+        values.get(idx).useEqual = useEqual;
         return this;
     }
 
+    public SetStatement setUseEqual(boolean useEqual) {
+        return setUseEqual(0, useEqual);
+    }
+
     public String getName() {
-        return values.get(0).name;
+        return getName(0);
+    }
+
+    public String getName(int idx) {
+        return values.get(idx).name;
     }
 
     public void setName(String name) {
-        values.get(0).name = name;
+        setName(0, name);
+    }
+
+    public void setName(int idx, String name) {
+        values.get(idx).name = name;
+    }
+
+    public Expression getExpression(int idx) {
+        return values.get(idx).expression;
     }
 
     public Expression getExpression() {
-        return values.get(0).expression;
+        return getExpression(0);
+    }
+
+    public void setExpression(int idx, Expression expression) {
+        values.get(idx).expression = expression;
     }
 
     public void setExpression(Expression expression) {
-        values.get(0).expression = expression;
+        setExpression(0, expression);
     }
 
     private String toString(NameExpr ne) {
-        return "SET " + ne.name + (ne.useEqual ? " = " : " ") + ne.expression.toString();
+        return ne.name + (ne.useEqual ? " = " : " ") + ne.expression.toString();
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/statement/execute/Execute.java
+++ b/src/main/java/net/sf/jsqlparser/statement/execute/Execute.java
@@ -2,7 +2,7 @@
  * #%L
  * JSQLParser library
  * %%
- * Copyright (C) 2004 - 2014 JSQLParser
+ * Copyright (C) 2004 - 2019 JSQLParser
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as

--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -208,7 +208,9 @@ public class Join extends ASTNodeAccessImpl {
 
     @Override
     public String toString() {
-        if (isSimple()) {
+        if (isSimple() && isOuter()) {
+            return "OUTER " + rightItem;
+        } else if (isSimple()) {
             return "" + rightItem;
         } else {
             String type = "";

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -348,9 +348,11 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
     }
 
     public void deparseJoin(Join join) {
-        if (join.isSimple()) {
-            buffer.append(", ");
-        } else {
+            if (join.isSimple() && join.isOuter()) {
+               buffer.append(", OUTER ");
+            } else if (join.isSimple()) {
+               buffer.append(", ");
+            } else {
 
             if (join.isRight()) {
                 buffer.append(" RIGHT");

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SetStatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SetStatementDeParser.java
@@ -2,7 +2,7 @@
  * #%L
  * JSQLParser library
  * %%
- * Copyright (C) 2004 - 2015 JSQLParser
+ * Copyright (C) 2004 - 2019 JSQLParser
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as 
@@ -49,12 +49,20 @@ public class SetStatementDeParser {
     }
 
     public void deParse(SetStatement set) {
-        buffer.append("SET ").append(set.getName());
-        if (set.isUseEqual()) {
-            buffer.append(" =");
+        buffer.append("SET ");
+
+        for (int i = 0; i < set.getCount(); i++) {
+            if (i > 0) {
+                buffer.append(", ");
+            }
+            buffer.append(set.getName(i));
+            if (set.isUseEqual(i)) {
+                buffer.append(" =");
+            }
+            buffer.append(" ");
+            set.getExpression(i).accept(expressionVisitor);
         }
-        buffer.append(" ");
-        set.getExpression().accept(expressionVisitor);
+
     }
 
     public ExpressionVisitor getExpressionVisitor() {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1729,7 +1729,7 @@ Join JoinerExpression() #JoinerExpression:
         | <K_CROSS> { join.setCross(true); } 
     ]
 
-          ( <K_JOIN> | "," { join.setSimple(true); } ) 
+          ( <K_JOIN> | "," { join.setSimple(true); } (<K_OUTER> { join.setOuter(true); } )? ) 
 
         right=FromItem()
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2,7 +2,7 @@
  * #%L
  * JSQLParser library
  * %%
- * Copyright (C) 2004 - 2014 JSQLParser
+ * Copyright (C) 2004 - 2019 JSQLParser
  * %%
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -3039,10 +3039,25 @@ RowConstructor RowConstructor(): {
     }
 }
 
+EqualsTo VariableExpression(): {
+    Expression left;
+    Expression right;
+} {
+    left = UserVariable() "=" right = SimpleExpression()
+    {
+        EqualsTo equals = new EqualsTo();
+        equals.setLeftExpression(left);
+        equals.setRightExpression(right);
+        return equals;
+    }
+}
+
 Execute Execute(): {
     List<String> funcName;
     ExpressionList expressionList = null;
     Execute execute = new Execute();
+    List<Expression> namedExprList;
+    Expression expr;
 }
 {
     (<K_EXEC> { execute.setExecType(Execute.EXEC_TYPE.EXEC); } 
@@ -3052,6 +3067,10 @@ Execute Execute(): {
     funcName=RelObjectNameList() { execute.setName(funcName); }
 
     ( 
+        LOOKAHEAD(3) ( expr = VariableExpression() { namedExprList = new ArrayList<Expression>(); namedExprList.add( expr ); }
+                ( "," expr = VariableExpression() { namedExprList.add(expr); })* 
+                { expressionList = new ExpressionList(namedExprList); } )
+        |
         LOOKAHEAD(3) expressionList=SimpleExpressionList() 
         |
         ("(" expressionList=SimpleExpressionList() ")" { execute.setParenthesis(true); })

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -521,12 +521,15 @@ SetStatement Set(): {
     String name;
     Expression value;
     boolean useEqual = false;
+    SetStatement set;
 }
 {
     <K_SET> name = RelObjectNameExt() ["=" { useEqual=true; } ] value=SimpleExpression()
-    {
-        return new SetStatement(name,value).setUseEqual(useEqual);
-    }
+    { set = new SetStatement(name,value).setUseEqual(useEqual); }
+    ( { useEqual=false; } "," name = RelObjectNameExt() ["=" { useEqual=true; } ] value=SimpleExpression()
+        { set.add(name, value, useEqual); } )*
+
+    { return set; }
 }
 
 DescribeStatement Describe(): {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2243,7 +2243,7 @@ Expression SQLCondition():
     { return result; }
 }
 
-Expression InExpression() :
+Expression InExpression() #InExpression :
 {
     InExpression result = new InExpression();
     ItemsList leftItemsList = null;
@@ -2265,6 +2265,7 @@ Expression InExpression() :
     [<K_NOT> { result.setNot(true); } ] <K_IN> "(" (LOOKAHEAD(3) rightItemsList=SubSelect() | rightItemsList=SimpleExpressionList() ) ")"
     {
         result.setRightItemsList(rightItemsList);
+        linkAST(result,jjtThis);
         return result;
     }
 }
@@ -2349,7 +2350,7 @@ ExpressionList SQLExpressionList():
     }
 }
 
-ExpressionList SimpleExpressionList():
+ExpressionList SimpleExpressionList() #ExpressionList:
 {
     ExpressionList retval = new ExpressionList();
     List<Expression> expressions = new ArrayList<Expression>();

--- a/src/test/java/net/sf/jsqlparser/statement/SetStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/SetStatementTest.java
@@ -45,6 +45,6 @@ public class SetStatementTest {
 
     @Test
     public void testMultiValue() throws JSQLParserException {
-        assertSqlCanBeParsedAndDeparsed("SET v=1, c=3");
+        assertSqlCanBeParsedAndDeparsed("SET v = 1, c = 3");
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/SetStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/SetStatementTest.java
@@ -20,10 +20,6 @@ package net.sf.jsqlparser.statement;
 
 import net.sf.jsqlparser.JSQLParserException;
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -31,25 +27,6 @@ import org.junit.Test;
  * @author toben
  */
 public class SetStatementTest {
-
-    public SetStatementTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() {
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-    }
-
-    @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
-    }
 
     @Test
     public void testSimpleSet() throws JSQLParserException {
@@ -64,5 +41,10 @@ public class SetStatementTest {
     @Test
     public void testIssue373_2() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SET tester 5");
+    }
+
+    @Test
+    public void testMultiValue() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SET v=1, c=3");
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/execute/ExecuteTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/execute/ExecuteTest.java
@@ -80,4 +80,24 @@ public class ExecuteTest {
     public void testAcceptCallWithParenthesis() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("CALL myproc ('a', 2, 'b')");
     }
+
+    @Test
+    public void testAcceptExecNamesParameters() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("EXEC procedure @param");
+    }
+
+    @Test
+    public void testAcceptExecNamesParameters2() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("EXEC procedure @param = 1");
+    }
+
+    @Test
+    public void testAcceptExecNamesParameters3() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("EXEC procedure @param = 'foo'");
+    }
+
+    @Test
+    public void testAcceptExecNamesParameters4() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("EXEC procedure @param = 'foo', @param2 = 'foo2'");
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -963,7 +963,9 @@ public class SelectTest {
         statement = "SELECT * FROM foo AS f LEFT OUTER JOIN (bar AS b RIGHT OUTER JOIN baz AS z ON f.id = z.id) ON f.id = b.id";
         select = (Select) parserManager.parse(new StringReader(statement));
         assertStatementCanBeDeparsedAs(select, statement);
-
+        statement = "SELECT * FROM foo AS f, OUTER bar AS b WHERE f.id = b.id";
+        select = (Select) parserManager.parse(new StringReader(statement));
+        assertStatementCanBeDeparsedAs(select, statement);
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -966,6 +966,12 @@ public class SelectTest {
         statement = "SELECT * FROM foo AS f, OUTER bar AS b WHERE f.id = b.id";
         select = (Select) parserManager.parse(new StringReader(statement));
         assertStatementCanBeDeparsedAs(select, statement);
+        plainSelect = (PlainSelect) select.getSelectBody();
+        assertEquals(1, plainSelect.getJoins().size());
+        assertTrue(plainSelect.getJoins().get(0).isOuter());
+        assertTrue(plainSelect.getJoins().get(0).isSimple());
+        assertEquals("bar", ((Table) plainSelect.getJoins().get(0).getRightItem()).getFullyQualifiedName());
+        assertEquals("b", ((Table) plainSelect.getJoins().get(0).getRightItem()).getAlias().getName());
     }
 
     @Test


### PR DESCRIPTION
Support of simple outer joins.
See https://www.ibm.com/support/knowledgecenter/en/SSGU8G_12.1.0/com.ibm.sqlt.doc/ids_sqt_163.htm
This fixes partially #364
e.g.  SELECT DISTINCT t1.f1, t2.f2 FROM t1, OUTER t2 WHERE t1.f3=1 AND t1.f4=t2.f4
