### PR TITLE
bugfix #720 #991: supporting SELECT "conditions"

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4195,7 +4195,7 @@ ColDataType ColDataType():
 		(tk=<K_CHARACTER> | tk=<K_BIT>) [tk2=<K_VARYING>] { colDataType.setDataType(tk.image + (tk2!=null?" " + tk2.image:"")); }
 		| tk=<K_DOUBLE> [LOOKAHEAD(2) tk2=<K_PRECISION>] { colDataType.setDataType(tk.image + (tk2!=null?" " + tk2.image:"")); }
 		| ( tk=<S_IDENTIFIER> | tk=<K_DATETIMELITERAL> | tk=<K_DATE_LITERAL> | tk=<K_XML> | tk=<K_INTERVAL>
-			| tk=<DT_ZONE> | tk=<K_CHAR> | tk=<K_SET> | tk=<K_BINARY> )
+			| tk=<DT_ZONE> | tk=<K_CHAR> | tk=<K_SET> | tk=<K_BINARY> | tk=<K_JSON> )
 				{ colDataType.setDataType(tk.image); }
 		| tk=<K_UNSIGNED> tk2=<S_IDENTIFIER> {colDataType.setDataType(tk.image + " " + tk2.image);}
 		| LOOKAHEAD(2) tk=<K_SIGNED> tk2=<S_IDENTIFIER> {colDataType.setDataType(tk.image + " " + tk2.image);}

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -8,8 +8,8 @@
  * #L%
  */
 
-options{
-    IGNORE_CASE = true ;
+options {
+    IGNORE_CASE = true;
     STATIC = false;
     DEBUG_PARSER = false;
     DEBUG_LOOKAHEAD = false;
@@ -970,7 +970,7 @@ List<SelectExpressionItem> ListExpressionItem():
 }
 {
    item = SelectExpressionItem() {retval.add(item);}
-   ("," item = SelectExpressionItem() {retval.add(item);} )*
+   (<K_COMMA> item = SelectExpressionItem() {retval.add(item);} )*
    { return retval; }
 }
 
@@ -1637,7 +1637,7 @@ SelectExpressionItem SelectExpressionItem():
     Alias alias = null;
 }
 {
-     expression=SimpleExpression() { selectExpressionItem = new SelectExpressionItem(); selectExpressionItem.setExpression(expression); }
+      expression=Condition() { selectExpressionItem = new SelectExpressionItem(); selectExpressionItem.setExpression(expression); }
              [alias=Alias() { selectExpressionItem.setAlias(alias); }] { return selectExpressionItem; }
 }
 
@@ -1786,9 +1786,20 @@ List<SelectExpressionItem> PivotSingleInItems():
    SelectExpressionItem item;
 }
 {
-   item = SelectExpressionItem() {retval.add(item);}
-   ("," item = SelectExpressionItem() {retval.add(item);} )*
+   item = PivotSelectExprItem() {retval.add(item);}
+   ("," item = PivotSelectExprItem() {retval.add(item);} )*
    { return retval; }
+}
+
+SelectExpressionItem PivotSelectExprItem():
+{
+    SelectExpressionItem selectExpressionItem = null;
+    Expression expression = null;
+    Alias alias = null;
+}
+{
+      expression=SimpleExpression() { selectExpressionItem = new SelectExpressionItem(); selectExpressionItem.setExpression(expression); }
+             [alias=Alias() { selectExpressionItem.setAlias(alias); }] { return selectExpressionItem; }
 }
 
 ExpressionListItem ExpressionListItem():
@@ -1958,12 +1969,12 @@ FromItem FromItem():
                 (
                     indexHint = MySQLIndexHint() {
                         if (fromItem instanceof Table)
-                                                    ((Table) fromItem).setHint(indexHint);
+                            ((Table) fromItem).setHint(indexHint);
                     }
                     |
                     sqlServerHints = SQLServerHints() {
                         if (fromItem instanceof Table)
-                                                    ((Table) fromItem).setSqlServerHints(sqlServerHints);
+                            ((Table) fromItem).setSqlServerHints(sqlServerHints);
                     }
                 )
             ]

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -21,6 +21,8 @@ import net.sf.jsqlparser.schema.*;
 import net.sf.jsqlparser.statement.*;
 import static net.sf.jsqlparser.test.TestUtils.*;
 import org.apache.commons.io.IOUtils;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -4207,5 +4209,17 @@ public class SelectTest {
     @Test
     public void testKeyWordExceptIssue1026() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT * FROM xxx WHERE exclude = 1");
+    }
+
+    @Test
+    public void testSelectConditionsIssue720And991() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT column IS NOT NULL FROM table");
+        assertSqlCanBeParsedAndDeparsed("SELECT 0 IS NULL");
+        assertSqlCanBeParsedAndDeparsed("SELECT 1 + 2");
+        assertSqlCanBeParsedAndDeparsed("SELECT 1 < 2");
+        assertSqlCanBeParsedAndDeparsed("SELECT 1 > 2");
+        assertSqlCanBeParsedAndDeparsed("SELECT 1 + 2 AS a, 3 < 4 AS b");
+        assertSqlCanBeParsedAndDeparsed("SELECT 1 < 2 AS a, 0 IS NULL AS b");
+//        assertSqlCanBeParsedAndDeparsed("SELECT 1 < 2 AS a, (0 IS NULL) AS b");
     }
 }

--- a/src/test/resources/RUBiS-create-requests.txt
+++ b/src/test/resources/RUBiS-create-requests.txt
@@ -365,6 +365,18 @@ true
 tmp_ids
 id.unique category
 
+#begin
+create table test.json_test (
+  c1 INTEGER PRIMARY KEY,
+  c2 varchar(20) not null,
+  c3 json default null
+)
+#end
+true
+test.json_test
+c1.unique c2 c3
+
+
 // -----------------------------------------------------------------------------------------------------------------------
 // Other tests
 // -----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
As it is in the issues above, sqls below won't parse.
```sql
SELECT column IS NOT NULL FROM table;
SELECT 0 IS NULL;
```
Then I figured out that in function `SelectExpressionItem()` -> `SimpleExpression()` should be replaced by `Condition()` since null expression, bool expression and SimpleExpression itself are handled in `Condition()`.
Because function `PivotSingleInItems()` also use `SelectExpressionItem()`, I copyed the original `SelectExpressionItem()` so that the "pivot" test doesn't break.

All tests passed, but "SELECT 1 < 2 AS a, (0 IS NULL) AS b" won't work because something is wrong with aliasing an  expression with parentheses. 
"SELECT (1 < 2) AND (3 < 4)" won't work too, I belive this can be fixed somehow in function `Condition()`.

