### PR TITLE
Support columns named `limit`

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1013,6 +1013,16 @@ List<String> RelObjectNameList() : {
     { return data; }
 }
 
+List<String> ColumnNameList() : {
+    String token = null;
+    List<String> data = new ArrayList<String>();
+} {
+    token = ColumnName() { data.add(token); }
+    ( LOOKAHEAD (2) "." ("." { data.add(null); })* token = ColumnName() { data.add(token); } ) *
+
+    { return data; }
+}
+
 // See: http://technet.microsoft.com/en-us/library/ms187879%28v=sql.105%29.aspx
 
 Column Column() #Column :
@@ -1022,7 +1032,7 @@ Column Column() #Column :
     List<String> data = new ArrayList<String>();
 }
 {
-    data = RelObjectNameList()
+    data = ColumnNameList()
 
     {
         Column col = new Column(data);
@@ -1067,6 +1077,20 @@ String RelObjectName() :
     { 
 		if (tk!=null) result=tk.image;
 		return result; 
+	}
+}
+
+/*
+Column names.
+*/
+String ColumnName() :
+{    Token tk = null; String result = null; }
+{
+    (result = RelObjectNameWithoutValue() | tk=<K_TOP> | tk=<K_VALUE> | tk=<K_VALUES> | tk=<K_INTERVAL> | tk = "LIMIT")
+
+    {
+		if (tk!=null) result=tk.image;
+		return result;
 	}
 }
 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -1587,6 +1587,20 @@ public class SelectTest {
     }
 
     @Test
+    public void testLimitColumnNameForOracle() throws JSQLParserException {
+        // 'limit' is not a restricted keyword in Oracle.
+        String sql = "SELECT limit FROM (SELECT * FROM table2 WHERE col1 = 'val')";
+        assertSqlCanBeParsedAndDeparsed(sql);
+    }
+
+    @Test
+    public void testLimitColumnInWhereClauseForOracle() throws JSQLParserException {
+        // 'limit' is not a restricted keyword in Oracle.
+        String sql = "SELECT * FROM table2 WHERE limit > 200";
+        assertSqlCanBeParsedAndDeparsed(sql);
+    }
+
+    @Test
     public void testCast() throws JSQLParserException {
         String stmt = "SELECT CAST(a AS varchar) FROM tabelle1";
         assertSqlCanBeParsedAndDeparsed(stmt);


### PR DESCRIPTION
`limit` is not a reserved keyword in Oracle.

Fixes ##790