### PR TITLE
Support for simple informix outer joins.

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -208,7 +208,9 @@ public class Join extends ASTNodeAccessImpl {
 
     @Override
     public String toString() {
-        if (isSimple()) {
+        if (isSimple() && isOuter()) {
+            return "OUTER " + rightItem;
+        } else if (isSimple()) {
             return "" + rightItem;
         } else {
             String type = "";

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -348,9 +348,11 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
     }
 
     public void deparseJoin(Join join) {
-        if (join.isSimple()) {
-            buffer.append(", ");
-        } else {
+            if (join.isSimple() && join.isOuter()) {
+               buffer.append(", OUTER ");
+            } else if (join.isSimple()) {
+               buffer.append(", ");
+            } else {
 
             if (join.isRight()) {
                 buffer.append(" RIGHT");

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1729,7 +1729,7 @@ Join JoinerExpression() #JoinerExpression:
         | <K_CROSS> { join.setCross(true); } 
     ]
 
-          ( <K_JOIN> | "," { join.setSimple(true); } ) 
+          ( <K_JOIN> | "," { join.setSimple(true); } (<K_OUTER> { join.setOuter(true); } )? ) 
 
         right=FromItem()
 

--- a/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
@@ -11,6 +11,11 @@ import net.sf.jsqlparser.statement.Statements;
 import org.junit.After;
 import org.junit.AfterClass;
 import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -65,7 +70,18 @@ public class CCJSqlParserUtilTest {
 
     @Test(expected = JSQLParserException.class)
     public void testParseExpressionNonPartial() throws Exception {
-        Expression result = CCJSqlParserUtil.parseExpression("a+", false);
+        CCJSqlParserUtil.parseExpression("a+", false);
+
+    }
+
+    @Test(expected = JSQLParserException.class)
+    public void testParseExpressionFromStringFail() throws Exception {
+         CCJSqlParserUtil.parse("whatever$");
+    }
+
+    @Test(expected = JSQLParserException.class)
+    public void testParseExpressionFromRaderFail() throws Exception {
+         CCJSqlParserUtil.parse(new StringReader("whatever$"));
     }
 
     @Test
@@ -78,6 +94,24 @@ public class CCJSqlParserUtilTest {
     public void testParseCondExpression() throws Exception {
         Expression result = CCJSqlParserUtil.parseCondExpression("a+b>5 and c<3");
         assertEquals("a + b > 5 AND c < 3", result.toString());
+    }
+
+    @Test(expected = JSQLParserException.class)
+    public void testParseCondExpressionFail() throws Exception {
+       CCJSqlParserUtil.parseCondExpression(";");
+
+    }
+
+    @Test(expected = JSQLParserException.class)
+    public void testParseFromStreamFail() throws Exception {
+       CCJSqlParserUtil.parse(new ByteArrayInputStream("BLA".getBytes(StandardCharsets.UTF_8)));
+
+    }
+
+    @Test(expected = JSQLParserException.class)
+    public void testParseFromStreamWithEncodingFail() throws Exception {
+       CCJSqlParserUtil.parse(new ByteArrayInputStream("BLA".getBytes(StandardCharsets.UTF_8)), StandardCharsets.UTF_8.name());
+
     }
 
     @Test
@@ -119,6 +153,16 @@ public class CCJSqlParserUtilTest {
         assertEquals("SELECT * FROM dual;\n"
                 + "SELECT * FROM dual;\n"
                 + "SELECT * FROM dual;\n", result.toString());
+    }
+
+    @Test(expected = JSQLParserException.class)
+    public void testParseStatementsFail() throws Exception {
+       CCJSqlParserUtil.parseStatements("select * from dual;WHATEVER!!");
+    }
+
+    @Test(expected = JSQLParserException.class)
+    public void testParseASTFail() throws Exception {
+       CCJSqlParserUtil.parseAST("select * from dual;WHATEVER!!");
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/parser/JSQLParserExceptionTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/JSQLParserExceptionTest.java
@@ -1,0 +1,84 @@
+package net.sf.jsqlparser.parser;
+
+import net.sf.jsqlparser.JSQLParserException;
+import org.junit.After;
+import org.junit.AfterClass;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ * @author schwitters
+ */
+public class JSQLParserExceptionTest {
+
+    public JSQLParserExceptionTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of parseExpression method, of class CCJSqlParserUtil.
+     */
+    @Test
+    public void testExceptionWithCause() throws Exception {
+        IllegalArgumentException arg1 = new IllegalArgumentException();
+        JSQLParserException ex1=new JSQLParserException("", arg1);
+        assertSame(arg1, ex1.getCause());
+    }
+    @Test
+    public void testExceptionPrintStacktrace() throws Exception {
+        IllegalArgumentException arg1 = new IllegalArgumentException("BRATKARTOFFEL");
+        JSQLParserException ex1=new JSQLParserException("", arg1);
+        StringWriter sw = new StringWriter();
+        ex1.printStackTrace(new PrintWriter(sw, true));
+        assertTrue(sw.toString().contains("BRATKARTOFFEL"));
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ex1.printStackTrace(new PrintStream(bos, true));
+        assertTrue(new String(bos.toByteArray(), StandardCharsets.UTF_8).contains("BRATKARTOFFEL"));
+
+    }
+
+    @Test
+    public void testExceptionPrintStacktraceNoCause() throws Exception {
+        JSQLParserException ex1=new JSQLParserException("", null);
+        StringWriter sw = new StringWriter();
+        ex1.printStackTrace(new PrintWriter(sw, true));
+        assertFalse(sw.toString().contains("BRATKARTOFFEL"));
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ex1.printStackTrace(new PrintStream(bos, true));
+        assertFalse(new String(bos.toByteArray(), StandardCharsets.UTF_8).contains("BRATKARTOFFEL"));
+    }
+    @Test
+    public void testExceptionDefaultContructorCauseInit() throws Exception {
+        JSQLParserException ex1=new JSQLParserException();
+        assertNull(ex1.getCause());
+        ex1=new JSQLParserException((Throwable) null);
+        assertNull(ex1.getCause());
+    }
+
+}

--- a/src/test/java/net/sf/jsqlparser/schema/DatabaseTest.java
+++ b/src/test/java/net/sf/jsqlparser/schema/DatabaseTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2016 JSQLParser.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package net.sf.jsqlparser.schema;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ * @author schwitters
+ */
+public class DatabaseTest {
+
+    public DatabaseTest() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+    }
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    @Test
+    public void testDatabaseSimple() {
+        String databaseName = "db1";
+        Database database = new Database(databaseName);
+        assertEquals(databaseName, database.getFullyQualifiedName());
+    }
+
+    @Test
+    public void testDatabaseAndServer() {
+        final Server server = new Server("SERVER", "INSTANCE");
+        String databaseName = "db1";
+        Database database = new Database(server, databaseName);
+        assertEquals("[SERVER\\INSTANCE].db1", database.getFullyQualifiedName());
+        assertSame(server, database.getServer());
+        assertEquals(databaseName, database.getDatabaseName());
+        assertEquals("[SERVER\\INSTANCE].db1", database.toString());
+    }
+
+    @Test
+    public void testNullDatabaseAndServer() {
+        final Server server = new Server("SERVER", "INSTANCE");
+        Database database = new Database(server, null);
+        assertEquals("[SERVER\\INSTANCE].", database.getFullyQualifiedName());
+        assertSame(server, database.getServer());
+    }
+
+}

--- a/src/test/java/net/sf/jsqlparser/schema/ServerTest.java
+++ b/src/test/java/net/sf/jsqlparser/schema/ServerTest.java
@@ -37,6 +37,7 @@ public class ServerTest {
         assertEquals(fullServerName, server.toString());
     }
 
+    @Test
     public void testServerNameAndInstanceParsing() throws Exception {
         final String serverName = "LOCALHOST";
         final String serverInstanceName = "SQLSERVER";
@@ -48,5 +49,51 @@ public class ServerTest {
         assertEquals(serverInstanceName, server.getInstanceName());
         assertEquals(fullServerName, server.toString());
 
+    }
+    @Test
+    public void testServerNameAndInstanceParsing2() throws Exception {
+        String simpleName = "LOCALHOST";
+        final Server server = new Server(simpleName);
+        assertEquals(simpleName, server.getFullyQualifiedName());
+    }
+    @Test
+    public void testServerNameAndInstanceParsingNull() throws Exception {
+        final Server server = new Server(null);
+        assertEquals("", server.getFullyQualifiedName());
+    }
+    @Test
+    public void testServerNameAndInstancePassValues() throws Exception {
+        final Server server = new Server("SERVER", "INSTANCE");
+        assertEquals("SERVER", server.getServerName());
+        assertEquals("INSTANCE", server.getInstanceName());
+        assertEquals(String.format("[%s\\%s]", "SERVER", "INSTANCE"), server.getFullyQualifiedName());
+    }
+    @Test
+    public void testServerNameNull() throws Exception {
+        final Server server = new Server(null, "INSTANCE");
+        assertEquals(null, server.getServerName());
+        assertEquals("INSTANCE", server.getInstanceName());
+        assertEquals("", server.getFullyQualifiedName());
+    }
+    @Test
+    public void testServerNameEmpty() throws Exception {
+        final Server server = new Server("", "INSTANCE");
+        assertEquals("", server.getServerName());
+        assertEquals("INSTANCE", server.getInstanceName());
+        assertEquals("", server.getFullyQualifiedName());
+    }
+    @Test
+    public void testInstanceNameNull() throws Exception {
+        final Server server = new Server("LOCALHOST", null);
+        assertEquals("LOCALHOST", server.getServerName());
+        assertEquals(null, server.getInstanceName());
+        assertEquals("[LOCALHOST]", server.getFullyQualifiedName());
+    }
+    @Test
+    public void testInstanceNameEmpty() throws Exception {
+        final Server server = new Server("LOCALHOST", "");
+         assertEquals("LOCALHOST", server.getServerName());
+         assertEquals("", server.getInstanceName());
+        assertEquals("[LOCALHOST]", server.getFullyQualifiedName());
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/BlockTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/BlockTest.java
@@ -23,6 +23,7 @@ import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import org.junit.After;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -76,4 +77,18 @@ public class BlockTest {
                 + "", stmts.toString());
 
     }
+    @Test
+    public void testBlock3() throws JSQLParserException {
+        Statements stmts = CCJSqlParserUtil.parseStatements("begin\nselect * from feature;\nend");
+        Block block =(Block) stmts.getStatements().get(0);
+        assertFalse(block.getStatements().getStatements().isEmpty());
+    }
+    @Test
+    public void testBlockToStringIsNullSafe() throws JSQLParserException {
+        Block block = new Block();
+        block.setStatements(null);
+        assertEquals("BEGIN\n"
+                 + "END", block.toString());
+    }
+
 }

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
@@ -229,7 +229,10 @@ public class CreateTableTest {
     public void testCreateTableWithCheck() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("CREATE TABLE table2 (id INT (10) NOT NULL, name TEXT, url TEXT, CONSTRAINT name_not_empty CHECK (name <> ''))");
     }
-
+    @Test
+    public void testCreateTableWithCheckNotNull() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("CREATE TABLE table2 (id INT (10) NOT NULL, name TEXT, url TEXT, CONSTRAINT name_not_null CHECK (name IS NOT NULL))");
+    }
     @Test
     public void testCreateTableIssue270() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("CREATE TABLE item (i_item_sk integer NOT NULL, i_item_id character (16) NOT NULL, i_rec_start_date date, i_rec_end_date date, i_item_desc character varying(200), i_current_price numeric(7,2), i_wholesale_cost numeric(7,2), i_brand_id integer, i_brand character(50), i_class_id integer, i_class character(50), i_category_id integer, i_category character(50), i_manufact_id integer, i_manufact character(50), i_size character(20), i_formulation character(20), i_color character(20), i_units character(10), i_container character(10), i_manager_id integer, i_product_name character(50) )", true);

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -963,7 +963,15 @@ public class SelectTest {
         statement = "SELECT * FROM foo AS f LEFT OUTER JOIN (bar AS b RIGHT OUTER JOIN baz AS z ON f.id = z.id) ON f.id = b.id";
         select = (Select) parserManager.parse(new StringReader(statement));
         assertStatementCanBeDeparsedAs(select, statement);
-
+        statement = "SELECT * FROM foo AS f, OUTER bar AS b WHERE f.id = b.id";
+        select = (Select) parserManager.parse(new StringReader(statement));
+        assertStatementCanBeDeparsedAs(select, statement);
+        plainSelect = (PlainSelect) select.getSelectBody();
+        assertEquals(1, plainSelect.getJoins().size());
+        assertTrue(plainSelect.getJoins().get(0).isOuter());
+        assertTrue(plainSelect.getJoins().get(0).isSimple());
+        assertEquals("bar", ((Table) plainSelect.getJoins().get(0).getRightItem()).getFullyQualifiedName());
+        assertEquals("b", ((Table) plainSelect.getJoins().get(0).getRightItem()).getAlias().getName());
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
@@ -563,4 +563,15 @@ public class TablesNamesFinderTest {
         assertEquals(1, tableList.size());
         assertEquals("foo.product", tableList.get(0));
     }
+    @Test
+    public void testBetween() throws JSQLParserException {
+        String sql = "mycol BETWEEN (select col2 from mytable) AND (select col3 from mytable2)";
+        Expression expr = (Expression) CCJSqlParserUtil.parseCondExpression(sql);
+        TablesNamesFinder tablesNamesFinder = new TablesNamesFinder();
+        List<String> tableList = tablesNamesFinder.getTableList(expr);
+        assertEquals(2, tableList.size());
+        assertTrue(tableList.contains("mytable"));
+        assertTrue(tableList.contains("mytable2"));
+
+    }
 }


### PR DESCRIPTION
Support for simple outer joins.
See https://www.ibm.com/support/knowledgecenter/en/SSGU8G_12.1.0/com.ibm.sqlt.doc/ids_sqt_163.htm
This fixes partially #364
e.g. SELECT DISTINCT t1.f1, t2.f2 FROM t1, OUTER t2 WHERE t1.f3=1 AND t1.f4=t2.f4

Hopefully the code coverage is now improved.