### PR TITLE
Add support for STRAIGHT_JOIN

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -26,6 +26,7 @@ public class Join extends ASTNodeAccessImpl {
     private boolean simple = false;
     private boolean cross = false;
     private boolean semi = false;
+    private boolean straight = false;
     private FromItem rightItem;
     private Expression onExpression;
     private List<Column> usingColumns;
@@ -45,6 +46,14 @@ public class Join extends ASTNodeAccessImpl {
 
     public void setInner(boolean b) {
         inner = b;
+    }
+
+    public boolean isStraight() {
+        return straight;
+    }
+
+    public void setStraight(boolean b) {
+        straight = b;
     }
 
     /**
@@ -210,7 +219,13 @@ public class Join extends ASTNodeAccessImpl {
                 type += "SEMI ";
             }
 
-            return type + "JOIN " + rightItem + ((joinWindow != null) ? " WITHIN " + joinWindow : "")
+            if (!isStraight()) {
+                type += "JOIN ";
+            } else {
+                type = "STRAIGHT_JOIN ";
+            }
+
+            return type + rightItem + ((joinWindow != null) ? " WITHIN " + joinWindow : "")
                     + ((onExpression != null) ? " ON " + onExpression + "" : "")
                     + PlainSelect.getFormatedList(usingColumns, "USING", true, true);
         }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -356,7 +356,11 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
                 buffer.append(" SEMI");
             }
 
-            buffer.append(" JOIN ");
+            if (!join.isStraight()) {
+                buffer.append(" JOIN ");
+            } else {
+                buffer.append(" STRAIGHT_JOIN ");
+            }
 
         }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -183,6 +183,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_IN:"IN">
 |   <K_INDEX: "INDEX">
 |   <K_INNER:"INNER">
+|   <K_STRAIGHT:"STRAIGHT_JOIN">
 |   <K_INSERT:"INSERT">
 |   <K_INTERSECT:"INTERSECT">
 |   <K_INTERVAL:"INTERVAL">
@@ -1711,10 +1712,11 @@ Join JoinerExpression() #JoinerExpression:
            ) [ <K_OUTER> { join.setOuter(true); } ]
         | <K_INNER> { join.setInner(true); }
         | <K_NATURAL> { join.setNatural(true); }
-        | <K_CROSS> { join.setCross(true); } 
+        | <K_CROSS> { join.setCross(true); }
     ]
 
-          ( <K_JOIN> | "," { join.setSimple(true); } (<K_OUTER> { join.setOuter(true); } )? ) 
+          ( <K_JOIN> | "," { join.setSimple(true); } (<K_OUTER> { join.setOuter(true); } )?
+           | <K_STRAIGHT> { join.setStraight(true); } )
 
         right=FromItem()
 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -1614,6 +1614,12 @@ public class SelectTest {
     }
 
     @Test
+    public void testStraightJoin() throws JSQLParserException {
+        String stmt = "SELECT col FROM tbl STRAIGHT_JOIN tbl2 ON tbl.id = tbl2.id";
+        assertSqlCanBeParsedAndDeparsed(stmt);
+    }
+
+    @Test
     public void testCastTypeProblem3() throws JSQLParserException {
         String stmt = "SELECT col1::varchar (256) FROM tabelle1";
         assertSqlCanBeParsedAndDeparsed(stmt);


### PR DESCRIPTION
Added support for the STRAIGHT_JOIN join type.
Parsing failed this far for queries like the following:
SELECT col FROM tbl STRAIGHT_JOIN tbl2 ON tbl.id = tbl2.id