### PR TITLE
Add support for expressions in case

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/CaseExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/CaseExpression.java
@@ -40,6 +40,7 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
  */
 public class CaseExpression extends ASTNodeAccessImpl implements Expression {
 
+    private Expression caseExpression;
     private Expression switchExpression;
     private List<WhenClause> whenClauses;
     private Expression elseExpression;
@@ -55,6 +56,14 @@ public class CaseExpression extends ASTNodeAccessImpl implements Expression {
 
     public void setSwitchExpression(Expression switchExpression) {
         this.switchExpression = switchExpression;
+    }
+
+    public Expression getCaseExpression() {
+        return caseExpression;
+    }
+
+    public void setCaseExpression(Expression caseExpression) {
+        this.caseExpression = caseExpression;
     }
 
     /**
@@ -87,7 +96,8 @@ public class CaseExpression extends ASTNodeAccessImpl implements Expression {
 
     @Override
     public String toString() {
-        return "CASE " + ((switchExpression != null) ? switchExpression + " " : "")
+        return "CASE " + ((caseExpression != null) ? caseExpression + " " : "") +
+                ((switchExpression != null) ? switchExpression + " " : "")
                 + PlainSelect.getStringList(whenClauses, false, false) + " "
                 + ((elseExpression != null) ? "ELSE " + elseExpression + " " : "") + "END";
     }

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -232,6 +232,9 @@ public class ExpressionVisitorAdapter implements ExpressionVisitor, ItemsListVis
 
     @Override
     public void visit(CaseExpression expr) {
+        if (expr.getCaseExpression() != null) {
+            expr.getCaseExpression().accept(this);
+        }
         if (expr.getSwitchExpression() != null) {
             expr.getSwitchExpression().accept(this);
         }

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -409,6 +409,9 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
      */
     @Override
     public void visit(CaseExpression caseExpression) {
+        if (caseExpression.getCaseExpression() != null) {
+            caseExpression.getCaseExpression().accept(this);
+        }
         if (caseExpression.getSwitchExpression() != null) {
             caseExpression.getSwitchExpression().accept(this);
         }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -519,6 +519,13 @@ public class ExpressionDeParser implements ExpressionVisitor, ItemsListVisitor {
     @Override
     public void visit(CaseExpression caseExpression) {
         buffer.append("CASE ");
+
+        Expression caseExp = caseExpression.getCaseExpression();
+        if (caseExp != null) {
+            caseExp.accept(this);
+            buffer.append(" ");
+        }
+
         Expression switchExp = caseExpression.getSwitchExpression();
         if (switchExp != null) {
             switchExp.accept(this);

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3271,12 +3271,13 @@ Expression CaseWhenExpression() #CaseWhenExpression:
 {
     CaseExpression caseExp = new CaseExpression();
     Expression switchExp = null;
+    Expression caseExpr = null;
     WhenClause clause;
     List<WhenClause> whenClauses = new ArrayList<WhenClause>();
     Expression elseExp = null;
 }
 {
-    <K_CASE>
+    <K_CASE> [ (LOOKAHEAD(Expression()) caseExpr=Expression() | caseExpr=SimpleExpression()) ]
     (
             ( clause=WhenThenSearchCondition() { whenClauses.add(clause); } )+
         |
@@ -3286,6 +3287,7 @@ Expression CaseWhenExpression() #CaseWhenExpression:
    [<K_ELSE> elseExp=Condition()]
     <K_END>
     {
+        caseExp.setCaseExpression(caseExpr);
         caseExp.setSwitchExpression(switchExp);
         caseExp.setWhenClauses(whenClauses);
         caseExp.setElseExpression(elseExp);

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -1310,6 +1310,11 @@ public class SelectTest {
     }
 
     @Test
+    public void testExpressionsInCaseBeforeWhen() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT a FROM tbl1 LEFT JOIN tbl2 ON CASE tbl1.col1 WHEN tbl1.col1 = 1 THEN tbl1.col2 = tbl2.col2 ELSE tbl1.col3 = tbl2.col3 END");
+    }
+
+    @Test
     public void testReplaceAsFunction() throws JSQLParserException {
         String statement = "SELECT REPLACE(a, 'b', c) FROM tab1";
         assertSqlCanBeParsedAndDeparsed(statement);


### PR DESCRIPTION
MySQL supports expressions in CASE statements before the WHEN clause.
Example: `CASE <expr> WHEN ....`

The expression after the CASE keyword is optional.
This PR adds support for such expressions, in case they exist in the query.

Relevant docs for both options: https://dev.mysql.com/doc/refman/5.7/en/case.html