### PR TITLE
Add support for columns in INTERVAL expressions

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2955,13 +2955,20 @@ JsonExpression JsonExpression() : {
 
 IntervalExpression IntervalExpression() : {
     IntervalExpression interval;
+    Column col;
     Token token;
     boolean signed = false;
 }
 {
     { interval = new IntervalExpression(); }
-    <K_INTERVAL> ["-" {signed=true;}] (token=<S_LONG> | token=<S_DOUBLE> | token=<S_CHAR_LITERAL> ) 
-    { interval.setParameter((signed?"-":"") + token.image); }
+    <K_INTERVAL> ["-" {signed=true;}]
+    (
+        ((token=<S_LONG> | token=<S_DOUBLE> | token=<S_CHAR_LITERAL> )
+        { interval.setParameter((signed?"-":"") + token.image); })
+        |
+        (col=Column()
+        { interval.setExpression(col); })
+    )
     [ LOOKAHEAD(2) (token = <S_IDENTIFIER> | token = <K_DATE_LITERAL>) { interval.setIntervalType(token.image); } ]
     {
         return interval;

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -2178,6 +2178,12 @@ public class SelectTest {
     }
 
     @Test
+    public void testIntervalWithColumn() throws JSQLParserException {
+        String stmt = "SELECT DATE_ADD(start_date, INTERVAL duration MINUTE) AS end_datetime FROM appointment";
+        assertSqlCanBeParsedAndDeparsed(stmt);
+    }
+
+    @Test
     public void testInterval1() throws JSQLParserException {
         String stmt = "SELECT 5 + INTERVAL '3 days'";
         assertSqlCanBeParsedAndDeparsed(stmt);


### PR DESCRIPTION
Expressions such as `INTERVAL <column> DAY` weren't supported this far, because of the `<column>` part. This pull request adds support for such expressions.
Query sample:
`SELECT DATE_ADD(start_date, INTERVAL duration MINUTE) AS end_datetime FROM appointment`