### PR TITLE
Array contructor support

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ArrayConstructor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ArrayConstructor.java
@@ -1,0 +1,58 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2021 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+
+import java.util.List;
+
+public class ArrayConstructor extends ASTNodeAccessImpl implements Expression {
+    private List<Expression> expressions;
+    private boolean arrayKeyword;
+
+    public List<Expression> getExpressions() {
+        return expressions;
+    }
+
+    public void setExpressions(List<Expression> expressions) {
+        this.expressions = expressions;
+    }
+
+    public boolean isArrayKeyword() {
+        return arrayKeyword;
+    }
+
+    public void setArrayKeyword(boolean arrayKeyword) {
+        this.arrayKeyword = arrayKeyword;
+    }
+
+    public ArrayConstructor(List<Expression> expressions, boolean arrayKeyword) {
+        this.expressions = expressions;
+        this.arrayKeyword = arrayKeyword;
+    }
+
+    @Override
+    public void accept(ExpressionVisitor expressionVisitor) {
+        expressionVisitor.visit(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        if (arrayKeyword) {
+            sb.append("ARRAY");
+        }
+        sb.append("[");
+        sb.append(PlainSelect.getStringList(expressions, true, false));
+        sb.append("]");
+        return sb.toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -158,6 +158,8 @@ public interface ExpressionVisitor {
 
     public void visit(ArrayExpression aThis);
 
+    public void visit(ArrayConstructor aThis);
+
     public void visit(VariableAssignment aThis);
 
     public void visit(XMLSerializeExpr aThis);

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -543,6 +543,13 @@ public class ExpressionVisitorAdapter implements ExpressionVisitor, ItemsListVis
     }
 
     @Override
+    public void visit(ArrayConstructor aThis) {
+        for (Expression expression : aThis.getExpressions()) {
+            expression.accept(this);
+        }
+    }
+
+    @Override
     public void visit(VariableAssignment var) {
         var.getVariable().accept(this);
         var.getExpression().accept(this);

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -15,6 +15,7 @@ import net.sf.jsqlparser.expression.AllComparisonExpression;
 import net.sf.jsqlparser.expression.AnalyticExpression;
 import net.sf.jsqlparser.expression.AnyComparisonExpression;
 import net.sf.jsqlparser.expression.ArrayExpression;
+import net.sf.jsqlparser.expression.ArrayConstructor;
 import net.sf.jsqlparser.expression.BinaryExpression;
 import net.sf.jsqlparser.expression.CaseExpression;
 import net.sf.jsqlparser.expression.CastExpression;
@@ -873,6 +874,13 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
     public void visit(ArrayExpression array) {
         array.getObjExpression().accept(this);
         array.getIndexExpression().accept(this);
+    }
+
+    @Override
+    public void visit(ArrayConstructor array) {
+        for (Expression expression : array.getExpressions()) {
+            expression.accept(this);
+        }
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -17,6 +17,7 @@ import net.sf.jsqlparser.expression.AnalyticExpression;
 import net.sf.jsqlparser.expression.AnalyticType;
 import net.sf.jsqlparser.expression.AnyComparisonExpression;
 import net.sf.jsqlparser.expression.ArrayExpression;
+import net.sf.jsqlparser.expression.ArrayConstructor;
 import net.sf.jsqlparser.expression.BinaryExpression;
 import net.sf.jsqlparser.expression.CaseExpression;
 import net.sf.jsqlparser.expression.CastExpression;
@@ -894,6 +895,24 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
         array.getObjExpression().accept(this);
         buffer.append("[");
         array.getIndexExpression().accept(this);
+        buffer.append("]");
+    }
+
+    @Override
+    public void visit(ArrayConstructor aThis) {
+        if (aThis.isArrayKeyword()) {
+            buffer.append("ARRAY");
+        }
+        buffer.append("[");
+        boolean first = true;
+        for (Expression expression : aThis.getExpressions()) {
+            if (!first) {
+                buffer.append(", ");
+            } else {
+                first = false;
+            }
+            expression.accept(this);
+        }
         buffer.append("]");
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
@@ -12,6 +12,7 @@ package net.sf.jsqlparser.util.validation.validator;
 import net.sf.jsqlparser.expression.AllComparisonExpression;
 import net.sf.jsqlparser.expression.AnalyticExpression;
 import net.sf.jsqlparser.expression.AnyComparisonExpression;
+import net.sf.jsqlparser.expression.ArrayConstructor;
 import net.sf.jsqlparser.expression.ArrayExpression;
 import net.sf.jsqlparser.expression.BinaryExpression;
 import net.sf.jsqlparser.expression.CaseExpression;
@@ -530,6 +531,13 @@ public class ExpressionValidator extends AbstractValidator<Expression> implement
     public void visit(ArrayExpression array) {
         array.getObjExpression().accept(this);
         array.getIndexExpression().accept(this);
+    }
+
+    @Override
+    public void visit(ArrayConstructor aThis) {
+        for (Expression expression : aThis.getExpressions()) {
+            expression.accept(this);
+        }
     }
 
     @Override

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3442,9 +3442,9 @@ ArrayConstructor ArrayConstructor(final boolean arrayKeyword) : {
     "["
         [ (LOOKAHEAD(3) exp = SimpleExpression() | exp = ArrayConstructor(false))
           { expList.add(exp); }
-        ]
         ("," (exp = SimpleExpression() | exp = ArrayConstructor(false))
             { expList.add(exp); })*
+        ]
     "]"
     { return array; }
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -129,7 +129,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_AND_OPERATOR:"&&">
 |   <K_ANY:"ANY">
 |   <K_APPLY:"APPLY">
-|   <K_ARRAYLITERAL: "ARRAY" >
+|   <K_ARRAY_LITERAL: "ARRAY" >
 |   <K_AS: "AS">
 |   <K_ASC:"ASC">
 |   <K_AUTHORIZATION:"AUTHORIZATION">
@@ -1346,7 +1346,7 @@ String RelObjectNameWithoutValue() :
       | tk=<K_VIEW> | tk=<K_NOLOCK> | tk=<K_VALIDATE> | tk=<K_CYCLE> | tk=<K_OF> | tk=<K_EXCLUDE>
     /*| tk=<K_PLACING> | tk=<K_BOTH> | tk=<K_LEADING> | tk=<K_TRAILING> */
       | tk=<K_FORMAT> | tk=<K_DIV> | tk=<K_UNSIGNED> | tk=<K_CASE>
-      | tk=<K_ARRAYLITERAL>
+      | tk=<K_ARRAY_LITERAL>
       )
 
     { return tk.image; }
@@ -3329,7 +3329,7 @@ Expression PrimaryExpression() #PrimaryExpression:
 
         | LOOKAHEAD(2) retval=DateTimeLiteralExpression()
 
-        | LOOKAHEAD(2) <K_ARRAYLITERAL> retval=ArrayConstructor(true)
+        | LOOKAHEAD(2) <K_ARRAY_LITERAL> retval=ArrayConstructor(true)
 
         | LOOKAHEAD(2) retval = NextValExpression()
 
@@ -3440,8 +3440,9 @@ ArrayConstructor ArrayConstructor(final boolean arrayKeyword) : {
     Expression exp = null;
 } {
     "["
-        (LOOKAHEAD(3) exp = SimpleExpression() | exp = ArrayConstructor(false))
-        { expList.add(exp); }
+        [ (LOOKAHEAD(3) exp = SimpleExpression() | exp = ArrayConstructor(false))
+          { expList.add(exp); }
+        ]
         ("," (exp = SimpleExpression() | exp = ArrayConstructor(false))
             { expList.add(exp); })*
     "]"
@@ -4504,6 +4505,8 @@ List<String> CreateParameter():
             tk=<K_TRUE> { param.add(tk.image); }
             |
             tk=<K_FALSE> { param.add(tk.image); }
+            |
+            (<K_ARRAY_LITERAL> exp=ArrayConstructor(true)) { param.add(exp.toString()); }
             |
 	    tk="::" colDataType = ColDataType() { param.add(tk.image); param.add(colDataType.toString()); }
         )

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -129,6 +129,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_AND_OPERATOR:"&&">
 |   <K_ANY:"ANY">
 |   <K_APPLY:"APPLY">
+|   <K_ARRAYLITERAL: "ARRAY" >
 |   <K_AS: "AS">
 |   <K_ASC:"ASC">
 |   <K_AUTHORIZATION:"AUTHORIZATION">
@@ -1345,6 +1346,7 @@ String RelObjectNameWithoutValue() :
       | tk=<K_VIEW> | tk=<K_NOLOCK> | tk=<K_VALIDATE> | tk=<K_CYCLE> | tk=<K_OF> | tk=<K_EXCLUDE>
     /*| tk=<K_PLACING> | tk=<K_BOTH> | tk=<K_LEADING> | tk=<K_TRAILING> */
       | tk=<K_FORMAT> | tk=<K_DIV> | tk=<K_UNSIGNED> | tk=<K_CASE>
+      | tk=<K_ARRAYLITERAL>
       )
 
     { return tk.image; }
@@ -3327,6 +3329,8 @@ Expression PrimaryExpression() #PrimaryExpression:
 
         | LOOKAHEAD(2) retval=DateTimeLiteralExpression()
 
+        | LOOKAHEAD(2) <K_ARRAYLITERAL> retval=ArrayConstructor(true)
+
         | LOOKAHEAD(2) retval = NextValExpression()
 
         | retval=Column()
@@ -3428,6 +3432,20 @@ DateTimeLiteralExpression DateTimeLiteralExpression() : {
     t=<K_DATETIMELITERAL>  { expr.setType(DateTimeLiteralExpression.DateTime.valueOf(t.image.toUpperCase())); }
 
     t=<S_CHAR_LITERAL> { expr.setValue(t.image); return expr; }
+}
+
+ArrayConstructor ArrayConstructor(final boolean arrayKeyword) : {
+    ArrayList<Expression> expList = new ArrayList();
+    ArrayConstructor array = new ArrayConstructor(expList, arrayKeyword);
+    Expression exp = null;
+} {
+    "["
+        (LOOKAHEAD(3) exp = SimpleExpression() | exp = ArrayConstructor(false))
+        { expList.add(exp); }
+        ("," (exp = SimpleExpression() | exp = ArrayConstructor(false))
+            { expList.add(exp); })*
+    "]"
+    { return array; }
 }
 
 JsonExpression JsonExpression() : {

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
@@ -681,4 +681,9 @@ public class CreateTableTest {
     public void testCreateTableWithParameterDefaultFalseIssue1089() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("create table ADDRESS_TYPE ( address_type CHAR(1) not null, at_name VARCHAR(250) not null, is_disabled BOOL not null default FALSE, constraint PK_ADDRESS_TYPE primary key (address_type) )", true);
     }   
+    @Test
+    public void testDefaultArray() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("CREATE TABLE t (f1 text[] DEFAULT ARRAY[] :: text[] NOT NULL, f2 int[] DEFAULT ARRAY[1, 2])");
+    }
+
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -4441,4 +4441,9 @@ public class SelectTest {
     public void testSignedKeywordIssue995() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT leading FROM prd_reprint");
     }
+
+    @Test
+    public void testArrayDeclare() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT ARRAY[1, f1], ARRAY[[1, 2], [3, f2 + 1]] FROM t1");
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -4444,6 +4444,6 @@ public class SelectTest {
 
     @Test
     public void testArrayDeclare() throws JSQLParserException {
-        assertSqlCanBeParsedAndDeparsed("SELECT ARRAY[1, f1], ARRAY[[1, 2], [3, f2 + 1]] FROM t1");
+        assertSqlCanBeParsedAndDeparsed("SELECT ARRAY[1, f1], ARRAY[[1, 2], [3, f2 + 1]], ARRAY[]::text[] FROM t1");
     }
 }


### PR DESCRIPTION
Array constructor support
 array[[1, 2], [id1, id2]]

https://www.postgresql.org/docs/current/sql-expressions.html#SQL-SYNTAX-ARRAY-CONSTRUCTORS
