### PR TITLE
Added support for the Case keyword in table names

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1344,7 +1344,7 @@ String RelObjectNameWithoutValue() :
       | tk=<K_READ> | tk=<K_SCHEMA> | tk=<K_SIZE> | tk=<K_SEQUENCE> | tk=<K_SESSION>
       | tk=<K_VIEW> | tk=<K_NOLOCK> | tk=<K_VALIDATE> | tk=<K_CYCLE> | tk=<K_OF> | tk=<K_EXCLUDE>
     /*| tk=<K_PLACING> | tk=<K_BOTH> | tk=<K_LEADING> | tk=<K_TRAILING> */
-      | tk=<K_FORMAT> | tk=<K_DIV> | tk=<K_UNSIGNED>
+      | tk=<K_FORMAT> | tk=<K_DIV> | tk=<K_UNSIGNED> | tk=<K_CASE>
       )
 
     { return tk.image; }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -3094,6 +3094,11 @@ public class SelectTest {
     }
 
     @Test
+    public void testCaseKeyword() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT * FROM Case");
+    }
+
+    @Test
     public void testCastToSignedInteger() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT CAST(contact_id AS SIGNED INTEGER) FROM contact WHERE contact_id = 20");
     }


### PR DESCRIPTION
This change will allow parsing queries such as:
`SELECT * FROM Case`