### PR TITLE
KSql 'Within' Clause  Time Unit Bug Fix

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1747,8 +1747,8 @@ KSQLJoinWindow JoinWindow():
     Token afterTimeUnitToken = null;
 }
 {
-    (beforeDurationToken=<S_LONG> beforeTimeUnitToken=<S_IDENTIFIER>
-        [ "," afterDurationToken=<S_LONG> afterTimeUnitToken=<S_IDENTIFIER> ]
+    (beforeDurationToken=<S_LONG> (beforeTimeUnitToken=<S_IDENTIFIER> | beforeTimeUnitToken=<K_DATE_LITERAL>)
+        [ "," afterDurationToken=<S_LONG> (afterTimeUnitToken=<S_IDENTIFIER> | afterTimeUnitToken=<K_DATE_LITERAL>) ]
     {
         if (afterDurationToken == null) {
             retval.setDuration(Long.parseLong(beforeDurationToken.image));

--- a/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
@@ -58,7 +58,7 @@ public class KSQLTest {
         sql = "SELECT *\n"
                 + "FROM table1 t1\n"
                 + "INNER JOIN table2 t2\n"
-                + "WITHIN (2 MINUTES, 5 MINUTES)\n"
+                + "WITHIN (1 MINUTE, 5 MINUTES)\n"
                 + "ON t1.id = t2.id\n";
 
         statement = CCJSqlParserUtil.parse(sql);
@@ -71,8 +71,8 @@ public class KSQLTest {
         assertEquals("table2", ((Table) plainSelect.getJoins().get(0).getRightItem()).
                 getFullyQualifiedName());
         assertTrue(plainSelect.getJoins().get(0).isWindowJoin());
-        assertEquals(2L, plainSelect.getJoins().get(0).getJoinWindow().getBeforeDuration());
-        assertEquals("MINUTES", plainSelect.getJoins().get(0).getJoinWindow().getBeforeTimeUnit().toString());
+        assertEquals(1L, plainSelect.getJoins().get(0).getJoinWindow().getBeforeDuration());
+        assertEquals("MINUTE", plainSelect.getJoins().get(0).getJoinWindow().getBeforeTimeUnit().toString());
         assertEquals(5L, plainSelect.getJoins().get(0).getJoinWindow().getAfterDuration());
         assertEquals("MINUTES", plainSelect.getJoins().get(0).getJoinWindow().getAfterTimeUnit().toString());
         assertTrue(plainSelect.getJoins().get(0).getJoinWindow().isBeforeAfterWindow());


### PR DESCRIPTION
The new release of JSQLParser breaks in case of singular Time units usage. For example usage of `MINUTE` was failing but `MINUTES` was fine. This bug fix would allow us to use both singular and plural time units.