### PR TITLE
Support default mode in full text search

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/FullTextSearch.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/FullTextSearch.java
@@ -69,6 +69,8 @@ public class FullTextSearch extends ASTNodeAccessImpl implements Expression {
                 columnsListCommaSeperated += ",";
             }
         }
-        return "MATCH (" + columnsListCommaSeperated + ") AGAINST (" + this._againstValue + " " + this._searchModifier + ")";
+
+        return "MATCH (" + columnsListCommaSeperated + ") AGAINST (" + this._againstValue +
+                (this._searchModifier != null ? " " + this._searchModifier : "") + ")";
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -215,7 +215,8 @@ public class ExpressionDeParser implements ExpressionVisitor, ItemsListVisitor {
                 columnsListCommaSeperated += ",";
             }
         }
-        buffer.append("MATCH (" + columnsListCommaSeperated + ") AGAINST (" + fullTextSearch.getAgainstValue() + " " + fullTextSearch.getSearchModifier() + ")");
+        buffer.append("MATCH (" + columnsListCommaSeperated + ") AGAINST (" + fullTextSearch.getAgainstValue() +
+                (fullTextSearch.getSearchModifier() != null ? " " + fullTextSearch.getSearchModifier() : "") + ")");
     }
 
     @Override

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3239,13 +3239,15 @@ FullTextSearch FullTextSearch() : {
 {
     <K_MATCH> "(" col=Column() { matchedColumns.add(col); } ("," col=Column() { matchedColumns.add(col); } )* ")" <K_AGAINST>
     "(" againstValue=<S_CHAR_LITERAL> { fs.setAgainstValue(new StringValue(againstValue.image)); }
-        (
-            searchModifier="IN NATURAL LANGUAGE MODE"
-            | searchModifier="IN NATURAL LANGUAGE MODE WITH QUERY EXPANSION"
-            | searchModifier="IN BOOLEAN MODE"
-            | searchModifier="WITH QUERY EXPANSION"
-        )
-        { fs.setSearchModifier(searchModifier.image); }
+        [
+            (
+                searchModifier="IN NATURAL LANGUAGE MODE"
+                | searchModifier="IN NATURAL LANGUAGE MODE WITH QUERY EXPANSION"
+                | searchModifier="IN BOOLEAN MODE"
+                | searchModifier="WITH QUERY EXPANSION"
+            )
+            { fs.setSearchModifier(searchModifier.image); }
+        ]
     ")"
     {
         fs.setMatchColumns(matchedColumns);

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -1865,6 +1865,12 @@ public class SelectTest {
     }
 
     @Test
+    public void testFullTextSearchInDefaultMode() throws JSQLParserException {
+        String statement = "SELECT col FROM tbl WHERE MATCH (col1,col2,col3) AGAINST ('test') ORDER BY col";
+        assertSqlCanBeParsedAndDeparsed(statement);
+    }
+
+    @Test
     public void testIsTrue() throws JSQLParserException {
         String statement = "SELECT col FROM tbl WHERE col IS TRUE";
         assertSqlCanBeParsedAndDeparsed(statement);


### PR DESCRIPTION
Adding support for the default mode for full text search (without explicitly choosing the mode in the AGAINST clause).

Explicit mode example:
`SELECT col FROM tbl WHERE MATCH (col1,col2,col3) AGAINST ('test' IN NATURAL LANGUAGE MODE)`
Default mode usage example:
`SELECT col FROM tbl WHERE MATCH (col1,col2,col3) AGAINST ('test')`
