### PR TITLE
Support CREATE TABLE parameters without columns definition, parameter values any names

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/create/table/CreateTable.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/CreateTable.java
@@ -158,10 +158,10 @@ public class CreateTable implements Statement {
                 sql += PlainSelect.getStringList(indexes);
             }
             sql += ")";
-            String options = PlainSelect.getStringList(tableOptionsStrings, false, false);
-            if (options != null && options.length() > 0) {
-                sql += " " + options;
-            }
+        }
+        String options = PlainSelect.getStringList(tableOptionsStrings, false, false);
+        if (options != null && options.length() > 0) {
+            sql += " " + options;
         }
 
         if (rowMovement != null) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4135,7 +4135,7 @@ CreateTable CreateTable():
     <K_TABLE>
     [ LOOKAHEAD(2) <K_IF> <K_NOT> <K_EXISTS> { createTable.setIfNotExists(true); }]
     table=Table()
-    [
+    [ LOOKAHEAD(2)
         ("("
         coldef = ColumnDefinition()
 
@@ -4259,9 +4259,10 @@ CreateTable CreateTable():
         )*
 
         ")"
-        (     parameter=CreateParameter() { tableOptions.addAll(parameter); } )*
         )
     ]
+    ( parameter=CreateParameter() { tableOptions.addAll(parameter); } )*
+
     // see https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_7002.htm#i2126725
     // table properties , all these are optional
     [ rowMovement = RowMovement() { createTable.setRowMovement(rowMovement); }]
@@ -4429,6 +4430,8 @@ List<String> CreateParameter():
             |
             tk=<K_COMMIT> { param.add(tk.image); }
             |
+            tk=<K_DROP> { param.add(tk.image); }
+            |
             tk=<K_ROWS> { param.add(tk.image); }
             |
             tk=<K_UNIQUE> { param.add(tk.image); }
@@ -4480,7 +4483,7 @@ List<String> CreateParameter():
             tk=<K_COLLATE> { param.add(tk.image); }
             |
             tk=<K_ASC> { param.add(tk.image); }
-	    |
+            |
             tk=<K_DESC> { param.add(tk.image); }
             |
             tk=<K_TRUE> { param.add(tk.image); }
@@ -4510,12 +4513,14 @@ String AList():
 {
     StringBuilder retval = new StringBuilder("(");
     Token tk = null;
-    Token tk2 = null;
+    String name = null;
 }
 {
      "("
 
-     ( (tk=<S_LONG> | tk=<S_DOUBLE> | tk=<S_CHAR_LITERAL> | tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER>) { retval.append(tk.image); }
+     (
+       ( (tk=<S_LONG> | tk=<S_DOUBLE> | tk=<S_CHAR_LITERAL>) { retval.append(tk.image); }
+         | (name=RelObjectNameWithoutValue()) { retval.append(name); })
        [("," {retval.append(",");} | "=" {retval.append("=");})] )*
 
     ")"

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
@@ -142,6 +142,12 @@ public class CreateTableTest {
     }
 
     @Test
+    public void testCreateTableParams2() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("CREATE TEMPORARY TABLE t1 WITH (APPENDONLY=true,ORIENTATION=column,COMPRESSTYPE=zlib,OIDS=FALSE) ON COMMIT DROP AS SELECT column FROM t2");
+    }
+
+
+    @Test
     public void testCreateTableUniqueConstraint() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("CREATE TABLE Activities (_id INTEGER PRIMARY KEY AUTOINCREMENT,uuid VARCHAR(255),user_id INTEGER,sound_id INTEGER,sound_type INTEGER,comment_id INTEGER,type String,tags VARCHAR(255),created_at INTEGER,content_id INTEGER,sharing_note_text VARCHAR(255),sharing_note_created_at INTEGER,UNIQUE (created_at, type, content_id, sound_id, user_id))", true);
     }


### PR DESCRIPTION
Support `CREATE TABLE` parameters without columns definition, parameter values any names

```
CREATE TEMPORARY TABLE t1 
WITH (APPENDONLY=true,ORIENTATION=column,COMPRESSTYPE=zlib,OIDS=FALSE) ON COMMIT DROP
AS SELECT column FROM t2
```
https://www.postgresql.org/docs/current/sql-createtable.html

Example based on greenplum query
https://gpdb.docs.pivotal.io/6-13/ref_guide/sql_commands/CREATE_TABLE.html
