### PR TITLE
Partial support construct tuple as simple expression

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3281,6 +3281,7 @@ Expression PrimaryExpression() #PrimaryExpression:
     boolean exclamationMarkNot = false;
     boolean dateExpressionAllowed = true;
     Expression idxExpr;
+    ExpressionList list;
 }
 {
     [ <K_NOT> { not=true; } | "!" { not=true; exclamationMarkNot=true; } ]
@@ -3341,7 +3342,14 @@ Expression PrimaryExpression() #PrimaryExpression:
 
         | LOOKAHEAD("(" retval=SubSelect() ")") "(" retval=SubSelect() ")"
 
-        | "(" retval=SimpleExpression() ")" {retval = new Parenthesis(retval); }
+        | "(" list = SimpleExpressionList() ")"
+          {
+              if (list.getExpressions().size() == 1) {
+                  retval = new Parenthesis(list.getExpressions().get(0));
+              } else {
+                  retval = new RowConstructor().withExprList(list);
+              }
+          }
     )
 
     [

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -4441,4 +4441,9 @@ public class SelectTest {
     public void testSignedKeywordIssue995() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT leading FROM prd_reprint");
     }
+
+    @Test
+    public void testSelectTuple() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT hyperloglog_distinct((1, 2)) FROM t");
+    }
 }


### PR DESCRIPTION
Partial support construct tuple as simple expression
`SELECT hyperloglog_distinct((f1, f2)) FROM t`
https://www.postgresql.org/docs/current/sql-expressions.html#SQL-SYNTAX-ROW-CONSTRUCTORS

> The key word ROW is optional when there is more than one expression in the list.