### PR TITLE
Fixes 649 to add support for HOUR, MINUTE, SECOND date literals and s…

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -140,7 +140,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_CROSS:"CROSS">
 |   <K_CURRENT: "CURRENT">
 |   <K_DATETIMELITERAL : ("DATE" | "TIME" | "TIMESTAMP") >
-|   <K_DATE_LITERAL : ( "YEAR" | "MONTH" | "DAY" ) >
+|   <K_DATE_LITERAL : ( "YEAR" | "MONTH" | "DAY" | "HOUR" | "MINUTE" | "SECOND" ) >
 |   <K_DEFERRABLE : "DEFERRABLE">
 |   <K_DELAYED : "DELAYED">
 |   <K_DELETE:"DELETE">
@@ -2837,7 +2837,7 @@ IntervalExpression IntervalExpression() : {
         [ LOOKAHEAD(2) (token = <S_IDENTIFIER> | token = <K_DATE_LITERAL>) { interval.setIntervalType(token.image); } ]
     |
         { interval = new IntervalExpression(false); }
-        ( token=<S_LONG> | token=<S_DOUBLE> | token=<S_CHAR_LITERAL> ) 
+        ( token=<S_LONG> | token=<S_DOUBLE> | token=<S_CHAR_LITERAL> | token = <S_IDENTIFIER>)
         { interval.setParameter((signed?"-":"") + token.image); }
         token = <K_DATE_LITERAL> { interval.setIntervalType(token.image); }
     )

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -3471,6 +3471,21 @@ public class SelectTest {
     }
 
     @Test
+    public void testDateArithmentic6() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT CURRENT_DATE + HOURS_OFFSET HOUR AS NEXT_DATE FROM SYSIBM.SYSDUMMY1");
+    }
+
+    @Test
+    public void testDateArithmentic7() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT CURRENT_DATE + MINUTE_OFFSET MINUTE AS NEXT_DATE FROM SYSIBM.SYSDUMMY1");
+    }
+
+    @Test
+    public void testDateArithmentic8() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT CURRENT_DATE + SECONDS_OFFSET SECOND AS NEXT_DATE FROM SYSIBM.SYSDUMMY1");
+    }
+
+    @Test
     public void testNotProblemIssue721() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT * FROM dual WHERE NOT regexp_like('a', '[\\w]+')");
     }


### PR DESCRIPTION
…upport for identifiers as the interval parameter.

See my comments in issue #649.

If you add <S_IDENTIFIER> to the line ( token=<S_LONG> | token=<S_DOUBLE> | token=<S_CHAR_LITERAL> | token = <S_IDENTIFIER>) it fixes many of the issues we are seeing (most of the time we use a single identifier as the offset value; it is a less frequent case that we use an expression).

A test case for this scenario is:

`select current_date + foo day as next_day from foo`

It still does not work for expressions.  I tried adding support for an expression directly there, but it gives a left parse error when reading the .jj file.  I tried wrapping the expression in brackets (accepted but not required in DB2), and everything compiled but tests started to fail - it looks like the parser was getting confused.

Anyway, the S_IDENTIFIER change works for most of our reports.  There are now only 11 out of 1553 reports which fail to parse.