### PR TITLE
Support KSQL's WINDOW

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/KSQLWindow.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/KSQLWindow.java
@@ -1,0 +1,133 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.select;
+
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
+public class KSQLWindow extends ASTNodeAccessImpl {
+
+    public enum TimeUnit {
+        DAY ("DAY"),
+        HOUR ("HOUR"),
+        MINUTE ("MINUTE"),
+        SECOND ("SECOND"),
+        MILLISECOND ("MILLISECOND"),
+        DAYS ("DAYS"),
+        HOURS ("HOURS"),
+        MINUTES ("MINUTES"),
+        SECONDS ("SECONDS"),
+        MILLISECONDS ("MILLISECONDS");
+
+        private String timeUnit;
+
+        TimeUnit(String timeUnit) {
+            this.timeUnit = timeUnit;
+        }
+
+        public String getTimeUnit() {
+            return timeUnit;
+        }
+    }
+
+    public enum WindowType {
+        HOPPING ("HOPPING"),
+        SESSION ("SESSION"),
+        TUMBLING ("TUMBLING");
+
+        private String windowType;
+
+        WindowType(String windowType) {
+            this.windowType = windowType;
+        }
+
+        public String getWindowType() {
+            return windowType;
+        }
+    }
+
+    private boolean hopping;
+    private boolean tumbling;
+    private boolean session;
+    private long sizeDuration;
+    private TimeUnit sizeTimeUnit;
+    private long advanceDuration;
+    private TimeUnit advanceTimeUnit;
+
+    public boolean isHoppingWindow() {
+        return hopping;
+    }
+
+    public void setHoppingWindow(boolean hopping) {
+        this.hopping = hopping;
+    }
+
+    public boolean isTumblingWindow() {
+        return tumbling;
+    }
+
+    public void setTumblingWindow(boolean tumbling) {
+        this.tumbling = tumbling;
+    }
+
+    public boolean isSessionWindow() {
+        return session;
+    }
+
+    public void setSessionWindow(boolean session) {
+        this.session = session;
+    }
+
+    public long getSizeDuration() {
+        return sizeDuration;
+    }
+
+    public void setSizeDuration(long sizeDuration) {
+        this.sizeDuration = sizeDuration;
+    }
+
+    public TimeUnit getSizeTimeUnit() {
+        return sizeTimeUnit;
+    }
+
+    public void setSizeTimeUnit(TimeUnit sizeTimeUnit) {
+        this.sizeTimeUnit = sizeTimeUnit;
+    }
+
+    public long getAdvanceDuration() {
+        return advanceDuration;
+    }
+
+    public void setAdvanceDuration(long advanceDuration) {
+        this.advanceDuration = advanceDuration;
+    }
+
+    public TimeUnit getAdvanceTimeUnit() {
+        return advanceTimeUnit;
+    }
+
+    public void setAdvanceTimeUnit(TimeUnit advanceTimeUnit) {
+        this.advanceTimeUnit = advanceTimeUnit;
+    }
+
+    public KSQLWindow() {
+    }
+
+    @Override
+    public String toString() {
+        if (isHoppingWindow()) {
+            return "HOPPING (" + "SIZE " + sizeDuration + " " + sizeTimeUnit + ", " +
+                    "ADVANCE BY " + advanceDuration + " " + advanceTimeUnit + ")";
+        } else if (isSessionWindow()) {
+            return "SESSION (" + sizeDuration + " " + sizeTimeUnit + ")";
+        } else {
+            return "TUMBLING (" + "SIZE " + sizeDuration + " " + sizeTimeUnit + ")";
+        }
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
@@ -47,6 +47,7 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
     private boolean mySqlSqlCalcFoundRows = false;
     private boolean sqlNoCacheFlag = false;
     private String forXmlPath;
+    private KSQLWindow ksqlWindow = null;
 
     public boolean isUseBrackets() {
         return useBrackets;
@@ -280,6 +281,14 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
         this.forXmlPath = forXmlPath;
     }
 
+    public KSQLWindow getKsqlWindow() {
+        return ksqlWindow;
+    }
+
+    public void setKsqlWindow(KSQLWindow ksqlWindow) {
+        this.ksqlWindow = ksqlWindow;
+    }
+
     @Override
     public String toString() {
         StringBuilder sql = new StringBuilder();
@@ -336,6 +345,10 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
                         sql.append(" ").append(join);
                     }
                 }
+            }
+
+            if (ksqlWindow != null) {
+                sql.append(" WINDOW ").append(ksqlWindow.toString());
             }
             if (where != null) {
                 sql.append(" WHERE ").append(where);

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -114,6 +114,11 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
             }
         }
 
+        if (plainSelect.getKsqlWindow() != null) {
+            buffer.append(" WINDOW ");
+            buffer.append(plainSelect.getKsqlWindow().toString());
+        }
+
         if (plainSelect.getWhere() != null) {
             buffer.append(" WHERE ");
             plainSelect.getWhere().accept(expressionVisitor);

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -106,6 +106,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 {
     <K_ACTION: "ACTION">
 |   <K_ADD:"ADD">
+|   <K_ADVANCE:"ADVANCE">
 |   <K_ALGORITHM: "ALGORITHM">
 |   <K_ALL:"ALL">
 |   <K_ALTER:"ALTER">
@@ -177,6 +178,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_GROUP_CONCAT:"GROUP_CONCAT">
 |   <K_HAVING:"HAVING">
 |   <K_HIGH_PRIORITY : "HIGH_PRIORITY">
+|   <K_HOPPING:"HOPPING">
 |   <K_IF:"IF">
 |   <K_IIF:"IIF">
 |   <K_IGNORE : "IGNORE">
@@ -248,11 +250,13 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_SELECT: ("SELECT" | "SEL")>
 |   <K_SEMI : "SEMI">
 |   <K_SEPARATOR:"SEPARATOR">
+|   <K_SESSION:"SESSION">
 |   <K_SET:"SET">
 |   <K_SETS:"SETS">
 |   <K_SHOW : "SHOW">
 |   <K_SIBLINGS:"SIBLINGS">
 |   <K_SIMILAR:"SIMILAR">
+|   <K_SIZE:"SIZE">
 |   <K_SKIP: "SKIP">
 |   <K_SOME:"SOME">
 |   <K_START:"START">
@@ -266,6 +270,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_TOP:"TOP">
 |   <K_TRAILING:"TRAILING">
 |   <K_TRUNCATE:"TRUNCATE">
+|   <K_TUMBLING:"TUMBLING">
 |   <K_TYPE:"TYPE">
 |   <K_UNBOUNDED: "UNBOUNDED"> 
 |   <K_UNION:"UNION">
@@ -287,6 +292,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_WAIT : "WAIT">
 |   <K_WHEN:"WHEN">
 |   <K_WHERE:"WHERE">
+|   <K_WINDOW:"WINDOW">
 |   <K_WITH:"WITH">
 |   <K_WITHIN:"WITHIN">
 |   <K_WITHOUT:"WITHOUT">
@@ -1186,6 +1192,7 @@ PlainSelect PlainSelect() #PlainSelect:
     Wait wait = null;
     boolean mySqlSqlCalcFoundRows = false;
     Token token;
+    KSQLWindow ksqlWindow=null;
 }
 {
     <K_SELECT>
@@ -1226,6 +1233,7 @@ PlainSelect PlainSelect() #PlainSelect:
       fromItem=FromItem()
       joins=JoinsList() ]
 
+    [ ksqlWindow=KSQLWindowClause() { plainSelect.setKsqlWindow(ksqlWindow); } ]
     [ where=WhereClause() { plainSelect.setWhere(where); }]
     [ oracleHierarchicalQueryClause=OracleHierarchicalQueryClause() { plainSelect.setOracleHierarchical(oracleHierarchicalQueryClause); } ]
     [ groupBy=GroupByColumnReferences() { plainSelect.setGroupByElement(groupBy); }]
@@ -1777,6 +1785,49 @@ KSQLJoinWindow JoinWindow():
         retval.setBeforeAfterWindow(true);
         return retval;
     })
+}
+
+KSQLWindow KSQLWindowClause():
+{
+    KSQLWindow retval = null;
+    Token sizeDurationToken = null;
+    Token sizeTimeUnitToken = null;
+    Token advanceDurationToken = null;
+    Token advanceTimeUnitToken = null;
+}
+{
+    <K_WINDOW>
+    {
+        retval=new KSQLWindow();
+        retval.setHoppingWindow(false);
+        retval.setSessionWindow(false);
+        retval.setTumblingWindow(false);
+    }
+    (
+        <K_HOPPING> "("
+            <K_SIZE> sizeDurationToken=<S_LONG> sizeTimeUnitToken=<S_IDENTIFIER> ","
+            <K_ADVANCE> <K_BY> advanceDurationToken=<S_LONG> advanceTimeUnitToken=<S_IDENTIFIER> ")"
+        {
+            retval.setHoppingWindow(true);
+        } |
+        <K_SESSION> "(" sizeDurationToken=<S_LONG> sizeTimeUnitToken=<S_IDENTIFIER> ")"
+        {
+            retval.setSessionWindow(true);
+        } |
+        <K_TUMBLING> "(" <K_SIZE> sizeDurationToken=<S_LONG> sizeTimeUnitToken=<S_IDENTIFIER> ")"
+        {
+            retval.setTumblingWindow(true);
+        }
+    )
+    {
+            retval.setSizeDuration(Long.parseLong(sizeDurationToken.image));
+            retval.setSizeTimeUnit(KSQLWindow.TimeUnit.valueOf(sizeTimeUnitToken.image));
+            if (advanceDurationToken != null) {
+                retval.setAdvanceDuration(Long.parseLong(advanceDurationToken.image));
+                retval.setAdvanceTimeUnit(KSQLWindow.TimeUnit.valueOf(advanceTimeUnitToken.image));
+            }
+            return retval;
+    }
 }
 
 Expression WhereClause():

--- a/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/KSQLTest.java
@@ -80,4 +80,77 @@ public class KSQLTest {
 
         assertSqlCanBeParsedAndDeparsed(sql, true);
     }
+
+    @Test
+    public void testKSQLHoppingWindows() throws Exception {
+        String sql;
+        Statement statement;
+        sql = "SELECT *\n"
+                + "FROM table1 t1\n"
+                + "WINDOW HOPPING (SIZE 30 SECONDS, ADVANCE BY 10 MINUTES)\n"
+                + "GROUP BY region.id\n";
+
+        statement = CCJSqlParserUtil.parse(sql);
+        System.out.println(statement.toString());
+
+        Select select = (Select) statement;
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertTrue(plainSelect.getKsqlWindow().isHoppingWindow());
+        assertFalse(plainSelect.getKsqlWindow().isSessionWindow());
+        assertFalse(plainSelect.getKsqlWindow().isTumblingWindow());
+        assertEquals(30L, plainSelect.getKsqlWindow().getSizeDuration());
+        assertEquals("SECONDS", plainSelect.getKsqlWindow().getSizeTimeUnit().toString());
+        assertEquals(10L, plainSelect.getKsqlWindow().getAdvanceDuration());
+        assertEquals("MINUTES", plainSelect.getKsqlWindow().getAdvanceTimeUnit().toString());
+        assertStatementCanBeDeparsedAs(select, sql, true);
+
+        assertSqlCanBeParsedAndDeparsed(sql, true);
+    }
+
+    @Test
+    public void testKSQLSessionWindows() throws Exception {
+        String sql;
+        Statement statement;
+        sql = "SELECT *\n"
+                + "FROM table1 t1\n"
+                + "WINDOW SESSION (5 MINUTES)\n"
+                + "GROUP BY region.id\n";
+
+        statement = CCJSqlParserUtil.parse(sql);
+        System.out.println(statement.toString());
+
+        Select select = (Select) statement;
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertTrue(plainSelect.getKsqlWindow().isSessionWindow());
+        assertFalse(plainSelect.getKsqlWindow().isHoppingWindow());
+        assertFalse(plainSelect.getKsqlWindow().isTumblingWindow());
+        assertEquals(5L, plainSelect.getKsqlWindow().getSizeDuration());
+        assertEquals("MINUTES", plainSelect.getKsqlWindow().getSizeTimeUnit().toString());
+
+        assertStatementCanBeDeparsedAs(select, sql, true);
+        assertSqlCanBeParsedAndDeparsed(sql, true);
+    }
+
+    @Test
+    public void testKSQLTumblingWindows() throws Exception {
+        String sql;
+        Statement statement;
+        sql = "SELECT *\n"
+                + "FROM table1 t1\n"
+                + "WINDOW TUMBLING (SIZE 30 SECONDS)\n"
+                + "GROUP BY region.id\n";
+
+        statement = CCJSqlParserUtil.parse(sql);
+        System.out.println(statement.toString());
+                Select select = (Select) statement;
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertTrue(plainSelect.getKsqlWindow().isTumblingWindow());
+        assertFalse(plainSelect.getKsqlWindow().isSessionWindow());
+        assertFalse(plainSelect.getKsqlWindow().isHoppingWindow());
+        assertEquals(30L, plainSelect.getKsqlWindow().getSizeDuration());
+        assertEquals("SECONDS", plainSelect.getKsqlWindow().getSizeTimeUnit().toString());
+
+        assertStatementCanBeDeparsedAs(select, sql, true);
+        assertSqlCanBeParsedAndDeparsed(sql, true);
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -3304,7 +3304,7 @@ public class SelectTest {
 
     @Test
     public void testMultiPartNamesIssue608() throws JSQLParserException {
-        assertSqlCanBeParsedAndDeparsed("SELECT @@session.tx_read_only");
+        assertSqlCanBeParsedAndDeparsed("SELECT @@sessions.tx_read_only");
     }
 
 //    Teradata allows SEL to be used in place of SELECT


### PR DESCRIPTION
[KSQL](https://github.com/confluentinc/ksql) supports `WINDOW` keyword for windowed queries in aggregation. The syntax is as follows for different queries:
* Hopping window:
```
WINDOW HOPPING (SIZE 30 SECONDS, ADVANCE BY 10 SECONDS)
```
* Session window:
```
WINDOW SESSION (60 SECONDS)
```
* Tumbling window:
```
WINDOW TUMBLING (SIZE 5 MINUTES)
```

See the syntax reference [here](https://docs.confluent.io/current/ksql/docs/developer-guide/syntax-reference.html#create-stream-as-select).

This PR adds support for KSQL `WINDOW`.
