### PR TITLE
Adding support for simple expressions in INTERVAL expressions

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3095,7 +3095,7 @@ IntervalExpression IntervalExpression() : {
 {
     
 { interval = new IntervalExpression(); }
-    <K_INTERVAL> ["-" {signed=true;}] (token=<S_LONG> | token=<S_DOUBLE> | token=<S_CHAR_LITERAL> | expr = Column()) 
+    <K_INTERVAL> ["-" {signed=true;}] (token=<S_LONG> | token=<S_DOUBLE> | token=<S_CHAR_LITERAL> | expr = SimpleExpression())
     { 
         if (expr != null) {
             if (signed) expr = new SignedExpression('-', expr);

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -1310,6 +1310,11 @@ public class SelectTest {
     }
 
     @Test
+    public void testExpressionsInIntervalExpression() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT DATE_SUB(mydate, INTERVAL DAY(anotherdate) - 1 DAY) FROM tbl");
+    }
+
+    @Test
     public void testReplaceAsFunction() throws JSQLParserException {
         String statement = "SELECT REPLACE(a, 'b', c) FROM tab1";
         assertSqlCanBeParsedAndDeparsed(statement);


### PR DESCRIPTION
This far, only columns or constants were supported in an INTERVAL expression.

Now adding support for simple expressions, such as function calls and addition/subtraction expressions.
Parsing this query failed before this fix:
`SELECT DATE_SUB(mydate, INTERVAL DAY(anotherdate) - 1 DAY) FROM tbl`