### PR TITLE
Support ALTER SEQUENCE 

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitor.java
@@ -10,6 +10,7 @@
 package net.sf.jsqlparser.statement;
 
 import net.sf.jsqlparser.statement.alter.Alter;
+import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.comment.Comment;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.schema.CreateSchema;
@@ -91,4 +92,6 @@ public interface StatementVisitor {
     void visit(Grant grant);
 
     void visit(CreateSequence createSequence);
+
+    void visit(AlterSequence alterSequence);
 }

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
@@ -10,6 +10,7 @@
 package net.sf.jsqlparser.statement;
 
 import net.sf.jsqlparser.statement.alter.Alter;
+import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.comment.Comment;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.schema.CreateSchema;
@@ -169,5 +170,9 @@ public class StatementVisitorAdapter implements StatementVisitor {
 
     @Override
     public void visit(CreateSequence createSequence) {
+    }
+
+    @Override
+    public void visit(AlterSequence alterSequence) {
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/alter/sequence/AlterSequence.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/sequence/AlterSequence.java
@@ -1,0 +1,42 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2020 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.alter.sequence;
+
+import net.sf.jsqlparser.schema.Sequence;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.StatementVisitor;
+
+/**
+ * An {@code ALTER SEQUENCE} statement
+ */
+public class AlterSequence implements Statement {
+
+    public Sequence sequence;
+
+    public void setSequence(Sequence sequence) {
+        this.sequence = sequence;
+    }
+
+    public Sequence getSequence() {
+        return sequence;
+    }
+
+    @Override
+    public void accept(StatementVisitor statementVisitor) {
+        statementVisitor.visit(this);
+    }
+
+    @Override
+    public String toString() {
+        String sql;
+        sql = "ALTER SEQUENCE " + sequence;
+        return sql;
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -878,9 +878,11 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
 
     @Override
     public void visit(CreateSequence createSequence) {
+        throw new UnsupportedOperationException("Finding tables from CreateSequence is not supported");
     }
 
     @Override
     public void visit(AlterSequence alterSequence) {
+        throw new UnsupportedOperationException("Finding tables from AlterSequence is not supported");
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -69,6 +69,7 @@ import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.Statements;
 import net.sf.jsqlparser.statement.UseStatement;
 import net.sf.jsqlparser.statement.alter.Alter;
+import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.comment.Comment;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.schema.CreateSchema;
@@ -877,6 +878,9 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
 
     @Override
     public void visit(CreateSequence createSequence) {
+    }
 
+    @Override
+    public void visit(AlterSequence alterSequence) {
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/AbstractDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/AbstractDeParser.java
@@ -1,0 +1,28 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2020 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.util.deparser;
+
+/**
+ * A base for a Statement DeParser
+ * @param <S> the type of statement this DeParser supports
+ */
+abstract class AbstractDeParser<S> {
+    protected StringBuilder buffer;
+
+    protected AbstractDeParser(StringBuilder buffer) {
+        this.buffer = buffer;
+    }
+
+    /**
+     * DeParses the given statement into the buffer
+     * @param statement the statement to deparse
+     */
+    abstract void deParse(S statement);
+}

--- a/src/main/java/net/sf/jsqlparser/util/deparser/AlterSequenceDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/AlterSequenceDeParser.java
@@ -1,0 +1,32 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2020 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.util.deparser;
+
+import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
+
+/**
+ * A class to de-parse (that is, transform from JSqlParser hierarchy into a string) a
+ * {@link net.sf.jsqlparser.statement.alter.sequence.AlterSequence}
+ */
+public class AlterSequenceDeParser extends AbstractDeParser<AlterSequence> {
+
+    /**
+     * @param buffer the buffer that will be filled with the AlterSequence
+     */
+    public AlterSequenceDeParser(StringBuilder buffer) {
+        super(buffer);
+    }
+
+    @Override
+    public void deParse(AlterSequence statement) {
+        buffer.append("ALTER SEQUENCE ");
+        buffer.append(statement.getSequence());
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/deparser/CreateSequenceDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/CreateSequenceDeParser.java
@@ -15,19 +15,18 @@ import net.sf.jsqlparser.statement.create.sequence.CreateSequence;
  * A class to de-parse (that is, transform from JSqlParser hierarchy into a string) a
  * {@link net.sf.jsqlparser.statement.create.sequence.CreateSequence}
  */
-public class CreateSequenceDeParser {
-
-    private StringBuilder buffer;
+public class CreateSequenceDeParser extends AbstractDeParser<CreateSequence>{
 
     /**
-     * @param buffer the buffer that will be filled with the select
+     * @param buffer the buffer that will be filled with the CreatSequence
      */
     public CreateSequenceDeParser(StringBuilder buffer) {
-        this.buffer = buffer;
+        super(buffer);
     }
 
-    public void deParse(CreateSequence createSequence) {
+    @Override
+    public void deParse(CreateSequence statement) {
         buffer.append("CREATE SEQUENCE ");
-        buffer.append(createSequence.getSequence());
+        buffer.append(statement.getSequence());
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -23,6 +23,7 @@ import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.Statements;
 import net.sf.jsqlparser.statement.UseStatement;
 import net.sf.jsqlparser.statement.alter.Alter;
+import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.comment.Comment;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.schema.CreateSchema;
@@ -292,5 +293,10 @@ public class StatementDeParser implements StatementVisitor {
     @Override
     public void visit(CreateSequence createSequence) {
         new CreateSequenceDeParser(buffer).deParse(createSequence);
+    }
+
+    @Override
+    public void visit(AlterSequence alterSequence) {
+        new AlterSequenceDeParser(buffer).deParse(alterSequence);
     }
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -37,6 +37,7 @@ import net.sf.jsqlparser.expression.operators.relational.*;
 import net.sf.jsqlparser.schema.*;
 import net.sf.jsqlparser.statement.*;
 import net.sf.jsqlparser.statement.alter.*;
+import net.sf.jsqlparser.statement.alter.sequence.*;
 import net.sf.jsqlparser.statement.comment.*;
 import net.sf.jsqlparser.statement.create.index.*;
 import net.sf.jsqlparser.statement.create.schema.*;
@@ -464,7 +465,11 @@ Statement SingleStatement() :
         LOOKAHEAD(CreateView())
         stm = CreateView()
         |
+        LOOKAHEAD(AlterView())
         stm = AlterView()
+        |
+        LOOKAHEAD(AlterSequence())
+        stm = AlterSequence()
         |
         stm = Drop()
         |
@@ -4681,7 +4686,6 @@ Sequence Sequence() #Sequence :
 }
 {
     data = RelObjectNameList()
-
     {
         Sequence sequence = new Sequence(data);
 		linkAST(sequence,jjtThis);
@@ -4689,18 +4693,14 @@ Sequence Sequence() #Sequence :
     }
 }
 
-CreateSequence CreateSequence():
+List<Sequence.Parameter> SequenceParameters():
 {
-  CreateSequence createSequence = new CreateSequence();
-  Sequence sequence;
   List<Sequence.Parameter> sequenceParameters = new ArrayList<Sequence.Parameter>();
   Sequence.Parameter parameter = null;
   Token token = null;
 }
 {
-  <K_CREATE>
-  <K_SEQUENCE> sequence=Sequence() { createSequence.setSequence(sequence); }
-  (
+(
    (<K_INCREMENT> <K_BY> token=<S_LONG>
     {
         parameter = new Sequence.Parameter(Sequence.ParameterType.INCREMENT_BY);
@@ -4773,7 +4773,36 @@ CreateSequence CreateSequence():
    )
   )* //zero or many times those productions
   {
-    sequence.setParameters(sequenceParameters);
+    return sequenceParameters;
+  }
+}
+
+CreateSequence CreateSequence():
+{
+  CreateSequence createSequence = new CreateSequence();
+  Sequence sequence;
+  List<Sequence.Parameter> sequenceParameters;
+}
+{
+  <K_CREATE>
+  <K_SEQUENCE> sequence=Sequence() { createSequence.setSequence(sequence); }
+  sequenceParameters = SequenceParameters() { sequence.setParameters(sequenceParameters); }
+  {
     return createSequence;
+  }
+}
+
+AlterSequence AlterSequence():
+{
+  AlterSequence alterSequence = new AlterSequence();
+  Sequence sequence;
+  List<Sequence.Parameter> sequenceParameters;
+}
+{
+  <K_ALTER>
+  <K_SEQUENCE> sequence=Sequence() { alterSequence.setSequence(sequence); }
+  sequenceParameters = SequenceParameters() { sequence.setParameters(sequenceParameters); }
+  {
+    return alterSequence;
   }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterSequenceTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterSequenceTest.java
@@ -1,0 +1,114 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2020 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.alter;
+
+import net.sf.jsqlparser.JSQLParserException;
+import org.junit.Test;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+
+public class AlterSequenceTest {
+
+    @Test
+    public void testAlterSequence_noParams() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq");
+    }
+
+    @Test
+    public void testAlterSequence_withIncrement() throws JSQLParserException{
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq INCREMENT BY 1");
+    }
+
+    @Test
+    public void testAlterSequence_withStart() throws JSQLParserException{
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq START WITH 10");
+    }
+
+    @Test
+    public void testAlterSequence_withMaxValue() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq MAXVALUE 5");
+    }
+
+    @Test
+    public void testAlterSequence_withNoMaxValue() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq NOMAXVALUE");
+    }
+
+    @Test
+    public void testAlterSequence_withMinValue() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq MINVALUE 5");
+    }
+
+    @Test
+    public void testAlterSequence_withNoMinValue() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq NOMINVALUE");
+    }
+
+    @Test
+    public void testAlterSequence_withCycle() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq CYCLE");
+    }
+
+    @Test
+    public void testAlterSequence_withNoCycle() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq NOCYCLE");
+    }
+
+    @Test
+    public void testAlterSequence_withCache() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq CACHE 10");
+    }
+
+    @Test
+    public void testAlterSequence_withNoCache() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq NOCACHE");
+    }
+
+    @Test
+    public void testAlterSequence_withOrder() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq ORDER");
+    }
+
+    @Test
+    public void testAlterSequence_withNoOrder() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq NOORDER");
+    }
+
+    @Test
+    public void testAlterSequence_withKeep() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq KEEP");
+    }
+
+    @Test
+    public void testAlterSequence_withNoKeep() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq NOKEEP");
+    }
+
+    @Test
+    public void testAlterSequence_withSession() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq SESSION");
+    }
+
+    @Test
+    public void testAlterSequence_withGlobal() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_seq GLOBAL");
+    }
+
+    /**
+     * Verifies that we declare the parameter options in the order we found them
+     */
+    @Test
+    public void testAlterSequence_preservesParamOrder() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_sec INCREMENT BY 2 START WITH 10");
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_sec START WITH 2 INCREMENT BY 5 NOCACHE");
+        assertSqlCanBeParsedAndDeparsed("ALTER SEQUENCE my_sec START WITH 2 INCREMENT BY 5 CACHE 200 CYCLE");
+    }
+
+}

--- a/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
@@ -9,11 +9,6 @@
  */
 package net.sf.jsqlparser.util;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.io.StringReader;
-import java.util.Iterator;
-import java.util.List;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.OracleHint;
@@ -34,8 +29,16 @@ import net.sf.jsqlparser.statement.simpleparsing.CCJSqlParserManagerTest;
 import net.sf.jsqlparser.statement.update.Update;
 import net.sf.jsqlparser.statement.upsert.Upsert;
 import net.sf.jsqlparser.test.TestException;
-import static org.junit.Assert.*;
 import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.*;
 
 public class TablesNamesFinderTest {
 
@@ -593,5 +596,23 @@ public class TablesNamesFinderTest {
         List<String> tableList = tablesNamesFinder.getTableList(stmt);
         assertEquals(1, tableList.size());
         assertTrue(tableList.contains("table1@remote"));
+    }
+
+    @Test
+    public void testCreateSequence_throwsException() throws JSQLParserException {
+        String sql = "CREATE SEQUENCE my_seq";
+        Statement stmt = CCJSqlParserUtil.parse(sql);
+        TablesNamesFinder tablesNamesFinder = new TablesNamesFinder();
+        assertThatThrownBy(() -> tablesNamesFinder.getTableList(stmt)).isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Finding tables from CreateSequence is not supported");
+    }
+
+    @Test
+    public void testAlterSequence_throwsException() throws JSQLParserException {
+        String sql = "ALTER SEQUENCE my_seq";
+        Statement stmt = CCJSqlParserUtil.parse(sql);
+        TablesNamesFinder tablesNamesFinder = new TablesNamesFinder();
+        assertThatThrownBy(() -> tablesNamesFinder.getTableList(stmt)).isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Finding tables from AlterSequence is not supported");
     }
 }


### PR DESCRIPTION
Part of #112 

Did a little refactoring mostly around the deparser (sharing a common class) and made a common production for SequenceProperties (both alter/create can use it).

Once this is merged, I'll follow up with a DROP SEQUENCE pr, and that should complete the sequences feature (at least for oracle syntax)