### PR TITLE
Add generated sources to classpath.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,25 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generated-sources/javacc/</source>
+                                <source>${project.build.directory}/generated-sources/jjtree/</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.7.0</version>
                 <configuration>


### PR DESCRIPTION
When importing the Maven project into Eclipse, the sources generated are not automatically included. This commit aims to do that.