### PR TITLE
Retain original value in TimestampValue

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/TimestampValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/TimestampValue.java
@@ -19,7 +19,8 @@ import java.sql.Timestamp;
 public class TimestampValue extends ASTNodeAccessImpl implements Expression {
 
     private Timestamp value;
-    private char quotation = '\'';
+    private String rawValue;
+    private static final char QUOTATION = '\'';
 
     public TimestampValue() {
         // empty constructor
@@ -29,11 +30,7 @@ public class TimestampValue extends ASTNodeAccessImpl implements Expression {
         if (value == null) {
             throw new java.lang.IllegalArgumentException("null string");
         } else {
-            if (value.charAt(0) == quotation) {
-                this.value = Timestamp.valueOf(value.substring(1, value.length() - 1));
-            } else {
-                this.value = Timestamp.valueOf(value.substring(0, value.length()));
-            }
+            setRawValue(value);
         }
     }
 
@@ -48,6 +45,19 @@ public class TimestampValue extends ASTNodeAccessImpl implements Expression {
 
     public void setValue(Timestamp d) {
         value = d;
+    }
+
+    public String getRawValue() {
+        return rawValue;
+    }
+
+    public void setRawValue(String rawValue) {
+        this.rawValue = rawValue;
+        if (rawValue.charAt(0) == QUOTATION) {
+            this.value = Timestamp.valueOf(rawValue.substring(1, rawValue.length() - 1));
+        } else {
+            this.value = Timestamp.valueOf(rawValue.substring(0, rawValue.length()));
+        }
     }
 
     @Override

--- a/src/test/java/net/sf/jsqlparser/expression/TimestampValueTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/TimestampValueTest.java
@@ -9,6 +9,7 @@
  */
 package net.sf.jsqlparser.expression;
 
+import static org.junit.Assert.assertEquals;
 import net.sf.jsqlparser.JSQLParserException;
 import org.junit.Test;
 
@@ -25,6 +26,7 @@ public class TimestampValueTest {
         String currentDate = dateFormat.format(new Date());
         TimestampValue tv = new TimestampValue(currentDate);
         System.out.println(tv.toString());
+        assertEquals(currentDate, tv.getRawValue());
     }
 
     @Test
@@ -33,5 +35,6 @@ public class TimestampValueTest {
         String currentDate = dateFormat.format(new Date());
         TimestampValue tv = new TimestampValue("'" + currentDate + "'");
         System.out.println(tv.toString());
+        assertEquals("'" + currentDate + "'", tv.getRawValue());
     }
 }


### PR DESCRIPTION
Currently we only keep a reference to a parsed java.sql.Timestamp, but java.sql.Timestamp.valueOf uses local machine Timezone to parse the timestamp value, this is not good for statement rewriting if jSQLParser is running on a separate machine (like a server) with different JVM configuration