### PR TITLE
Added support for comment(s) for column definitions in CREATE TABLE s…

### DIFF
--- a/src/main/java/net/sf/jsqlparser/schema/Table.java
+++ b/src/main/java/net/sf/jsqlparser/schema/Table.java
@@ -51,19 +51,18 @@ public class Table extends ASTNodeAccessImpl implements FromItem, MultiPartName 
     }
 
     public Table(String name) {
-        setIndex(NAME_IDX, name);
+        setName(name);
     }
 
     public Table(String schemaName, String name) {
-        setIndex(NAME_IDX, name);
-        setIndex(SCHEMA_IDX, schemaName);
+        setSchemaName(schemaName);
+        setName(name);
     }
 
     public Table(Database database, String schemaName, String name) {
-        setIndex(NAME_IDX, name);
-        setIndex(SCHEMA_IDX, schemaName);
-        setIndex(DATABASE_IDX, database.getDatabaseName());
-        setIndex(SERVER_IDX, database.getServer().getFullyQualifiedName());
+        setName(name);
+        setSchemaName(schemaName);
+        setDatabase(database);
     }
 
     public Table(List<String> partItems) {
@@ -77,6 +76,7 @@ public class Table extends ASTNodeAccessImpl implements FromItem, MultiPartName 
 
     public void setDatabase(Database database) {
         setIndex(DATABASE_IDX, database.getDatabaseName());
+        setIndex(SERVER_IDX, database.getServer().getFullyQualifiedName());
     }
 
     public String getSchemaName() {
@@ -173,3 +173,4 @@ public class Table extends ASTNodeAccessImpl implements FromItem, MultiPartName 
                 + ((hint != null) ? hint.toString() : "");
     }
 }
+

--- a/src/main/java/net/sf/jsqlparser/schema/Table.java
+++ b/src/main/java/net/sf/jsqlparser/schema/Table.java
@@ -55,8 +55,8 @@ public class Table extends ASTNodeAccessImpl implements FromItem, MultiPartName 
     }
 
     public Table(String schemaName, String name) {
-        setSchemaName(schemaName);
         setName(name);
+        setSchemaName(schemaName);
     }
 
     public Table(Database database, String schemaName, String name) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3584,6 +3584,8 @@ List<String> CreateParameter():
             tk=<K_IN> { param.add(tk.image); }
 			|
             tk=<K_TYPE> { param.add(tk.image); }
+			|
+            tk=<K_COMMENT> { param.add(tk.image); }
         )
     {return param;}
 }

--- a/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
@@ -128,4 +128,17 @@ public class CCJSqlParserUtilTest {
                 + "---test");
         assertEquals("SELECT * FROM dual;\n", result.toString());
     }
+
+    @Test
+    public void testParseStatementIssue742() throws Exception {
+        Statements result = CCJSqlParserUtil.parseStatements("CREATE TABLE `table_name` (\n" +
+                "  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n" +
+                "  `another_column_id` bigint(20) NOT NULL COMMENT 'column id as sent by SYSTEM',\n" +
+                "  PRIMARY KEY (`id`),\n" +
+                "  UNIQUE KEY `uk_another_column_id` (`another_column_id`)\n" +
+                ")");
+        assertEquals("CREATE TABLE `table_name` (`id` bigint (20) NOT NULL AUTO_INCREMENT, `another_column_id` " +
+                "bigint (20) NOT NULL COMMENT 'column id as sent by SYSTEM', PRIMARY KEY (`id`), UNIQUE KEY `uk_another_column_id` " +
+                "(`another_column_id`)", result.toString());
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
@@ -139,6 +139,6 @@ public class CCJSqlParserUtilTest {
                 ")");
         assertEquals("CREATE TABLE `table_name` (`id` bigint (20) NOT NULL AUTO_INCREMENT, `another_column_id` " +
                 "bigint (20) NOT NULL COMMENT 'column id as sent by SYSTEM', PRIMARY KEY (`id`), UNIQUE KEY `uk_another_column_id` " +
-                "(`another_column_id`)", result.toString());
+                "(`another_column_id`));\n", result.toString());
     }
 }


### PR DESCRIPTION
Added support for comment(s) for column definitions in CREATE TABLE statements.

> CREATE TABLE `table_name` (`id` bigint (20) NOT NULL AUTO_INCREMENT, `another_column_id` bigint (20) NOT NULL COMMENT 'column id as sent by SYSTEM', PRIMARY KEY (`id`), UNIQUE KEY `uk_another_column_id` (`another_column_id`))

This should fix [742](https://github.com/JSQLParser/JSqlParser/issues/742)