### PR TITLE
#913 SQL Server variable assignment in a select does not parse | SELECT @var = 1

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/SelectExpressionItem.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/SelectExpressionItem.java
@@ -11,11 +11,13 @@ package net.sf.jsqlparser.statement.select;
 
 import net.sf.jsqlparser.expression.Alias;
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.UserVariable;
 import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
 public class SelectExpressionItem extends ASTNodeAccessImpl implements SelectItem {
 
     private Expression expression;
+    private UserVariable userVariable;
     private Alias alias;
 
     public SelectExpressionItem() {
@@ -33,6 +35,14 @@ public class SelectExpressionItem extends ASTNodeAccessImpl implements SelectIte
         return expression;
     }
 
+    public UserVariable getUserVariable() {
+        return userVariable;
+    }
+
+    public void setUserVariable(UserVariable userVariable) {
+        this.userVariable = userVariable;
+    }
+
     public void setAlias(Alias alias) {
         this.alias = alias;
     }
@@ -48,6 +58,8 @@ public class SelectExpressionItem extends ASTNodeAccessImpl implements SelectIte
 
     @Override
     public String toString() {
-        return expression + ((alias != null) ? alias.toString() : "");
+        return  (userVariable != null ? userVariable.toString() + " = " : "") +
+                expression +
+                ((alias != null) ? alias.toString() : "");
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -187,6 +187,9 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
 
     @Override
     public void visit(SelectExpressionItem selectExpressionItem) {
+        if (selectExpressionItem.getUserVariable() != null) {
+            buffer.append(selectExpressionItem.getUserVariable()).append(" = ");
+        }
         selectExpressionItem.getExpression().accept(expressionVisitor);
         if (selectExpressionItem.getAlias() != null) {
             buffer.append(selectExpressionItem.getAlias().toString());

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1449,10 +1449,16 @@ SelectExpressionItem SelectExpressionItem():
 {
     SelectExpressionItem selectExpressionItem = null;
     Expression expression = null;
+    UserVariable userVariable = null;
     Alias alias = null;
 }
 {
-     expression=SimpleExpression() { selectExpressionItem = new SelectExpressionItem(); selectExpressionItem.setExpression(expression); }
+     [LOOKAHEAD(3) userVariable=UserVariable() "="]
+     expression=SimpleExpression() {
+         selectExpressionItem = new SelectExpressionItem();
+         selectExpressionItem.setExpression(expression);
+         selectExpressionItem.setUserVariable(userVariable);
+     }
              [alias=Alias() { selectExpressionItem.setAlias(alias); }] { return selectExpressionItem; }
 }
 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -3984,6 +3984,11 @@ public class SelectTest {
 
     @Test
     public void testSqlServerAssignVariableIssue913() throws JSQLParserException {
-        assertSqlCanBeParsedAndDeparsed("SELECT @var = 1");
+        final String statement = "SELECT @var = 1";
+        assertSqlCanBeParsedAndDeparsed(statement);
+        Select select = (Select) CCJSqlParserUtil.parse(statement);
+        final SelectExpressionItem selectExpressionItem = (SelectExpressionItem) ((PlainSelect) select.getSelectBody()).getSelectItems().get(0);
+        assertEquals("1", ((LongValue) selectExpressionItem.getExpression()).getStringValue());
+        assertEquals("var", selectExpressionItem.getUserVariable().getName());
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -3981,4 +3981,9 @@ public class SelectTest {
                 .extracting(item -> item.toString())
                 .contains("col");
     }
+
+    @Test
+    public void testSqlServerAssignVariableIssue913() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT @var = 1");
+    }
 }


### PR DESCRIPTION
This fixes #913 but breaks SelectTest.testMultiPartNamesIssue608().
Unfortunately, I don't know JavaCC enough to fix both.

My test works: `SELECT @var = 1`
but it breaks `SELECT @@sessions.tx_read_only`