### PR TITLE
#915 SQL Server hints are not supported

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/SqlServerTableHint.java
+++ b/src/main/java/net/sf/jsqlparser/expression/SqlServerTableHint.java
@@ -1,0 +1,68 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+/**
+ * Example:
+ * <code>SELECT 1 FROM tableName1 AS t1 WITH (INDEX (idx1), NOLOCK) JOIN tableName2 AS t2 WITH (INDEX (idx2)) ON t1.id = t2.id</code>
+ */
+public class SqlServerTableHint {
+    private SqlServerTableHintType hintType;
+    private String indexName;
+
+    public SqlServerTableHint(SqlServerTableHintType hintType, String indexName) {
+        this.hintType = hintType;
+        this.indexName = indexName;
+    }
+
+    public static SqlServerTableHint createIndexHint(SqlServerTableHintType hintType, String indexName) {
+        return new SqlServerTableHint(hintType, indexName);
+    }
+
+    public static SqlServerTableHint createHint(String hintType) {
+        return new SqlServerTableHint(SqlServerTableHintType.valueOf(hintType), null);
+    }
+
+    public static SqlServerTableHint createHint(SqlServerTableHintType hintType) {
+        return new SqlServerTableHint(hintType, null);
+    }
+
+    public SqlServerTableHintType getHintType() {
+        return hintType;
+    }
+
+    public void setHintType(SqlServerTableHintType hintType) {
+        this.hintType = hintType;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public void setIndexName(String indexName) {
+        this.indexName = indexName;
+    }
+
+    @Override
+    public String toString() {
+        return hintType +
+                (indexName == null ? "" : "(" + indexName + ")");
+    }
+
+    public static String toString(Collection<SqlServerTableHint> hints) {
+        if (hints == null) {
+            return "";
+        }
+        return " WITH (" + hints.stream().map(SqlServerTableHint::toString).collect(Collectors.joining(", ")) + ")";
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/expression/SqlServerTableHintType.java
+++ b/src/main/java/net/sf/jsqlparser/expression/SqlServerTableHintType.java
@@ -1,0 +1,37 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+public enum SqlServerTableHintType {
+    INDEX,
+    FORCESEEK,
+    FORCESCAN,
+    SPATIAL_WINDOW_MAX_CELLS,
+    HOLDLOCK,
+    NOLOCK,
+    NOWAIT,
+    PAGLOCK,
+    READCOMMITTED,
+    READCOMMITTEDLOCK,
+    READPAST,
+    READUNCOMMITTED,
+    REPEATABLEREAD,
+    ROWLOCK,
+    SERIALIZABLE,
+    SNAPSHOT,
+    TABLOCK,
+    TABLOCKX,
+    UPDLOCK,
+    XLOCK,
+    KEEPIDENTITY,
+    KEEPDEFAULTS,
+    IGNORE_CONSTRAINTS,
+    IGNORE_TRIGGERS,
+}

--- a/src/main/java/net/sf/jsqlparser/schema/Table.java
+++ b/src/main/java/net/sf/jsqlparser/schema/Table.java
@@ -35,6 +35,7 @@ public class Table extends ASTNodeAccessImpl implements FromItem, MultiPartName 
     private Pivot pivot;
     private UnPivot unpivot;
     private MySQLIndexHint hint;
+    private List<SqlServerTableHint> sqlServerTableHints;
 
     public Table() {
     }
@@ -167,12 +168,21 @@ public class Table extends ASTNodeAccessImpl implements FromItem, MultiPartName 
         this.hint = hint;
     }
 
+    public List<SqlServerTableHint> getSqlServerHints() {
+        return sqlServerTableHints;
+    }
+
+    public void setSqlServerHints(List<SqlServerTableHint> sqlServerTableHints) {
+        this.sqlServerTableHints = sqlServerTableHints;
+    }
+
     @Override
     public String toString() {
         return getFullyQualifiedName()
                 + ((alias != null) ? alias.toString() : "")
                 + ((pivot != null) ? " " + pivot : "")
                 + ((unpivot != null) ? " " + unpivot : "")
-                + ((hint != null) ? hint.toString() : "");
+                + ((hint != null) ? hint.toString() : "")
+                + ((sqlServerTableHints != null) ? SqlServerTableHint.toString(sqlServerTableHints) : "");
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -238,6 +238,10 @@ public class SelectDeParser implements SelectVisitor, SelectItemVisitor, FromIte
         if (indexHint != null) {
             buffer.append(indexHint);
         }
+        List<SqlServerTableHint> sqlServerHints = tableName.getSqlServerHints();
+        if (sqlServerHints != null) {
+            buffer.append(SqlServerTableHint.toString(sqlServerHints));
+        }
     }
 
     @Override

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1528,6 +1528,38 @@ MySQLIndexHint MySQLIndexHint():
 	}
 }
 
+List<SqlServerTableHint> SqlServerTableHints():
+{
+    SqlServerTableHint sqlServerTableHint = null;
+    List<SqlServerTableHint> sqlServerTableHints = new ArrayList();
+}
+{
+    <K_WITH> "("
+  	sqlServerTableHint = SqlServerTableHint() { sqlServerTableHints.add(sqlServerTableHint); }
+  	("," sqlServerTableHint = SqlServerTableHint() { sqlServerTableHints.add(sqlServerTableHint); })*
+    ")"
+    {
+        return sqlServerTableHints;
+    }
+}
+
+SqlServerTableHint SqlServerTableHint():
+{
+    String indexType= null;
+    String indexName= null;
+	SqlServerTableHint sqlServerTableHint = null;
+}
+{
+    (
+        <K_INDEX> "(" indexName = Identifier() {sqlServerTableHint = SqlServerTableHint.createIndexHint(SqlServerTableHintType.INDEX, indexName);} ")"
+        |
+        indexType = Identifier() {sqlServerTableHint = SqlServerTableHint.createHint(indexType);}
+    )
+    {
+        return sqlServerTableHint;
+    }
+}
+
 String Identifier():
 {
 	Token tk = null;
@@ -1715,6 +1747,7 @@ FromItem FromItem():
     UnPivot unpivot = null;
     Alias alias = null;
     MySQLIndexHint indexHint = null;
+    List<SqlServerTableHint> sqlServerTableHints = null;
 }
 {
     (
@@ -1753,6 +1786,12 @@ FromItem FromItem():
                 indexHint=MySQLIndexHint() {
                     if (fromItem instanceof Table)
 						((Table) fromItem).setHint(indexHint);
+                }
+                |
+                LOOKAHEAD(3)
+                sqlServerTableHints=SqlServerTableHints() {
+                    if (fromItem instanceof Table)
+						((Table) fromItem).setSqlServerHints(sqlServerTableHints);
                 }
             ]
         )


### PR DESCRIPTION
Added support for table hints but it breaks testCreateWithReadOnlyViewIssue838.
The conflict comes from the WITH I have introduced in the FromItem:
`SELECT 1 FROM tableName1 WITH (INDEX (idx1))`
`CREATE VIEW v(c) AS SELECT c FROM t WITH READ ONLY`

I have no experience in JavaCC, could you please guide me in solving the regression?