### PR TITLE
When calling toString on subjoin with joins, the result is not as expected

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -195,7 +195,7 @@ public class Join extends ASTNodeAccessImpl {
         if (isSimple() && isOuter()) {
             return "OUTER " + rightItem;
         } else if (isSimple()) {
-            return "" + rightItem;
+            return ", " + rightItem;
         } else {
             String type = "";
 

--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -195,7 +195,7 @@ public class Join extends ASTNodeAccessImpl {
         if (isSimple() && isOuter()) {
             return "OUTER " + rightItem;
         } else if (isSimple()) {
-            return ", " + rightItem;
+            return "" + rightItem;
         } else {
             String type = "";
 

--- a/src/main/java/net/sf/jsqlparser/statement/select/SubJoin.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/SubJoin.java
@@ -65,7 +65,11 @@ public class SubJoin implements FromItem {
         StringBuilder sb = new StringBuilder();
         sb.append("(").append(left);
         for (Join j : joinList) {
-            sb.append(j.isSimple() ? "" : " ").append(j);
+            if (j.isSimple()) {
+                sb.append(", ").append(j);
+            } else {
+                sb.append(" ").append(j);
+            }
         }
 
         sb.append(")").append((alias != null) ? (" " + alias.toString()) : "").append((pivot != null) ? " " + pivot : "");

--- a/src/main/java/net/sf/jsqlparser/statement/select/SubJoin.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/SubJoin.java
@@ -65,7 +65,7 @@ public class SubJoin implements FromItem {
         StringBuilder sb = new StringBuilder();
         sb.append("(").append(left);
         for (Join j : joinList) {
-            sb.append(" ").append(j);
+            sb.append(j.isSimple() ? "" : " ").append(j);
         }
 
         sb.append(")").append((alias != null) ? (" " + alias.toString()) : "").append((pivot != null) ? " " + pivot : "");

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -2011,7 +2011,7 @@ public class SelectTest {
 
     @Test
     public void testSubjoinWithJoins() throws JSQLParserException {
-        String stmt = "SELECT COUNT(DISTINCT `webProduct`.`id`) FROM (`webProduct`, `base`, `protectedBase`)";
+        String stmt = "SELECT COUNT(DISTINCT `tbl1`.`id`) FROM (`tbl1`, `tbl2`, `tbl3`)";
         assertSqlCanBeParsedAndDeparsed(stmt);
     }
 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -2010,6 +2010,12 @@ public class SelectTest {
     }
 
     @Test
+    public void testSubjoinWithJoins() throws JSQLParserException {
+        String stmt = "SELECT COUNT(DISTINCT `webProduct`.`id`) FROM (`webProduct`, `base`, `protectedBase`)";
+        assertSqlCanBeParsedAndDeparsed(stmt);
+    }
+
+    @Test
     public void testWithUnionProblem() throws JSQLParserException {
         String stmt = "WITH test AS ((SELECT mslink FROM tablea) UNION (SELECT mslink FROM tableb)) SELECT * FROM tablea WHERE mslink IN (SELECT mslink FROM test)";
         assertSqlCanBeParsedAndDeparsed(stmt);


### PR DESCRIPTION
For this query:
`SELECT COUNT(DISTINCT `tbl1`.`id`) FROM (`tbl1`, `tbl2`, `tbl3`)`
When parsing and deparsing, the output is:
`SELECT COUNT(DISTINCT `tbl1`.`id`) FROM (`tbl1` `tbl2` `tbl3`)`
Note the missing commas between the table names in the FROM clause.

This pull request fixes that issue.