### PR TITLE
support postgresql CREATE INDEX syntax

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
@@ -4,7 +4,19 @@
  * %%
  * Copyright (C) 2004 - 2019 JSQLParser
  * %%
- * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
 package net.sf.jsqlparser.statement.create.index;
@@ -56,6 +68,11 @@ public class CreateIndex implements Statement {
         buffer.append(index.getName());
         buffer.append(" ON ");
         buffer.append(table.getFullyQualifiedName());
+
+        if (index.getUsing() != null){
+            buffer.append(" USING ");
+            buffer.append(index.getUsing());
+        }
 
         if (index.getColumnsNames() != null) {
             buffer.append(" (");

--- a/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
@@ -4,19 +4,7 @@
  * %%
  * Copyright (C) 2004 - 2019 JSQLParser
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
  * #L%
  */
 package net.sf.jsqlparser.statement.create.index;

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
@@ -4,19 +4,7 @@
  * %%
  * Copyright (C) 2004 - 2019 JSQLParser
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
  * #L%
  */
 package net.sf.jsqlparser.statement.create.table;

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
@@ -4,7 +4,19 @@
  * %%
  * Copyright (C) 2004 - 2019 JSQLParser
  * %%
- * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
 package net.sf.jsqlparser.statement.create.table;
@@ -16,6 +28,7 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
 public class Index {
 
     private String type;
+    private String using;
     private List<String> columnsNames;
     private String name;
     private List<String> idxSpec;
@@ -32,6 +45,17 @@ public class Index {
         return type;
     }
 
+    /**
+     * In postgresql, the index type (Btree, GIST, etc.) is indicated
+     * with a USING clause.
+     * Please note that:
+     *  Oracle - the type might be BITMAP, indicating a bitmap kind of index
+     *  MySQL - the type might be FULLTEXT or SPATIAL
+    */
+    public void setUsing(String string) {
+        using = string;
+    }
+
     public void setColumnsNames(List<String> list) {
         columnsNames = list;
     }
@@ -42,6 +66,10 @@ public class Index {
 
     public void setType(String string) {
         type = string;
+    }
+
+    public String getUsing() {
+        return using;
     }
 
     public List<String> getIndexSpec() {

--- a/src/main/java/net/sf/jsqlparser/util/deparser/CreateIndexDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/CreateIndexDeParser.java
@@ -4,19 +4,7 @@
  * %%
  * Copyright (C) 2004 - 2019 JSQLParser
  * %%
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation, either version 2.1 of the
- * License, or (at your option) any later version.
- * 
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Lesser Public License for more details.
- * 
- * You should have received a copy of the GNU General Lesser Public
- * License along with this program.  If not, see
- * <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
  * #L%
  */
 package net.sf.jsqlparser.util.deparser;

--- a/src/main/java/net/sf/jsqlparser/util/deparser/CreateIndexDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/CreateIndexDeParser.java
@@ -4,7 +4,19 @@
  * %%
  * Copyright (C) 2004 - 2019 JSQLParser
  * %%
- * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 2.1 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-2.1.html>.
  * #L%
  */
 package net.sf.jsqlparser.util.deparser;
@@ -36,6 +48,12 @@ public class CreateIndexDeParser {
         buffer.append(index.getName());
         buffer.append(" ON ");
         buffer.append(createIndex.getTable().getFullyQualifiedName());
+
+        String using = index.getUsing();
+        if (using != null){
+            buffer.append(" USING ");
+            buffer.append(using);
+        }
 
         if (index.getColumnsNames() != null) {
             buffer.append(" (");

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3290,6 +3290,7 @@ CreateIndex CreateIndex():
     Table table = null;
     List<String> colNames = new ArrayList<String>();
     Token columnName;
+    Token using;
     Index index = null;
     String name = null;
     List<String> parameter = new ArrayList<String>();
@@ -3306,6 +3307,8 @@ CreateIndex CreateIndex():
     }
 
     <K_ON> table=Table()
+
+    [ <K_USING> using=<S_IDENTIFIER> {index.setUsing(using.image);} ]
 
     "("
     (columnName=<S_IDENTIFIER>

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
@@ -92,6 +92,21 @@ public class CreateIndexTest {
     }
 
     @Test
+    public void testCreateIndex7() throws JSQLParserException {
+        String statement
+                = "CREATE INDEX myindex1 ON mytab USING GIST (mycol)";
+        CreateIndex createIndex = (CreateIndex) parserManager.parse(new StringReader(statement));
+        assertEquals(1, createIndex.getIndex().getColumnsNames().size());
+        assertEquals("myindex1", createIndex.getIndex().getName());
+        assertNull(createIndex.getIndex().getType());
+        assertEquals("mytab", createIndex.getTable().getFullyQualifiedName());
+        assertEquals("mycol", createIndex.getIndex().getColumnsNames().get(0));
+        assertEquals("GIST", createIndex.getIndex().getUsing()); 
+        assertEquals(statement, "" + createIndex);
+        assertSqlCanBeParsedAndDeparsed(statement);
+    }
+
+    @Test
     @Ignore
     public void testCreateIndexIssue633() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("CREATE INDEX idx_american_football_action_plays_1 ON american_football_action_plays USING btree (play_type)");


### PR DESCRIPTION
The postgresql CREATE INDEX statement uses the USING clause to indicate the indexing method, e.g.
   CREATE INDEX myindex1 ON mytab USING GIST (mycol)
This PR adds support for this syntax.

The PR passes all tests, and a test has been added for the USING syntax.
testCreateIndexIssue633 in CreateIndexTest.java will likely now pass.

Most other SQL dialects indicate the indexing method in the parameters between CREATE and INDEX
     CREATE (parameter)* INDEX
and in some cases, there can be two parameters, e.g. in TransactSQL one can say
    CREATE Unique Clustered INDEX
The current code will only pick up "Unique" for Index.type and will drop "Clustered".
In general, Index.type should be List<String>

