### PR TITLE
Adding support for complex expressions in the ORDER BY clause

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2046,7 +2046,7 @@ OrderByElement OrderByElement():
     Expression columnReference = null;
 }
 {
-    columnReference = SimpleExpression()
+    columnReference = Expression()
     [ ( <K_ASC> | (<K_DESC> { orderByElement.setAsc(false); } )) { orderByElement.setAscDescPresent(true); }  ]
     [<K_NULLS> ( 
         <K_FIRST> { orderByElement.setNullOrdering(OrderByElement.NullOrdering.NULLS_FIRST);  }  | 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -1215,6 +1215,12 @@ public class SelectTest {
     }
 
     @Test
+    public void testOrderByWithComplexExpression() throws JSQLParserException {
+        String statement = "SELECT col FROM tbl tbl_alias ORDER BY tbl_alias.id = 1 DESC";
+        assertSqlCanBeParsedAndDeparsed(statement);
+    }
+
+    @Test
     public void testTimestamp() throws JSQLParserException {
         String statement = "SELECT * FROM tab1 WHERE a > {ts '2004-04-30 04:05:34.56'}";
         Select select = (Select) parserManager.parse(new StringReader(statement));


### PR DESCRIPTION
Some databases, such as MySQL, allow complex expressions in the ORDER BY clause. This far, such expressions (equality expressions, LIKE expression, etc.), weren't supported in the ORDER BY clause. This PR enhances the OrderByElement to support such expressions.

Sample query:
`SELECT col FROM tbl tbl_alias ORDER BY tbl_alias.id = 1 DESC`