### PR TITLE
Minimal function/procedure support

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/CreateFunctionalStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/CreateFunctionalStatement.java
@@ -1,0 +1,75 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2020 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement;
+
+import java.util.List;
+
+/**
+ * A base for the declaration of function like statements
+ */
+public abstract class CreateFunctionalStatement implements Statement {
+
+    private String kind;
+    private List<String> functionDeclarationParts;
+
+    protected CreateFunctionalStatement(String kind, List<String> functionDeclarationParts) {
+        this.kind = kind;
+        this.functionDeclarationParts = functionDeclarationParts;
+    }
+
+    /**
+     * @return the declaration parts after {@code CREATE FUNCTION|PROCEDURE}
+     */
+    public List<String> getFunctionDeclarationParts() {
+        return functionDeclarationParts;
+    }
+
+    /**
+     * @return the kind of functional statement
+     */
+    public String getKind() {
+        return kind;
+    }
+
+    /**
+     * @return a whitespace appended String with the declaration parts with some minimal formatting.
+     */
+    public String formatDeclaration() {
+        StringBuilder declaration = new StringBuilder();
+
+        int currIndex = 0;
+        while (currIndex < functionDeclarationParts.size()) {
+            String token = functionDeclarationParts.get(currIndex);
+            declaration.append(token);
+
+            // if the next token is a ; don't put a space
+            if (currIndex + 1 < functionDeclarationParts.size()) {
+                // peek ahead just to format nicely
+                String nextToken = functionDeclarationParts.get(currIndex+1);
+                if (!nextToken.equals(";")) {
+                    declaration.append(" ");
+                }
+            }
+            currIndex++;
+        }
+
+        return declaration.toString();
+    }
+
+    @Override
+    public void accept(StatementVisitor statementVisitor) {
+        statementVisitor.visit(this);
+    }
+
+    @Override
+    public String toString() {
+        return "CREATE " + kind + " " + formatDeclaration();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitor.java
@@ -94,4 +94,6 @@ public interface StatementVisitor {
     void visit(CreateSequence createSequence);
 
     void visit(AlterSequence alterSequence);
+
+    void visit(CreateFunctionalStatement createFunctionalStatement);
 }

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
@@ -175,4 +175,8 @@ public class StatementVisitorAdapter implements StatementVisitor {
     @Override
     public void visit(AlterSequence alterSequence) {
     }
+
+    @Override
+    public void visit(CreateFunctionalStatement createFunctionalStatement) {
+    }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/create/function/CreateFunction.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/function/CreateFunction.java
@@ -1,0 +1,24 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2020 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.function;
+
+import net.sf.jsqlparser.statement.CreateFunctionalStatement;
+
+import java.util.List;
+
+/**
+ * A {@code CREATE PROCEDURE} statement
+ */
+public class CreateFunction extends CreateFunctionalStatement {
+
+    public CreateFunction(List<String> functionDeclarationParts) {
+      super("FUNCTION", functionDeclarationParts);
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/procedure/CreateProcedure.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/procedure/CreateProcedure.java
@@ -1,0 +1,25 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2020 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.procedure;
+
+import net.sf.jsqlparser.statement.CreateFunctionalStatement;
+
+import java.util.List;
+
+/**
+ * A {@code CREATE PROCEDURE} statement
+ */
+public class CreateProcedure extends CreateFunctionalStatement {
+
+    public CreateProcedure(List<String> functionDeclarationParts) {
+        super("PROCEDURE", functionDeclarationParts);
+    }
+
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -56,18 +56,7 @@ import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
 import net.sf.jsqlparser.expression.operators.relational.*;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
-import net.sf.jsqlparser.statement.Block;
-import net.sf.jsqlparser.statement.Commit;
-import net.sf.jsqlparser.statement.DeclareStatement;
-import net.sf.jsqlparser.statement.DescribeStatement;
-import net.sf.jsqlparser.statement.ExplainStatement;
-import net.sf.jsqlparser.statement.SetStatement;
-import net.sf.jsqlparser.statement.ShowColumnsStatement;
-import net.sf.jsqlparser.statement.ShowStatement;
-import net.sf.jsqlparser.statement.Statement;
-import net.sf.jsqlparser.statement.StatementVisitor;
-import net.sf.jsqlparser.statement.Statements;
-import net.sf.jsqlparser.statement.UseStatement;
+import net.sf.jsqlparser.statement.*;
 import net.sf.jsqlparser.statement.alter.Alter;
 import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.comment.Comment;
@@ -884,5 +873,10 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
     @Override
     public void visit(AlterSequence alterSequence) {
         throw new UnsupportedOperationException("Finding tables from AlterSequence is not supported");
+    }
+
+    @Override
+    public void visit(CreateFunctionalStatement createFunctionalStatement) {
+        throw new UnsupportedOperationException("Finding tables from CreateFunctionalStatement is not supported");
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -10,18 +10,8 @@
 package net.sf.jsqlparser.util.deparser;
 
 import java.util.Iterator;
-import net.sf.jsqlparser.statement.Block;
-import net.sf.jsqlparser.statement.Commit;
-import net.sf.jsqlparser.statement.DeclareStatement;
-import net.sf.jsqlparser.statement.DescribeStatement;
-import net.sf.jsqlparser.statement.ExplainStatement;
-import net.sf.jsqlparser.statement.SetStatement;
-import net.sf.jsqlparser.statement.ShowColumnsStatement;
-import net.sf.jsqlparser.statement.ShowStatement;
-import net.sf.jsqlparser.statement.Statement;
-import net.sf.jsqlparser.statement.StatementVisitor;
-import net.sf.jsqlparser.statement.Statements;
-import net.sf.jsqlparser.statement.UseStatement;
+
+import net.sf.jsqlparser.statement.*;
 import net.sf.jsqlparser.statement.alter.Alter;
 import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.comment.Comment;
@@ -298,5 +288,10 @@ public class StatementDeParser implements StatementVisitor {
     @Override
     public void visit(AlterSequence alterSequence) {
         new AlterSequenceDeParser(buffer).deParse(alterSequence);
+    }
+
+    @Override
+    public void visit(CreateFunctionalStatement createFunctionalStatement) {
+        buffer.append(createFunctionalStatement.toString());
     }
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -39,7 +39,9 @@ import net.sf.jsqlparser.statement.*;
 import net.sf.jsqlparser.statement.alter.*;
 import net.sf.jsqlparser.statement.alter.sequence.*;
 import net.sf.jsqlparser.statement.comment.*;
+import net.sf.jsqlparser.statement.create.function.*;
 import net.sf.jsqlparser.statement.create.index.*;
+import net.sf.jsqlparser.statement.create.procedure.*;
 import net.sf.jsqlparser.statement.create.schema.*;
 import net.sf.jsqlparser.statement.create.sequence.*;
 import net.sf.jsqlparser.statement.create.table.*;
@@ -195,6 +197,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_FROM:"FROM">
 |   <K_FULL:"FULL">
 |   <K_FULLTEXT:"FULLTEXT">
+|   <K_FUNCTION:"FUNCTION">
 |   <K_GLOBAL:"GLOBAL">
 |   <K_GRANT:"GRANT">
 |   <K_GROUP:"GROUP">
@@ -274,6 +277,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_PRECISION : "PRECISION">
 |   <K_PRIMARY:"PRIMARY">
 |   <K_PRIOR:"PRIOR">
+|   <K_PROCEDURE:"PROCEDURE">
 |   <K_RANGE: "RANGE">
 |   <K_READ: "READ" >
 |   <K_RECURSIVE:"RECURSIVE">
@@ -449,6 +453,9 @@ Statement SingleStatement() :
         stm = AlterTable()
         |
         stm = Merge()
+        |
+        LOOKAHEAD(CreateFunctionStatement())
+        stm = CreateFunctionStatement()
         |
         LOOKAHEAD(CreateIndex())
         stm = CreateIndex()
@@ -1218,7 +1225,7 @@ String RelObjectNameExt():
 {
     ( result=RelObjectName() | tk=<K_LEFT> | tk=<K_RIGHT> | tk=<K_SET>
         | tk=<K_DOUBLE> | tk=<K_IF> | <K_OPTIMIZE> | tk=<K_LIMIT>
-        | tk=<K_OFFSET> )
+        | tk=<K_OFFSET> | tk=<K_PROCEDURE> )
     {
         if (tk!=null) result=tk.image;
         return result;
@@ -4861,4 +4868,45 @@ AlterSequence AlterSequence():
   {
     return alterSequence;
   }
+}
+
+CreateFunctionalStatement CreateFunctionStatement():
+{
+  CreateFunctionalStatement type = null;
+  List<String> tokens = new LinkedList<String>();
+  String statementType = null;
+}
+{
+  <K_CREATE>
+  (
+   <K_FUNCTION> { statementType = "FUNCTION"; }
+   |
+   <K_PROCEDURE> { statementType = "PROCEDURE"; }
+  )
+  tokens=captureRest()
+  {
+    if(statementType.equals("FUNCTION")) {
+      type = new CreateFunction(tokens);
+    }
+    if(statementType.equals("PROCEDURE")) {
+      type = new CreateProcedure(tokens);
+    }
+
+    return type;
+  }
+}
+
+JAVACODE
+List<String> captureRest() {
+  List<String> tokens = new LinkedList<String>();
+  Token tok;
+  while(true) {
+    tok = getToken(1);
+    if(tok.kind == EOF) {
+      break;
+    }
+    tokens.add(tok.image);
+    tok = getNextToken();
+  }
+  return tokens;
 }

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateFunctionalStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateFunctionalStatementTest.java
@@ -1,0 +1,64 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2020 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.create.function.CreateFunction;
+import net.sf.jsqlparser.statement.create.procedure.CreateProcedure;
+import org.junit.Test;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the behavior of {@link net.sf.jsqlparser.statement.CreateFunctionalStatement funtion statements}
+ */
+public class CreateFunctionalStatementTest {
+
+    @Test
+    public void createFunctionMinimal() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("CREATE FUNCTION foo RETURN 5 END;");
+    }
+
+    @Test
+    public void createFunctionLong() throws JSQLParserException {
+        CreateFunction stm = (CreateFunction) CCJSqlParserUtil.parse("CREATE FUNCTION fun(query_from_time date) RETURNS TABLE(foo double precision, bar double precision)\n" +
+                "    LANGUAGE plpgsql\n" +
+                "    AS $$\n" +
+                "      BEGIN\n" +
+                "       RETURN QUERY\n" +
+                "      WITH bla AS (\n" +
+                "        SELECT * from foo)\n" +
+                "      Select * from bla;\n" +
+                "      END;\n" +
+                "      $$;");
+        assertThat(stm).isNotNull();
+        assertThat(stm.formatDeclaration()).contains("fun ( query_from_time date )");
+    }
+
+    @Test
+    public void createProcedureMinimal() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("CREATE PROCEDURE foo AS BEGIN END;");
+    }
+
+    @Test
+    public void createProcedureLong() throws JSQLParserException {
+        CreateProcedure stm = (CreateProcedure) CCJSqlParserUtil.parse("CREATE PROCEDURE remove_emp (employee_id NUMBER) AS\n" +
+                "   tot_emps NUMBER;\n" +
+                "   BEGIN\n" +
+                "      DELETE FROM employees\n" +
+                "      WHERE employees.employee_id = remove_emp.employee_id;\n" +
+                "   tot_emps := tot_emps - 1;\n" +
+                "   END;");
+        assertThat(stm).isNotNull();
+        assertThat(stm.formatDeclaration()).contains("remove_emp ( employee_id NUMBER )");
+    }
+}


### PR DESCRIPTION
Fixes #251 
Fixes #111

Provides very minimal support for function/procedure parsing, returning everything after `FUNCTION` and `PROCEDURE` as a String (or List<Strings> if desired for other formatting)