### PR TITLE
Add support for UNION with brackets and ORDER BY

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1609,7 +1609,7 @@ SelectBody SetOperationList() #SetOperationList: {
         } else {
             if (selects.size()>1 && selects.get(selects.size()-1) instanceof PlainSelect) {
                 PlainSelect ps = (PlainSelect)selects.get(selects.size()-1);
-                if (ps.getOrderByElements() != null) {
+                if (ps.getOrderByElements() != null && !brackets.get(brackets.size() - 1)) {
                     list.setOrderByElements(ps.getOrderByElements());
                     ps.setOrderByElements(null);
                 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -2398,6 +2398,12 @@ public class SelectTest {
     }
 
     @Test
+    public void testUnionWithBracketsAndOrderBy() throws JSQLParserException {
+        String stmt = "(SELECT a FROM tbl ORDER BY a) UNION DISTINCT (SELECT a FROM tbl ORDER BY a)";
+        assertSqlCanBeParsedAndDeparsed(stmt);
+    }
+
+    @Test
     public void testMultiValueNotInBinds() throws JSQLParserException {
         String stmt = "SELECT * FROM mytable WHERE (a, b) NOT IN ((?, ?), (?, ?))";
         assertSqlCanBeParsedAndDeparsed(stmt);


### PR DESCRIPTION
When parsing the following statement, the ORDER BY clause of the last part of the union was wrongfully considered as if it was the global ORDER BY clause of the union.

Original query:
`(SELECT a FROM tbl ORDER BY a) UNION DISTINCT (SELECT a FROM tbl ORDER BY a)`
Before fixing the issue, the query was parsed to:
`(SELECT a FROM tbl ORDER BY a) UNION DISTINCT (SELECT a FROM tbl) ORDER BY a`

Now after this fix, it will be parsed to the same as the original query.

Fixes #1130