### PR TITLE
Adding support for STRAIGHT_JOIN in the select clause

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
@@ -35,6 +35,7 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
     private Fetch fetch;
     private OptimizeFor optimizeFor;
     private Skip skip;
+    private boolean straightJoin;
     private First first;
     private Top top;
     private OracleHierarchicalExpression oracleHierarchical = null;
@@ -170,6 +171,14 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
         this.skip = skip;
     }
 
+    public boolean getStraightJoin() {
+        return this.straightJoin;
+    }
+
+    public void setStraightJoin(boolean straightJoin) {
+        this.straightJoin = straightJoin;
+    }
+
     public First getFirst() {
         return first;
     }
@@ -296,6 +305,10 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
             sql.append("(");
         }
         sql.append("SELECT ");
+
+        if (this.straightJoin) {
+            sql.append("STRAIGHT_JOIN ");
+        }
 
         if (oracleHint != null) {
             sql.append(oracleHint).append(" ");

--- a/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
@@ -35,7 +35,7 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
     private Fetch fetch;
     private OptimizeFor optimizeFor;
     private Skip skip;
-    private boolean straightJoin;
+    private boolean mySqlHintStraightJoin;
     private First first;
     private Top top;
     private OracleHierarchicalExpression oracleHierarchical = null;
@@ -171,12 +171,12 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
         this.skip = skip;
     }
 
-    public boolean getStraightJoin() {
-        return this.straightJoin;
+    public boolean getMySqlHintStraightJoin() {
+        return this.mySqlHintStraightJoin;
     }
 
-    public void setStraightJoin(boolean straightJoin) {
-        this.straightJoin = straightJoin;
+    public void setMySqlHintStraightJoin(boolean mySqlHintStraightJoin) {
+        this.mySqlHintStraightJoin = mySqlHintStraightJoin;
     }
 
     public First getFirst() {
@@ -306,7 +306,7 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
         }
         sql.append("SELECT ");
 
-        if (this.straightJoin) {
+        if (this.mySqlHintStraightJoin) {
             sql.append("STRAIGHT_JOIN ");
         }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -36,6 +36,10 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
         }
         buffer.append("SELECT ");
 
+        if (plainSelect.getStraightJoin()) {
+            buffer.append("STRAIGHT_JOIN ");
+        }
+
         OracleHint hint = plainSelect.getOracleHint();
         if (hint != null) {
             buffer.append(hint).append(" ");

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -36,7 +36,7 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
         }
         buffer.append("SELECT ");
 
-        if (plainSelect.getStraightJoin()) {
+        if (plainSelect.getMySqlHintStraightJoin()) {
             buffer.append("STRAIGHT_JOIN ");
         }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1277,6 +1277,8 @@ PlainSelect PlainSelect() #PlainSelect:
 {
     <K_SELECT>
 
+    [ <K_STRAIGHT> { plainSelect.setStraightJoin(true); } ]
+
     { plainSelect.setOracleHint(getOracleHint()); }
 
     [skip = Skip() { plainSelect.setSkip(skip);    } ]

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1277,7 +1277,7 @@ PlainSelect PlainSelect() #PlainSelect:
 {
     <K_SELECT>
 
-    [ <K_STRAIGHT> { plainSelect.setStraightJoin(true); } ]
+    [ <K_STRAIGHT> { plainSelect.setMySqlHintStraightJoin(true); } ]
 
     { plainSelect.setOracleHint(getOracleHint()); }
 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -1632,6 +1632,12 @@ public class SelectTest {
     }
 
     @Test
+    public void testStraightJoinInSelect() throws JSQLParserException {
+        String stmt = "SELECT STRAIGHT_JOIN col, col2 FROM tbl INNER JOIN tbl2 ON tbl.id = tbl2.id";
+        assertSqlCanBeParsedAndDeparsed(stmt);
+    }
+
+    @Test
     public void testCastTypeProblem3() throws JSQLParserException {
         String stmt = "SELECT col1::varchar (256) FROM tabelle1";
         assertSqlCanBeParsedAndDeparsed(stmt);

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -1626,7 +1626,7 @@ public class SelectTest {
     }
 
     @Test
-    public void testStraightJoin() throws JSQLParserException {
+    public void testMySQLHintStraightJoin() throws JSQLParserException {
         String stmt = "SELECT col FROM tbl STRAIGHT_JOIN tbl2 ON tbl.id = tbl2.id";
         assertSqlCanBeParsedAndDeparsed(stmt);
     }


### PR DESCRIPTION
In MySQL, the STRAIGHT_JOIN flag can be used in both the FROM clause and the SELECT clause.
This pull request adds support for this flag in the SELECT clause.

A sample of a valid query:
`SELECT STRAIGHT_JOIN col, col2 FROM tbl INNER JOIN tbl2 ON tbl.id = tbl2.id`