### PR TITLE
added support for simple informix outer joins

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -208,7 +208,9 @@ public class Join extends ASTNodeAccessImpl {
 
     @Override
     public String toString() {
-        if (isSimple()) {
+        if (isSimple() && isOuter()) {
+            return "OUTER " + rightItem;
+        } else if (isSimple()) {
             return "" + rightItem;
         } else {
             String type = "";

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -348,9 +348,11 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
     }
 
     public void deparseJoin(Join join) {
-        if (join.isSimple()) {
-            buffer.append(", ");
-        } else {
+            if (join.isSimple() && join.isOuter()) {
+               buffer.append(", OUTER ");
+            } else if (join.isSimple()) {
+               buffer.append(", ");
+            } else {
 
             if (join.isRight()) {
                 buffer.append(" RIGHT");

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1729,7 +1729,7 @@ Join JoinerExpression() #JoinerExpression:
         | <K_CROSS> { join.setCross(true); } 
     ]
 
-          ( <K_JOIN> | "," { join.setSimple(true); } ) 
+          ( <K_JOIN> | "," { join.setSimple(true); } (<K_OUTER> { join.setOuter(true); } )? ) 
 
         right=FromItem()
 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -963,7 +963,15 @@ public class SelectTest {
         statement = "SELECT * FROM foo AS f LEFT OUTER JOIN (bar AS b RIGHT OUTER JOIN baz AS z ON f.id = z.id) ON f.id = b.id";
         select = (Select) parserManager.parse(new StringReader(statement));
         assertStatementCanBeDeparsedAs(select, statement);
-
+        statement = "SELECT * FROM foo AS f, OUTER bar AS b WHERE f.id = b.id";
+        select = (Select) parserManager.parse(new StringReader(statement));
+        assertStatementCanBeDeparsedAs(select, statement);
+        plainSelect = (PlainSelect) select.getSelectBody();
+        assertEquals(1, plainSelect.getJoins().size());
+        assertTrue(plainSelect.getJoins().get(0).isOuter());
+        assertTrue(plainSelect.getJoins().get(0).isSimple());
+        assertEquals("bar", ((Table) plainSelect.getJoins().get(0).getRightItem()).getFullyQualifiedName());
+        assertEquals("b", ((Table) plainSelect.getJoins().get(0).getRightItem()).getAlias().getName());
     }
 
     @Test


### PR DESCRIPTION
Support of simple outer joins.
See https://www.ibm.com/support/knowledgecenter/en/SSGU8G_12.1.0/com.ibm.sqlt.doc/ids_sqt_163.htm
This fixes partially #364
e.g. SELECT DISTINCT t1.f1, t2.f2 FROM t1, OUTER t2 WHERE t1.f3=1 AND t1.f4=t2.f4
