### PR TITLE
Added support for 'ALTER TABLE CHANGE COLUMN'

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -37,7 +37,9 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
 public class AlterExpression {
 
     private AlterOperation operation;
+    private String optionalSpecifier;
     private String columnName;
+    private String columnOldName;
     //private ColDataType dataType;
 
     private List<ColumnDataType> colDataTypeList;
@@ -64,6 +66,14 @@ public class AlterExpression {
 
     public void setOperation(AlterOperation operation) {
         this.operation = operation;
+    }
+
+    public String getOptionalSpecifier() {
+        return optionalSpecifier;
+    }
+
+    public void setOptionalSpecifier(String optionalSpecifier) {
+        this.optionalSpecifier = optionalSpecifier;
     }
 
     public boolean isOnDeleteCascade() {
@@ -135,6 +145,14 @@ public class AlterExpression {
 
     public void setColumnName(String columnName) {
         this.columnName = columnName;
+    }
+
+    public String getColOldName() {
+        return columnOldName;
+    }
+
+    public void setColOldName(String columnOldName) {
+        this.columnOldName = columnOldName;
     }
 
     public String getConstraintName() {
@@ -214,7 +232,12 @@ public class AlterExpression {
         if (columnName != null) {
             b.append("COLUMN ").append(columnName);
         } else if (getColDataTypeList() != null) {
-            if (colDataTypeList.size() > 1) {
+            if(operation == AlterOperation.CHANGE) {
+                if(optionalSpecifier != null) {
+                    b.append(optionalSpecifier).append(" ");
+                }
+                b.append(columnOldName).append(" ");
+            } else if (colDataTypeList.size() > 1) {
                 b.append("(");
             } else {
                 b.append("COLUMN ");

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -158,6 +158,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_CASE:"CASE">
 |   <K_CAST:"CAST">
 |   <K_CHARACTER:"CHARACTER">
+|   <K_CHANGE:"CHANGE">
 |   <K_CHECK:"CHECK">
 |   <K_CHAR:"CHAR">
 |   <K_COLUMN:"COLUMN">
@@ -3862,6 +3863,22 @@ AlterExpression AlterExpression():
 			 )
         )
         )
+    )
+    |
+    (<K_CHANGE>
+      {
+        alterExp.setOperation(AlterOperation.CHANGE);
+      }
+      (
+        <K_COLUMN> { alterExp.setOptionalSpecifier("COLUMN"); } | {}
+      )
+      (
+        (tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER>)
+        alterExpressionColumnDataType = AlterExpressionColumnDataType() {
+            alterExp.setColOldName(tk.image);
+            alterExp.addColDataType(alterExpressionColumnDataType);
+        }
+      )
     )
     |
     (<K_DROP>

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -1,18 +1,18 @@
 package net.sf.jsqlparser.statement.alter;
 
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static net.sf.jsqlparser.test.TestUtils.assertStatementCanBeDeparsedAs;
+import static org.junit.Assert.*;
+
 import java.util.Arrays;
 import java.util.List;
+
+import org.junit.Test;
+
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.alter.AlterExpression.ColumnDataType;
-import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
-import static net.sf.jsqlparser.test.TestUtils.assertStatementCanBeDeparsedAs;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
 
 public class AlterTest {
 
@@ -260,6 +260,24 @@ public class AlterTest {
     public void testAlterTableAlterColumn() throws JSQLParserException {
       // http://www.postgresqltutorial.com/postgresql-change-column-type/
       assertSqlCanBeParsedAndDeparsed("ALTER TABLE table_name ALTER COLUMN column_name_1 TYPE TIMESTAMP, ALTER COLUMN column_name_2 TYPE BOOLEAN");
+    }
+
+    @Test
+    public void testAlterTableChangeColumn1() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE tb_test CHANGE COLUMN c1 c2 INT (10)");
+    }
+
+    @Test
+    public void testAlterTableChangeColumn2() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE tb_test CHANGE c1 c2 INT (10)");
+    }
+
+    @Test
+    public void testAlterTableChangeColumn3() throws JSQLParserException {
+        Statement stmt = CCJSqlParserUtil.parse("ALTER TABLE tb_test CHANGE c1 c2 INT (10)");
+        Alter alter = (Alter) stmt;
+        assertEquals(AlterOperation.CHANGE, alter.getAlterExpressions().get(0).getOperation());
+        assertEquals("c1", alter.getAlterExpressions().get(0).getColOldName());
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -264,20 +264,20 @@ public class AlterTest {
 
     @Test
     public void testAlterTableChangeColumn1() throws JSQLParserException {
-        assertSqlCanBeParsedAndDeparsed("ALTER TABLE tb_test CHANGE COLUMN c1 c2 INT (10)");
+        Statement stmt = CCJSqlParserUtil.parse("ALTER TABLE tb_test CHANGE COLUMN c1 c2 INT (10)");
+        Alter alter = (Alter) stmt;
+        assertEquals(AlterOperation.CHANGE, alter.getAlterExpressions().get(0).getOperation());
+        assertEquals("c1", alter.getAlterExpressions().get(0).getColOldName());
+        assertEquals("COLUMN", alter.getAlterExpressions().get(0).getOptionalSpecifier());
     }
 
     @Test
     public void testAlterTableChangeColumn2() throws JSQLParserException {
-        assertSqlCanBeParsedAndDeparsed("ALTER TABLE tb_test CHANGE c1 c2 INT (10)");
-    }
-
-    @Test
-    public void testAlterTableChangeColumn3() throws JSQLParserException {
         Statement stmt = CCJSqlParserUtil.parse("ALTER TABLE tb_test CHANGE c1 c2 INT (10)");
         Alter alter = (Alter) stmt;
         assertEquals(AlterOperation.CHANGE, alter.getAlterExpressions().get(0).getOperation());
         assertEquals("c1", alter.getAlterExpressions().get(0).getColOldName());
+        assertNull(alter.getAlterExpressions().get(0).getOptionalSpecifier());
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -281,6 +281,16 @@ public class AlterTest {
     }
 
     @Test
+    public void testAlterTableChangeColumn3() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE tb_test CHANGE COLUMN c1 c2 INT (10)");
+    }
+
+    @Test
+    public void testAlterTableChangeColumn4() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE tb_test CHANGE c1 c2 INT (10)");
+    }
+
+    @Test
     public void testAlterTableAddColumnWithZone() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE mytable ADD COLUMN col1 timestamp with time zone");
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE mytable ADD COLUMN col1 timestamp without time zone");

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -1,18 +1,18 @@
 package net.sf.jsqlparser.statement.alter;
 
-import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
-import static net.sf.jsqlparser.test.TestUtils.assertStatementCanBeDeparsedAs;
-import static org.junit.Assert.*;
-
 import java.util.Arrays;
 import java.util.List;
-
-import org.junit.Test;
-
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.alter.AlterExpression.ColumnDataType;
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static net.sf.jsqlparser.test.TestUtils.assertStatementCanBeDeparsedAs;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
 
 public class AlterTest {
 


### PR DESCRIPTION
Added support for 'ALTER TABLE CHANGE COLUMN oldName newName columnDefinition'. 
Please see https://dev.mysql.com/doc/refman/8.0/en/alter-table.html for reference.

I was not really sure how to modify the AlterStatement class. I found introducing these two new fields was the easiest solution, but I am open to suggestions should there be a better way of doing it.
Also, this is my first time writing anything in JavaCC, so if I've made some obvious mistakes or bad practises, I would gladly take feedback. 

This should fix #380 and parts of #571 