### PR TITLE
Add support for union without brackets and with limit

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1607,13 +1607,16 @@ SelectBody SetOperationList() #SetOperationList: {
                 ((PlainSelect)selects.get(0)).setUseBrackets(true);
             return selects.get(0);
         } else {
-            if (ps.getOrderByElements() != null && !brackets.get(brackets.size() - 1)) {
-                list.setOrderByElements(ps.getOrderByElements());
-                list.setLimit(ps.getLimit());
-                list.setOffset(ps.getOffset());
-                ps.setOrderByElements(null);
-                ps.setLimit(null);
-                ps.setOffset(null);
+            if (selects.size()>1 && selects.get(selects.size()-1) instanceof PlainSelect) {
+                PlainSelect ps = (PlainSelect)selects.get(selects.size()-1);
+                if (ps.getOrderByElements() != null && !brackets.get(brackets.size() - 1)) {
+                    list.setOrderByElements(ps.getOrderByElements());
+                    list.setLimit(ps.getLimit());
+                    list.setOffset(ps.getOffset());
+                    ps.setOrderByElements(null);
+                    ps.setLimit(null);
+                    ps.setOffset(null);
+                }
             }
             list.setBracketsOpsAndSelects(brackets,selects,operations);
             return list;

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1607,12 +1607,13 @@ SelectBody SetOperationList() #SetOperationList: {
                 ((PlainSelect)selects.get(0)).setUseBrackets(true);
             return selects.get(0);
         } else {
-            if (selects.size()>1 && selects.get(selects.size()-1) instanceof PlainSelect) {
-                PlainSelect ps = (PlainSelect)selects.get(selects.size()-1);
-                if (ps.getOrderByElements() != null) {
-                    list.setOrderByElements(ps.getOrderByElements());
-                    ps.setOrderByElements(null);
-                }
+            if (ps.getOrderByElements() != null && !brackets.get(brackets.size() - 1)) {
+                list.setOrderByElements(ps.getOrderByElements());
+                list.setLimit(ps.getLimit());
+                list.setOffset(ps.getOffset());
+                ps.setOrderByElements(null);
+                ps.setLimit(null);
+                ps.setOffset(null);
             }
             list.setBracketsOpsAndSelects(brackets,selects,operations);
             return list;

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -883,6 +883,12 @@ public class SelectTest {
     }
 
     @Test
+    public void testUnionWithOrderByAndLimitAndNoBrackets() throws JSQLParserException {
+        String stmt = "SELECT id FROM table1 UNION SELECT id FROM table2 ORDER BY id ASC LIMIT 55";
+        assertSqlCanBeParsedAndDeparsed(stmt);
+    }
+
+    @Test
     public void testUnion() throws JSQLParserException {
         String statement = "SELECT * FROM mytable WHERE mytable.col = 9 UNION "
                 + "SELECT * FROM mytable3 WHERE mytable3.col = ? UNION " + "SELECT * FROM mytable2 LIMIT 3, 4";


### PR DESCRIPTION
The parser misplaces the LIMIT clause when parsing a UNION query that doesn't include brackets.

The original query:
`select col from tbl union distinct select col2 from tbl order by test limit 100;`
The query after parsing (before the fix):
`SELECT tbl.col FROM tbl UNION DISTINCT SELECT tbl.col2 FROM tbl LIMIT 100 ORDER BY test`

Note that the LIMIT clause shows up before the ORDER BY clause, which is invalid.

After the fix, the query parses as the same as the original query.

Fixes #1018
Fixes #1116