### PR TITLE
Adding support for casting to SIGNED

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3858,7 +3858,8 @@ ColDataType ColDataType():
 		| ( tk=<S_IDENTIFIER> | tk=<K_DATETIMELITERAL> | tk=<K_DATE_LITERAL> | tk=<K_XML> | tk=<K_INTERVAL> | tk=<DT_ZONE> | tk=<K_CHAR> | tk=<K_SET> )  
 				{ colDataType.setDataType(tk.image); }
 		| tk=<K_UNSIGNED> tk2=<S_IDENTIFIER> {colDataType.setDataType(tk.image + " " + tk2.image);}
-		| tk=<K_SIGNED> tk2=<S_IDENTIFIER> {colDataType.setDataType(tk.image + " " + tk2.image);}
+		| LOOKAHEAD(2) tk=<K_SIGNED> tk2=<S_IDENTIFIER> {colDataType.setDataType(tk.image + " " + tk2.image);}
+		| tk=<K_SIGNED> { colDataType.setDataType(tk.image);}
 	)
 
     [LOOKAHEAD(2) "(" {tk2 =null;} ( (tk=<S_LONG> [ tk2=<K_BYTE> | tk2=<K_CHAR> ] | tk=<S_CHAR_LITERAL> | tk=<S_IDENTIFIER> ) 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -2944,6 +2944,11 @@ public class SelectTest {
         assertSqlCanBeParsedAndDeparsed("SELECT CAST(contact_id AS SIGNED INTEGER) FROM contact WHERE contact_id = 20");
     }
 
+    @Test
+    public void testCastToSigned() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT CAST(contact_id AS SIGNED) FROM contact WHERE contact_id = 20");
+    }
+
 //    @Test
 //    public void testWhereIssue240_notBoolean() {
 //        try {


### PR DESCRIPTION
The following wasn't supported by the parser this far, because of the "AS SIGNED" expression:
`SELECT CAST(contact_id AS SIGNED) FROM contact WHERE contact_id = 20;`

Similar expressions like `AS SIGNED INTEGER` are supported, but the parser expects a data type after the `SIGNED` keyword, which isn't mandatory according to the docs.

More examples can be seen in the documentation (search for "as SIGNED"):
https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html

