### PR TITLE
Oracle compliant  ALTER TABLE ADD/MODIFY deparser

### DIFF
--- a/nb-configuration.xml
+++ b/nb-configuration.xml
@@ -13,7 +13,7 @@
 		That way multiple projects can share the same settings (useful for formatting rules for example).
 		Any value defined here will override the pom.xml file value but is only applicable to the current project.
 		-->
-        <netbeans.compile.on.save>none</netbeans.compile.on.save>
+        <netbeans.compile.on.save>all</netbeans.compile.on.save>
         <com-junichi11-netbeans-changelf.enable>false</com-junichi11-netbeans-changelf.enable>
         <com-junichi11-netbeans-changelf.use-project>true</com-junichi11-netbeans-changelf.use-project>
         <com-junichi11-netbeans-changelf.lf-kind>LF</com-junichi11-netbeans-changelf.lf-kind>

--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -29,656 +29,673 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
 
 public class AlterExpression {
 
-    private AlterOperation operation;
-    private String optionalSpecifier;
-    private String columnName;
-    private String columnOldName;
-    // private ColDataType dataType;
+  private AlterOperation operation;
+  private String optionalSpecifier;
+  private String columnName;
+  private String columnOldName;
+  // private ColDataType dataType;
 
-    private List<ColumnDataType> colDataTypeList;
-    private List<ColumnDropNotNull> columnDropNotNullList;
+  private List<ColumnDataType> colDataTypeList;
+  private List<ColumnDropNotNull> columnDropNotNullList;
 
-    private List<String> pkColumns;
-    private List<String> ukColumns;
-    private String ukName;
-    private Index index = null;
-    private String constraintName;
-    private boolean constraintIfExists;
+  private List<String> pkColumns;
+  private List<String> ukColumns;
+  private String ukName;
+  private Index index = null;
+  private String constraintName;
+  private boolean constraintIfExists;
 
-    private Set<ReferentialAction> referentialActions = new LinkedHashSet<>(2);
+  private Set<ReferentialAction> referentialActions = new LinkedHashSet<>(2);
 
-    private List<String> fkColumns;
-    private String fkSourceSchema;
+  private List<String> fkColumns;
+  private String fkSourceSchema;
 
-    private String fkSourceTable;
-    private List<String> fkSourceColumns;
-    private boolean uk;
-    private boolean useEqual;
+  private String fkSourceTable;
+  private List<String> fkSourceColumns;
+  private boolean uk;
+  private boolean useEqual;
 
-    private List<ConstraintState> constraints;
-    private List<String> parameters;
-    private String commentText;
-    
-    public String getFkSourceSchema() {
-      return fkSourceSchema;
+  private List<ConstraintState> constraints;
+  private List<String> parameters;
+  private String commentText;
+
+  private boolean hasColumn = false;
+
+  public boolean hasColumn() {
+    return hasColumn;
+  }
+
+  public void hasColumn(boolean hasColumn) {
+    this.hasColumn = hasColumn;
+  }
+
+  public String getFkSourceSchema() {
+    return fkSourceSchema;
+  }
+
+  public void setFkSourceSchema(String fkSourceSchema) {
+    this.fkSourceSchema = fkSourceSchema;
+  }
+
+  public String getCommentText() {
+    return commentText;
+  }
+
+  public void setCommentText(String commentText) {
+    this.commentText = commentText;
+  }
+
+  public AlterOperation getOperation() {
+    return operation;
+  }
+
+  public void setOperation(AlterOperation operation) {
+    this.operation = operation;
+  }
+
+  public String getOptionalSpecifier() {
+    return optionalSpecifier;
+  }
+
+  public void setOptionalSpecifier(String optionalSpecifier) {
+    this.optionalSpecifier = optionalSpecifier;
+  }
+
+  /**
+   * @param type
+   * @param action
+   */
+  public void setReferentialAction(Type type, Action action) {
+    setReferentialAction(type, action, true);
+  }
+
+  public AlterExpression withReferentialAction(Type type, Action action) {
+    setReferentialAction(type, action);
+    return this;
+  }
+
+  /** @param type */
+  public void removeReferentialAction(Type type) {
+    setReferentialAction(type, null, false);
+  }
+
+  /**
+   * @param type
+   * @return
+   */
+  public ReferentialAction getReferentialAction(Type type) {
+    return referentialActions.stream()
+        .filter(ra -> type.equals(ra.getType()))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private void setReferentialAction(Type type, Action action, boolean set) {
+    ReferentialAction found = getReferentialAction(type);
+    if (set) {
+      if (found == null) {
+        referentialActions.add(new ReferentialAction(type, action));
+      } else {
+        found.setAction(action);
+      }
+    } else if (found != null) {
+      referentialActions.remove(found);
     }
-    public void setFkSourceSchema(String fkSourceSchema) {
-      this.fkSourceSchema = fkSourceSchema;
-    }
+  }
+  /**
+   * @return
+   * @deprecated use {@link #getOnDeleteReferentialAction()}
+   */
+  @Deprecated
+  public boolean isOnDeleteCascade() {
+    ReferentialAction found = getReferentialAction(Type.DELETE);
+    return found != null && Action.CASCADE.equals(found.getAction());
+  }
 
-    public String getCommentText() {
-        return commentText;
-    }
+  /**
+   * @return
+   * @deprecated use {@link #setOnDeleteReferentialAction(Action)
+   */
+  @Deprecated
+  public void setOnDeleteCascade(boolean onDeleteCascade) {
+    setReferentialAction(Type.DELETE, Action.CASCADE, onDeleteCascade);
+  }
 
-    public void setCommentText(String commentText) {
-        this.commentText = commentText;
-    }
+  /**
+   * @return
+   * @deprecated use {@link #getOnDeleteReferentialAction()}
+   */
+  @Deprecated
+  public boolean isOnDeleteRestrict() {
+    ReferentialAction found = getReferentialAction(Type.DELETE);
+    return found != null && Action.RESTRICT.equals(found.getAction());
+  }
 
-    public AlterOperation getOperation() {
-        return operation;
-    }
+  /**
+   * @return
+   * @deprecated use {@link #setOnDeleteReferentialAction(Action)
+   */
+  @Deprecated
+  public void setOnDeleteRestrict(boolean onDeleteRestrict) {
+    setReferentialAction(Type.DELETE, Action.RESTRICT, onDeleteRestrict);
+  }
 
-    public void setOperation(AlterOperation operation) {
-        this.operation = operation;
-    }
+  /**
+   * @return
+   * @deprecated use {@link #getOnDeleteReferentialAction()}
+   */
+  @Deprecated
+  public boolean isOnDeleteSetNull() {
+    ReferentialAction found = getReferentialAction(Type.DELETE);
+    return found != null && Action.SET_NULL.equals(found.getAction());
+  }
 
-    public String getOptionalSpecifier() {
-        return optionalSpecifier;
-    }
+  /**
+   * @return
+   * @deprecated use {@link #setOnDeleteReferentialAction(Action)
+   */
+  @Deprecated
+  public void setOnDeleteSetNull(boolean onDeleteSetNull) {
+    setReferentialAction(Type.DELETE, Action.SET_NULL, onDeleteSetNull);
+  }
 
-    public void setOptionalSpecifier(String optionalSpecifier) {
-        this.optionalSpecifier = optionalSpecifier;
-    }
+  public List<String> getFkColumns() {
+    return fkColumns;
+  }
 
-    /**
-     * @param type
-     * @param action
-     */
-    public void setReferentialAction(Type type, Action action) {
-        setReferentialAction(type, action, true);
-    }
+  public void setFkColumns(List<String> fkColumns) {
+    this.fkColumns = fkColumns;
+  }
 
-    public AlterExpression withReferentialAction(Type type, Action action) {
-        setReferentialAction(type, action);
-        return this;
-    }
+  public String getFkSourceTable() {
+    return fkSourceTable;
+  }
 
-    /**
-     * @param type
-     */
-    public void removeReferentialAction(Type type) {
-        setReferentialAction(type, null, false);
-    }
+  public void setFkSourceTable(String fkSourceTable) {
+    this.fkSourceTable = fkSourceTable;
+  }
 
-    /**
-     * @param type
-     * @return
-     */
-    public ReferentialAction getReferentialAction(Type type) {
-        return referentialActions.stream().filter(ra -> type.equals(ra.getType())).findFirst().orElse(null);
-    }
+  public List<ColumnDataType> getColDataTypeList() {
+    return colDataTypeList;
+  }
 
-    private void setReferentialAction(Type type, Action action, boolean set) {
-        ReferentialAction found = getReferentialAction(type);
-        if (set) {
-            if (found == null) {
-                referentialActions.add(new ReferentialAction(type, action));
-            } else {
-                found.setAction(action);
-            }
-        } else if (found != null) {
-            referentialActions.remove(found);
+  public void addColDataType(String columnName, ColDataType colDataType) {
+    addColDataType(new ColumnDataType(columnName, false, colDataType, null));
+  }
+
+  public void addColDataType(ColumnDataType columnDataType) {
+    if (colDataTypeList == null) {
+      colDataTypeList = new ArrayList<>();
+    }
+    colDataTypeList.add(columnDataType);
+  }
+
+  public void addColDropNotNull(ColumnDropNotNull columnDropNotNull) {
+    if (columnDropNotNullList == null) {
+      columnDropNotNullList = new ArrayList<>();
+    }
+    columnDropNotNullList.add(columnDropNotNull);
+  }
+
+  public List<String> getFkSourceColumns() {
+    return fkSourceColumns;
+  }
+
+  public void setFkSourceColumns(List<String> fkSourceColumns) {
+    this.fkSourceColumns = fkSourceColumns;
+  }
+
+  public String getColumnName() {
+    return columnName;
+  }
+
+  public void setColumnName(String columnName) {
+    this.columnName = columnName;
+  }
+
+  @Deprecated
+  public String getColOldName() {
+    return getColumnOldName();
+  }
+
+  @Deprecated
+  public void setColOldName(String columnOldName) {
+    setColumnOldName(columnOldName);
+  }
+
+  public String getColumnOldName() {
+    return columnOldName;
+  }
+
+  public void setColumnOldName(String columnOldName) {
+    this.columnOldName = columnOldName;
+  }
+
+  public String getConstraintName() {
+    return this.constraintName;
+  }
+
+  public void setConstraintName(final String constraintName) {
+    this.constraintName = constraintName;
+  }
+
+  public boolean isConstraintIfExists() {
+    return constraintIfExists;
+  }
+
+  public void setConstraintIfExists(boolean constraintIfExists) {
+    this.constraintIfExists = constraintIfExists;
+  }
+
+  public List<String> getPkColumns() {
+    return pkColumns;
+  }
+
+  public void setPkColumns(List<String> pkColumns) {
+    this.pkColumns = pkColumns;
+  }
+
+  public List<String> getUkColumns() {
+    return ukColumns;
+  }
+
+  public void setUkColumns(List<String> ukColumns) {
+    this.ukColumns = ukColumns;
+  }
+
+  public String getUkName() {
+    return ukName;
+  }
+
+  public void setUkName(String ukName) {
+    this.ukName = ukName;
+  }
+
+  public Index getIndex() {
+    return index;
+  }
+
+  public void setIndex(Index index) {
+    this.index = index;
+  }
+
+  public List<ConstraintState> getConstraints() {
+    return constraints;
+  }
+
+  public void setConstraints(List<ConstraintState> constraints) {
+    this.constraints = constraints;
+  }
+
+  public List<ColumnDropNotNull> getColumnDropNotNullList() {
+    return columnDropNotNullList;
+  }
+
+  public void addParameters(String... params) {
+    if (parameters == null) {
+      parameters = new ArrayList<>();
+    }
+    parameters.addAll(Arrays.asList(params));
+  }
+
+  public List<String> getParameters() {
+    return parameters;
+  }
+
+  public boolean getUseEqual() {
+    return useEqual;
+  }
+
+  public void setUseEqual(boolean useEqual) {
+    this.useEqual = useEqual;
+  }
+
+  public boolean getUk() {
+    return uk;
+  }
+
+  public void setUk(boolean uk) {
+    this.uk = uk;
+  }
+
+  @Override
+  public String toString() {
+
+    StringBuilder b = new StringBuilder();
+
+    b.append(operation).append(" ");
+
+    if (commentText != null) {
+      if (columnName != null) {
+        b.append(columnName).append(" COMMENT ");
+      }
+      b.append(commentText);
+    } else if (columnName != null) {
+      if (hasColumn) {
+        b.append("COLUMN ");
+      }
+      if (operation == AlterOperation.RENAME) {
+        b.append(columnOldName).append(" TO ");
+      }
+      b.append(columnName);
+    } else if (getColDataTypeList() != null) {
+      if (operation == AlterOperation.CHANGE) {
+        if (optionalSpecifier != null) {
+          b.append(optionalSpecifier).append(" ");
         }
-    }
-    /**
-     * @return
-     * @deprecated use {@link #getOnDeleteReferentialAction()}
-     */
-    @Deprecated
-    public boolean isOnDeleteCascade() {
-        ReferentialAction found = getReferentialAction(Type.DELETE);
-        return found != null && Action.CASCADE.equals(found.getAction());
-    }
-
-    /**
-     * @return
-     * @deprecated use {@link #setOnDeleteReferentialAction(Action)
-     */
-    @Deprecated
-    public void setOnDeleteCascade(boolean onDeleteCascade) {
-        setReferentialAction(Type.DELETE, Action.CASCADE, onDeleteCascade);
-    }
-
-    /**
-     * @return
-     * @deprecated use {@link #getOnDeleteReferentialAction()}
-     */
-    @Deprecated
-    public boolean isOnDeleteRestrict() {
-        ReferentialAction found = getReferentialAction(Type.DELETE);
-        return found != null && Action.RESTRICT.equals(found.getAction());
-    }
-
-    /**
-     * @return
-     * @deprecated use {@link #setOnDeleteReferentialAction(Action)
-     */
-    @Deprecated
-    public void setOnDeleteRestrict(boolean onDeleteRestrict) {
-        setReferentialAction(Type.DELETE, Action.RESTRICT, onDeleteRestrict);
-    }
-
-    /**
-     * @return
-     * @deprecated use {@link #getOnDeleteReferentialAction()}
-     */
-    @Deprecated
-    public boolean isOnDeleteSetNull() {
-        ReferentialAction found = getReferentialAction(Type.DELETE);
-        return found != null && Action.SET_NULL.equals(found.getAction());
-    }
-
-    /**
-     * @return
-     * @deprecated use {@link #setOnDeleteReferentialAction(Action)
-     */
-    @Deprecated
-    public void setOnDeleteSetNull(boolean onDeleteSetNull) {
-        setReferentialAction(Type.DELETE, Action.SET_NULL, onDeleteSetNull);
-    }
-
-    public List<String> getFkColumns() {
-        return fkColumns;
-    }
-
-    public void setFkColumns(List<String> fkColumns) {
-        this.fkColumns = fkColumns;
-    }
-
-    public String getFkSourceTable() {
-        return fkSourceTable;
-    }
-
-    public void setFkSourceTable(String fkSourceTable) {
-        this.fkSourceTable = fkSourceTable;
-    }
-
-    public List<ColumnDataType> getColDataTypeList() {
-        return colDataTypeList;
-    }
-
-    public void addColDataType(String columnName, ColDataType colDataType) {
-        addColDataType(new ColumnDataType(columnName, false, colDataType, null));
-    }
-
-    public void addColDataType(ColumnDataType columnDataType) {
-        if (colDataTypeList == null) {
-            colDataTypeList = new ArrayList<>();
+        b.append(columnOldName).append(" ");
+      } else if (colDataTypeList.size() > 1) {
+        b.append("(");
+      } else {
+        if (hasColumn) {
+          b.append("COLUMN ");
         }
-        colDataTypeList.add(columnDataType);
-    }
-
-    public void addColDropNotNull(ColumnDropNotNull columnDropNotNull) {
-        if (columnDropNotNullList == null) {
-            columnDropNotNullList = new ArrayList<>();
+      }
+      b.append(PlainSelect.getStringList(colDataTypeList));
+      if (colDataTypeList.size() > 1) {
+        b.append(")");
+      }
+    } else if (getColumnDropNotNullList() != null) {
+      if (operation == AlterOperation.CHANGE) {
+        if (optionalSpecifier != null) {
+          b.append(optionalSpecifier).append(" ");
         }
-        columnDropNotNullList.add(columnDropNotNull);
-    }
-
-    public List<String> getFkSourceColumns() {
-        return fkSourceColumns;
-    }
-
-    public void setFkSourceColumns(List<String> fkSourceColumns) {
-        this.fkSourceColumns = fkSourceColumns;
-    }
-
-    public String getColumnName() {
-        return columnName;
-    }
-
-    public void setColumnName(String columnName) {
-        this.columnName = columnName;
-    }
-
-    @Deprecated
-    public String getColOldName() {
-        return getColumnOldName();
-    }
-
-    @Deprecated
-    public void setColOldName(String columnOldName) {
-        setColumnOldName(columnOldName);
-    }
-
-    public String getColumnOldName() {
-        return columnOldName;
-    }
-
-    public void setColumnOldName(String columnOldName) {
-        this.columnOldName = columnOldName;
-    }
-
-    public String getConstraintName() {
-        return this.constraintName;
-    }
-
-    public void setConstraintName(final String constraintName) {
-        this.constraintName = constraintName;
-    }
-
-    public boolean isConstraintIfExists() {
-        return constraintIfExists;
-    }
-
-    public void setConstraintIfExists(boolean constraintIfExists) {
-        this.constraintIfExists = constraintIfExists;
-    }
-
-    public List<String> getPkColumns() {
-        return pkColumns;
-    }
-
-    public void setPkColumns(List<String> pkColumns) {
-        this.pkColumns = pkColumns;
-    }
-
-    public List<String> getUkColumns() {
-        return ukColumns;
-    }
-
-    public void setUkColumns(List<String> ukColumns) {
-        this.ukColumns = ukColumns;
-    }
-
-    public String getUkName() {
-        return ukName;
-    }
-
-    public void setUkName(String ukName) {
-        this.ukName = ukName;
-    }
-
-    public Index getIndex() {
-        return index;
-    }
-
-    public void setIndex(Index index) {
-        this.index = index;
-    }
-
-    public List<ConstraintState> getConstraints() {
-        return constraints;
-    }
-
-    public void setConstraints(List<ConstraintState> constraints) {
-        this.constraints = constraints;
-    }
-
-    public List<ColumnDropNotNull> getColumnDropNotNullList() {
-        return columnDropNotNullList;
-    }
-
-    public void addParameters(String... params) {
-        if (parameters == null) {
-            parameters = new ArrayList<>();
+        b.append(columnOldName).append(" ");
+      } else if (columnDropNotNullList.size() > 1) {
+        b.append("(");
+      } else {
+        b.append("COLUMN ");
+      }
+      b.append(PlainSelect.getStringList(columnDropNotNullList));
+      if (columnDropNotNullList.size() > 1) {
+        b.append(")");
+      }
+    } else if (constraintName != null) {
+      b.append("CONSTRAINT ");
+      if (constraintIfExists) {
+        b.append("IF EXISTS ");
+      }
+      b.append(constraintName);
+    } else if (pkColumns != null) {
+      b.append("PRIMARY KEY (").append(PlainSelect.getStringList(pkColumns)).append(')');
+    } else if (ukColumns != null) {
+      b.append("UNIQUE");
+      if (ukName != null) {
+        if (getUk()) {
+          b.append(" KEY ");
+        } else {
+          b.append(" INDEX ");
         }
-        parameters.addAll(Arrays.asList(params));
+        b.append(ukName);
+      }
+      b.append(" (").append(PlainSelect.getStringList(ukColumns)).append(")");
+    } else if (fkColumns != null) {
+      b.append("FOREIGN KEY (")
+          .append(PlainSelect.getStringList(fkColumns))
+          .append(") REFERENCES ")
+          .append(
+              fkSourceSchema != null && fkSourceSchema.trim().length() > 0
+                  ? fkSourceSchema + "."
+                  : "")
+          .append(fkSourceTable)
+          .append(" (")
+          .append(PlainSelect.getStringList(fkSourceColumns))
+          .append(")");
+      referentialActions.forEach(b::append);
+    } else if (index != null) {
+      b.append(index);
+    }
+    if (getConstraints() != null && !getConstraints().isEmpty()) {
+      b.append(' ').append(PlainSelect.getStringList(constraints, false, false));
+    }
+    if (getUseEqual()) {
+      b.append('=');
+    }
+    if (parameters != null && !parameters.isEmpty()) {
+      b.append(' ').append(PlainSelect.getStringList(parameters, false, false));
     }
 
-    public List<String> getParameters() {
-        return parameters;
+    return b.toString();
+  }
+
+  public AlterExpression withOperation(AlterOperation operation) {
+    this.setOperation(operation);
+    return this;
+  }
+
+  public AlterExpression withOptionalSpecifier(String optionalSpecifier) {
+    this.setOptionalSpecifier(optionalSpecifier);
+    return this;
+  }
+
+  public AlterExpression withColumnName(String columnName) {
+    this.setColumnName(columnName);
+    return this;
+  }
+
+  public AlterExpression withPkColumns(List<String> pkColumns) {
+    this.setPkColumns(pkColumns);
+    return this;
+  }
+
+  public AlterExpression withUkColumns(List<String> ukColumns) {
+    this.setUkColumns(ukColumns);
+    return this;
+  }
+
+  public AlterExpression withUkName(String ukName) {
+    this.setUkName(ukName);
+    return this;
+  }
+
+  public AlterExpression withIndex(Index index) {
+    this.setIndex(index);
+    return this;
+  }
+
+  public AlterExpression withConstraintName(String constraintName) {
+    this.setConstraintName(constraintName);
+    return this;
+  }
+
+  public AlterExpression constraintIfExists(boolean constraintIfExists) {
+    this.setConstraintIfExists(constraintIfExists);
+    return this;
+  }
+
+  public AlterExpression withOnDeleteRestrict(boolean onDeleteRestrict) {
+    this.setOnDeleteRestrict(onDeleteRestrict);
+    return this;
+  }
+
+  public AlterExpression withOnDeleteSetNull(boolean onDeleteSetNull) {
+    this.setOnDeleteSetNull(onDeleteSetNull);
+    return this;
+  }
+
+  public AlterExpression withOnDeleteCascade(boolean onDeleteCascade) {
+    this.setOnDeleteCascade(onDeleteCascade);
+    return this;
+  }
+
+  public AlterExpression withFkColumns(List<String> fkColumns) {
+    this.setFkColumns(fkColumns);
+    return this;
+  }
+
+  public AlterExpression withFkSourceSchema(String fkSourceSchema) {
+    this.setFkSourceTable(fkSourceSchema);
+    return this;
+  }
+
+  public AlterExpression withFkSourceTable(String fkSourceTable) {
+    this.setFkSourceTable(fkSourceTable);
+    return this;
+  }
+
+  public AlterExpression withFkSourceColumns(List<String> fkSourceColumns) {
+    this.setFkSourceColumns(fkSourceColumns);
+    return this;
+  }
+
+  public AlterExpression withUk(boolean uk) {
+    this.setUk(uk);
+    return this;
+  }
+
+  public AlterExpression withUseEqual(boolean useEqual) {
+    this.setUseEqual(useEqual);
+    return this;
+  }
+
+  public AlterExpression withConstraints(List<ConstraintState> constraints) {
+    this.setConstraints(constraints);
+    return this;
+  }
+
+  public AlterExpression withCommentText(String commentText) {
+    this.setCommentText(commentText);
+    return this;
+  }
+
+  public AlterExpression withColumnOldName(String columnOldName) {
+    setColumnOldName(columnOldName);
+    return this;
+  }
+
+  public AlterExpression addPkColumns(String... pkColumns) {
+    List<String> collection = Optional.ofNullable(getPkColumns()).orElseGet(ArrayList::new);
+    Collections.addAll(collection, pkColumns);
+    return this.withPkColumns(collection);
+  }
+
+  public AlterExpression addPkColumns(Collection<String> pkColumns) {
+    List<String> collection = Optional.ofNullable(getPkColumns()).orElseGet(ArrayList::new);
+    collection.addAll(pkColumns);
+    return this.withPkColumns(collection);
+  }
+
+  public AlterExpression addUkColumns(String... ukColumns) {
+    List<String> collection = Optional.ofNullable(getUkColumns()).orElseGet(ArrayList::new);
+    Collections.addAll(collection, ukColumns);
+    return this.withUkColumns(collection);
+  }
+
+  public AlterExpression addUkColumns(Collection<String> ukColumns) {
+    List<String> collection = Optional.ofNullable(getUkColumns()).orElseGet(ArrayList::new);
+    collection.addAll(ukColumns);
+    return this.withUkColumns(collection);
+  }
+
+  public AlterExpression addFkColumns(String... fkColumns) {
+    List<String> collection = Optional.ofNullable(getFkColumns()).orElseGet(ArrayList::new);
+    Collections.addAll(collection, fkColumns);
+    return this.withFkColumns(collection);
+  }
+
+  public AlterExpression addFkColumns(Collection<String> fkColumns) {
+    List<String> collection = Optional.ofNullable(getFkColumns()).orElseGet(ArrayList::new);
+    collection.addAll(fkColumns);
+    return this.withFkColumns(collection);
+  }
+
+  public AlterExpression addFkSourceColumns(String... fkSourceColumns) {
+    List<String> collection = Optional.ofNullable(getFkSourceColumns()).orElseGet(ArrayList::new);
+    Collections.addAll(collection, fkSourceColumns);
+    return this.withFkSourceColumns(collection);
+  }
+
+  public AlterExpression addFkSourceColumns(Collection<String> fkSourceColumns) {
+    List<String> collection = Optional.ofNullable(getFkSourceColumns()).orElseGet(ArrayList::new);
+    collection.addAll(fkSourceColumns);
+    return this.withFkSourceColumns(collection);
+  }
+
+  public AlterExpression addConstraints(ConstraintState... constraints) {
+    List<ConstraintState> collection =
+        Optional.ofNullable(getConstraints()).orElseGet(ArrayList::new);
+    Collections.addAll(collection, constraints);
+    return this.withConstraints(collection);
+  }
+
+  public AlterExpression addConstraints(Collection<? extends ConstraintState> constraints) {
+    List<ConstraintState> collection =
+        Optional.ofNullable(getConstraints()).orElseGet(ArrayList::new);
+    collection.addAll(constraints);
+    return this.withConstraints(collection);
+  }
+
+  public static final class ColumnDataType extends ColumnDefinition {
+
+    private final boolean withType;
+
+    public ColumnDataType(boolean withType) {
+      super();
+      this.withType = withType;
     }
 
-    public boolean getUseEqual() {
-        return useEqual;
-    }
-
-    public void setUseEqual(boolean useEqual) {
-        this.useEqual = useEqual;
-    }
-
-    public boolean getUk() {
-        return uk;
-    }
-
-    public void setUk(boolean uk) {
-        this.uk = uk;
+    public ColumnDataType(
+        String columnName, boolean withType, ColDataType colDataType, List<String> columnSpecs) {
+      super(columnName, colDataType, columnSpecs);
+      this.withType = withType;
     }
 
     @Override
     public String toString() {
-
-        StringBuilder b = new StringBuilder();
-
-        b.append(operation).append(" ");
-
-        if (commentText != null) {
-            if (columnName != null) {
-                b.append(columnName).append(" COMMENT ");
-            }
-            b.append(commentText);
-        } else if (columnName != null) {
-            b.append("COLUMN ");
-            if (operation == AlterOperation.RENAME) {
-                b.append(columnOldName).append(" TO ");
-            }
-            b.append(columnName);
-        } else if (getColDataTypeList() != null) {
-            if (operation == AlterOperation.CHANGE) {
-                if (optionalSpecifier != null) {
-                    b.append(optionalSpecifier).append(" ");
-                }
-                b.append(columnOldName).append(" ");
-            } else if (colDataTypeList.size() > 1) {
-                b.append("(");
-            } else {
-                b.append("COLUMN ");
-            }
-            b.append(PlainSelect.getStringList(colDataTypeList));
-            if (colDataTypeList.size() > 1) {
-                b.append(")");
-            }
-        } else if (getColumnDropNotNullList() != null) {
-            if (operation == AlterOperation.CHANGE) {
-                if (optionalSpecifier != null) {
-                    b.append(optionalSpecifier).append(" ");
-                }
-                b.append(columnOldName).append(" ");
-            } else if (columnDropNotNullList.size() > 1) {
-                b.append("(");
-            } else {
-                b.append("COLUMN ");
-            }
-            b.append(PlainSelect.getStringList(columnDropNotNullList));
-            if (columnDropNotNullList.size() > 1) {
-                b.append(")");
-            }
-        } else if (constraintName != null) {
-            b.append("CONSTRAINT ");
-            if (constraintIfExists) {
-                b.append("IF EXISTS ");
-            }
-            b.append(constraintName);
-        } else if (pkColumns != null) {
-            b.append("PRIMARY KEY (").append(PlainSelect.getStringList(pkColumns)).append(')');
-        } else if (ukColumns != null) {
-            b.append("UNIQUE");
-            if (ukName != null) {
-                if (getUk()) {
-                    b.append(" KEY ");
-                } else {
-                    b.append(" INDEX ");
-                }
-                b.append(ukName);
-            }
-            b.append(" (").append(PlainSelect.getStringList(ukColumns)).append(")");
-        } else if (fkColumns != null) {
-              b.append("FOREIGN KEY (")
-                  .append(PlainSelect.getStringList(fkColumns))
-                  .append(") REFERENCES ")
-                  .append(
-                      fkSourceSchema != null && fkSourceSchema.trim().length() > 0
-                          ? fkSourceSchema + "."
-                          : "")
-                  .append(fkSourceTable)
-                  .append(" (")
-                  .append(PlainSelect.getStringList(fkSourceColumns))
-                  .append(")");
-              referentialActions.forEach(b::append);
-        } else if (index != null) {
-            b.append(index);
-        }
-        if (getConstraints() != null && !getConstraints().isEmpty()) {
-            b.append(' ').append(PlainSelect.getStringList(constraints, false, false));
-        }
-        if (getUseEqual()) {
-            b.append('=');
-        }
-        if (parameters != null && !parameters.isEmpty()) {
-            b.append(' ').append(PlainSelect.getStringList(parameters, false, false));
-        }
-
-        return b.toString();
+      return getColumnName() + (withType ? " TYPE " : " ") + toStringDataTypeAndSpec();
     }
 
-    public AlterExpression withOperation(AlterOperation operation) {
-        this.setOperation(operation);
-        return this;
+    @Override
+    public ColumnDataType withColDataType(ColDataType colDataType) {
+      return (ColumnDataType) super.withColDataType(colDataType);
     }
 
-    public AlterExpression withOptionalSpecifier(String optionalSpecifier) {
-        this.setOptionalSpecifier(optionalSpecifier);
-        return this;
+    @Override
+    public ColumnDataType withColumnName(String columnName) {
+      return (ColumnDataType) super.withColumnName(columnName);
     }
 
-    public AlterExpression withColumnName(String columnName) {
-        this.setColumnName(columnName);
-        return this;
+    @Override
+    public ColumnDataType addColumnSpecs(String... columnSpecs) {
+      return (ColumnDataType) super.addColumnSpecs(columnSpecs);
     }
 
-    public AlterExpression withPkColumns(List<String> pkColumns) {
-        this.setPkColumns(pkColumns);
-        return this;
+    @Override
+    public ColumnDataType addColumnSpecs(Collection<String> columnSpecs) {
+      return (ColumnDataType) super.addColumnSpecs(columnSpecs);
     }
 
-    public AlterExpression withUkColumns(List<String> ukColumns) {
-        this.setUkColumns(ukColumns);
-        return this;
+    @Override
+    public ColumnDataType withColumnSpecs(List<String> columnSpecs) {
+      return (ColumnDataType) super.withColumnSpecs(columnSpecs);
+    }
+  }
+
+  public static final class ColumnDropNotNull {
+
+    private final String columnName;
+    private final boolean withNot;
+
+    public ColumnDropNotNull(String columnName) {
+      this(columnName, false);
     }
 
-    public AlterExpression withUkName(String ukName) {
-        this.setUkName(ukName);
-        return this;
+    public ColumnDropNotNull(String columnName, boolean withNot) {
+      this.columnName = columnName;
+      this.withNot = withNot;
     }
 
-    public AlterExpression withIndex(Index index) {
-        this.setIndex(index);
-        return this;
+    public String getColumnName() {
+      return columnName;
     }
 
-    public AlterExpression withConstraintName(String constraintName) {
-        this.setConstraintName(constraintName);
-        return this;
+    public boolean isWithNot() {
+      return withNot;
     }
 
-    public AlterExpression constraintIfExists(boolean constraintIfExists) {
-        this.setConstraintIfExists(constraintIfExists);
-        return this;
+    @Override
+    public String toString() {
+      return columnName + " DROP" + (withNot ? " NOT " : " ") + "NULL";
     }
-
-    public AlterExpression withOnDeleteRestrict(boolean onDeleteRestrict) {
-        this.setOnDeleteRestrict(onDeleteRestrict);
-        return this;
-    }
-
-    public AlterExpression withOnDeleteSetNull(boolean onDeleteSetNull) {
-        this.setOnDeleteSetNull(onDeleteSetNull);
-        return this;
-    }
-
-    public AlterExpression withOnDeleteCascade(boolean onDeleteCascade) {
-        this.setOnDeleteCascade(onDeleteCascade);
-        return this;
-    }
-
-    public AlterExpression withFkColumns(List<String> fkColumns) {
-        this.setFkColumns(fkColumns);
-        return this;
-    }
-    
-    public AlterExpression withFkSourceSchema(String fkSourceSchema) {
-        this.setFkSourceTable(fkSourceSchema);
-        return this;
-    }
-
-    public AlterExpression withFkSourceTable(String fkSourceTable) {
-        this.setFkSourceTable(fkSourceTable);
-        return this;
-    }
-
-    public AlterExpression withFkSourceColumns(List<String> fkSourceColumns) {
-        this.setFkSourceColumns(fkSourceColumns);
-        return this;
-    }
-
-    public AlterExpression withUk(boolean uk) {
-        this.setUk(uk);
-        return this;
-    }
-
-    public AlterExpression withUseEqual(boolean useEqual) {
-        this.setUseEqual(useEqual);
-        return this;
-    }
-
-    public AlterExpression withConstraints(List<ConstraintState> constraints) {
-        this.setConstraints(constraints);
-        return this;
-    }
-
-    public AlterExpression withCommentText(String commentText) {
-        this.setCommentText(commentText);
-        return this;
-    }
-
-    public AlterExpression withColumnOldName(String columnOldName) {
-        setColumnOldName(columnOldName);
-        return this;
-    }
-
-    public AlterExpression addPkColumns(String... pkColumns) {
-        List<String> collection = Optional.ofNullable(getPkColumns()).orElseGet(ArrayList::new);
-        Collections.addAll(collection, pkColumns);
-        return this.withPkColumns(collection);
-    }
-
-    public AlterExpression addPkColumns(Collection<String> pkColumns) {
-        List<String> collection = Optional.ofNullable(getPkColumns()).orElseGet(ArrayList::new);
-        collection.addAll(pkColumns);
-        return this.withPkColumns(collection);
-    }
-
-    public AlterExpression addUkColumns(String... ukColumns) {
-        List<String> collection = Optional.ofNullable(getUkColumns()).orElseGet(ArrayList::new);
-        Collections.addAll(collection, ukColumns);
-        return this.withUkColumns(collection);
-    }
-
-    public AlterExpression addUkColumns(Collection<String> ukColumns) {
-        List<String> collection = Optional.ofNullable(getUkColumns()).orElseGet(ArrayList::new);
-        collection.addAll(ukColumns);
-        return this.withUkColumns(collection);
-    }
-
-    public AlterExpression addFkColumns(String... fkColumns) {
-        List<String> collection = Optional.ofNullable(getFkColumns()).orElseGet(ArrayList::new);
-        Collections.addAll(collection, fkColumns);
-        return this.withFkColumns(collection);
-    }
-
-    public AlterExpression addFkColumns(Collection<String> fkColumns) {
-        List<String> collection = Optional.ofNullable(getFkColumns()).orElseGet(ArrayList::new);
-        collection.addAll(fkColumns);
-        return this.withFkColumns(collection);
-    }
-
-    public AlterExpression addFkSourceColumns(String... fkSourceColumns) {
-        List<String> collection = Optional.ofNullable(getFkSourceColumns()).orElseGet(ArrayList::new);
-        Collections.addAll(collection, fkSourceColumns);
-        return this.withFkSourceColumns(collection);
-    }
-
-    public AlterExpression addFkSourceColumns(Collection<String> fkSourceColumns) {
-        List<String> collection = Optional.ofNullable(getFkSourceColumns()).orElseGet(ArrayList::new);
-        collection.addAll(fkSourceColumns);
-        return this.withFkSourceColumns(collection);
-    }
-
-    public AlterExpression addConstraints(ConstraintState... constraints) {
-        List<ConstraintState> collection = Optional.ofNullable(getConstraints()).orElseGet(ArrayList::new);
-        Collections.addAll(collection, constraints);
-        return this.withConstraints(collection);
-    }
-
-    public AlterExpression addConstraints(Collection<? extends ConstraintState> constraints) {
-        List<ConstraintState> collection = Optional.ofNullable(getConstraints()).orElseGet(ArrayList::new);
-        collection.addAll(constraints);
-        return this.withConstraints(collection);
-    }
-
-    public static final class ColumnDataType extends ColumnDefinition {
-
-        private final boolean withType;
-
-        public ColumnDataType(boolean withType) {
-            super();
-            this.withType = withType;
-        }
-
-        public ColumnDataType(String columnName, boolean withType, ColDataType colDataType, List<String> columnSpecs) {
-            super(columnName, colDataType, columnSpecs);
-            this.withType = withType;
-        }
-
-        @Override
-        public String toString() {
-            return getColumnName() + (withType ? " TYPE " : " ") + toStringDataTypeAndSpec();
-        }
-
-        @Override
-        public ColumnDataType withColDataType(ColDataType colDataType) {
-            return (ColumnDataType) super.withColDataType(colDataType);
-        }
-
-        @Override
-        public ColumnDataType withColumnName(String columnName) {
-            return (ColumnDataType) super.withColumnName(columnName);
-        }
-
-        @Override
-        public ColumnDataType addColumnSpecs(String... columnSpecs) {
-            return (ColumnDataType) super.addColumnSpecs(columnSpecs);
-        }
-
-        @Override
-        public ColumnDataType addColumnSpecs(Collection<String> columnSpecs) {
-            return (ColumnDataType) super.addColumnSpecs(columnSpecs);
-        }
-
-        @Override
-        public ColumnDataType withColumnSpecs(List<String> columnSpecs) {
-            return (ColumnDataType) super.withColumnSpecs(columnSpecs);
-        }
-
-    }
-
-    public final static class ColumnDropNotNull {
-
-        private final String columnName;
-        private final boolean withNot;
-
-        public ColumnDropNotNull(String columnName) {
-            this(columnName, false);
-        }
-
-        public ColumnDropNotNull(String columnName, boolean withNot) {
-            this.columnName = columnName;
-            this.withNot = withNot;
-        }
-
-        public String getColumnName() {
-            return columnName;
-        }
-
-        public boolean isWithNot() {
-            return withNot;
-        }
-
-        @Override
-        public String toString() {
-            return columnName + " DROP"
-                    + (withNot ? " NOT " : " ") + "NULL";
-        }
-    }
+  }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -48,6 +48,8 @@ public class AlterExpression {
     private Set<ReferentialAction> referentialActions = new LinkedHashSet<>(2);
 
     private List<String> fkColumns;
+    private String fkSourceSchema;
+
     private String fkSourceTable;
     private List<String> fkSourceColumns;
     private boolean uk;
@@ -56,6 +58,13 @@ public class AlterExpression {
     private List<ConstraintState> constraints;
     private List<String> parameters;
     private String commentText;
+    
+    public String getFkSourceSchema() {
+      return fkSourceSchema;
+    }
+    public void setFkSourceSchema(String fkSourceSchema) {
+      this.fkSourceSchema = fkSourceSchema;
+    }
 
     public String getCommentText() {
         return commentText;
@@ -405,11 +414,18 @@ public class AlterExpression {
             }
             b.append(" (").append(PlainSelect.getStringList(ukColumns)).append(")");
         } else if (fkColumns != null) {
-            b.append("FOREIGN KEY (").append(PlainSelect.getStringList(fkColumns)).append(") REFERENCES ")
-            .append(fkSourceTable).append(" (").append(
-                    PlainSelect.getStringList(fkSourceColumns))
-            .append(")");
-            referentialActions.forEach(b::append);
+              b.append("FOREIGN KEY (")
+                  .append(PlainSelect.getStringList(fkColumns))
+                  .append(") REFERENCES ")
+                  .append(
+                      fkSourceSchema != null && fkSourceSchema.trim().length() > 0
+                          ? fkSourceSchema + "."
+                          : "")
+                  .append(fkSourceTable)
+                  .append(" (")
+                  .append(PlainSelect.getStringList(fkSourceColumns))
+                  .append(")");
+              referentialActions.forEach(b::append);
         } else if (index != null) {
             b.append(index);
         }
@@ -488,6 +504,11 @@ public class AlterExpression {
 
     public AlterExpression withFkColumns(List<String> fkColumns) {
         this.setFkColumns(fkColumns);
+        return this;
+    }
+    
+    public AlterExpression withFkSourceSchema(String fkSourceSchema) {
+        this.setFkSourceTable(fkSourceSchema);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
+++ b/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import static java.util.stream.Collectors.joining;
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
@@ -27,6 +28,7 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
 public class Delete implements Statement {
 
     private Table table;
+    private OracleHint oracleHint = null;
     private List<Table> tables;
     private List<Join> joins;
     private Expression where;
@@ -60,6 +62,14 @@ public class Delete implements Statement {
 
     public void setWhere(Expression expression) {
         where = expression;
+    }
+    
+    public OracleHint getOracleHint() {
+        return oracleHint;
+    }
+
+    public void setOracleHint(OracleHint oracleHint) {
+        this.oracleHint = oracleHint;
     }
 
     public Limit getLimit() {

--- a/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
@@ -16,6 +16,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.expression.operators.relational.ItemsList;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
@@ -29,6 +30,7 @@ import net.sf.jsqlparser.statement.select.WithItem;
 public class Insert implements Statement {
 
     private Table table;
+    private OracleHint oracleHint = null;
     private List<Column> columns;
     private ItemsList itemsList;
     private boolean useValues = true;
@@ -60,6 +62,14 @@ public class Insert implements Statement {
 
     public void setTable(Table name) {
         table = name;
+    }
+    
+    public OracleHint getOracleHint() {
+        return oracleHint;
+    }
+
+    public void setOracleHint(OracleHint oracleHint) {
+        this.oracleHint = oracleHint;
     }
 
     public List<Column> getColumns() {

--- a/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
@@ -11,6 +11,7 @@ package net.sf.jsqlparser.statement.merge;
 
 import net.sf.jsqlparser.expression.Alias;
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
@@ -19,6 +20,7 @@ import net.sf.jsqlparser.statement.select.SubSelect;
 public class Merge implements Statement {
 
     private Table table;
+    private OracleHint oracleHint = null;
     private Table usingTable;
     private SubSelect usingSelect;
     private Alias usingAlias;
@@ -33,6 +35,14 @@ public class Merge implements Statement {
 
     public void setTable(Table name) {
         table = name;
+    }
+    
+    public OracleHint getOracleHint() {
+        return oracleHint;
+    }
+
+    public void setOracleHint(OracleHint oracleHint) {
+        this.oracleHint = oracleHint;
     }
 
     public Table getUsingTable() {

--- a/src/main/java/net/sf/jsqlparser/statement/merge/MergeInsert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/MergeInsert.java
@@ -22,6 +22,7 @@ public class MergeInsert {
 
     private List<Column> columns = null;
     private List<Expression> values = null;
+    private Expression whereCondition;
 
     public List<Column> getColumns() {
         return columns;
@@ -38,12 +39,21 @@ public class MergeInsert {
     public void setValues(List<Expression> values) {
         this.values = values;
     }
+    
+    public Expression getWhereCondition() {
+        return whereCondition;
+    }
+
+    public void setWhereCondition(Expression whereCondition) {
+        this.whereCondition = whereCondition;
+    }
 
     @Override
     public String toString() {
         return " WHEN NOT MATCHED THEN INSERT "
                 + (columns.isEmpty() ? "" : PlainSelect.getStringList(columns, true, true))
-                + " VALUES " + PlainSelect.getStringList(values, true, true);
+                + " VALUES " + PlainSelect.getStringList(values, true, true)
+                + (whereCondition != null ? (" WHERE " + whereCondition) : "");
     }
 
     public MergeInsert withColumns(List<Column> columns) {
@@ -78,5 +88,14 @@ public class MergeInsert {
         List<Expression> collection = Optional.ofNullable(getValues()).orElseGet(ArrayList::new);
         collection.addAll(values);
         return this.withValues(collection);
+    }
+    
+     public MergeInsert withWhereCondition(Expression whereCondition) {
+        this.setWhereCondition(whereCondition);
+        return this;
+    }
+     
+     public <E extends Expression> E getWhereCondition(Class<E> type) {
+        return type.cast(getWhereCondition());
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/update/Update.java
+++ b/src/main/java/net/sf/jsqlparser/statement/update/Update.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
@@ -39,6 +40,7 @@ public class Update implements Statement {
     private Select select;
     private boolean useColumnsBrackets = true;
     private boolean useSelect = false;
+    private OracleHint oracleHint = null;
     private List<OrderByElement> orderByElements;
     private Limit limit;
     private boolean returningAllColumns = false;
@@ -63,6 +65,14 @@ public class Update implements Statement {
 
     public void setWhere(Expression expression) {
         where = expression;
+    }
+    
+    public OracleHint getOracleHint() {
+        return oracleHint;
+    }
+
+    public void setOracleHint(OracleHint oracleHint) {
+        this.oracleHint = oracleHint;
     }
 
     public List<Column> getColumns() {
@@ -160,7 +170,7 @@ public class Update implements Statement {
     public void setReturningExpressionList(List<SelectExpressionItem> returningExpressionList) {
         this.returningExpressionList = returningExpressionList;
     }
-
+    
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder("UPDATE ");

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4779,7 +4779,7 @@ AlterExpression AlterExpression():
               [<K_USING> sk4=RelObjectName() { alterExp.addParameters("USING", sk4); }]
             )
                     |
-            LOOKAHEAD(3) ( (LOOKAHEAD(2) <K_COLUMN>)?
+            LOOKAHEAD(3) ( (LOOKAHEAD(2) <K_COLUMN> { alterExp.hasColumn(true); })?
                 (LOOKAHEAD(2) alterExpressionColumnDataType = AlterExpressionColumnDataType() { alterExp.addColDataType(alterExpressionColumnDataType); }
                 |
                 alterExpressionColumnDropNotNull = AlterExpressionColumnDropNotNull() { alterExp.addColDropNotNull( alterExpressionColumnDropNotNull); })
@@ -4904,7 +4904,7 @@ AlterExpression AlterExpression():
           alterExp.setOperation(AlterOperation.CHANGE);
         }
         (
-          <K_COLUMN> { alterExp.setOptionalSpecifier("COLUMN"); } | {}
+          <K_COLUMN> { alterExp.hasColumn(true); alterExp.setOptionalSpecifier("COLUMN"); } | {}
         )
         (
           (tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER>)
@@ -4919,7 +4919,7 @@ AlterExpression AlterExpression():
               alterExp.setOperation(AlterOperation.DROP);
           }
            (
-               (  (LOOKAHEAD(2) <K_COLUMN>)?
+               (  (LOOKAHEAD(2) <K_COLUMN> { alterExp.hasColumn(true); })?
                   (tk=<S_IDENTIFIER>    | tk=<S_QUOTED_IDENTIFIER>)
                        {
                               alterExp.setColumnName(tk.image);
@@ -4955,7 +4955,7 @@ AlterExpression AlterExpression():
       |
       (<K_RENAME> {alterExp.setOperation(AlterOperation.RENAME);}
         (
-          <K_COLUMN>
+          <K_COLUMN> {alterExp.hasColumn(true);}
           (tk=<S_IDENTIFIER>    | tk=<S_QUOTED_IDENTIFIER>) { alterExp.setColOldName(tk.image);}
            (<K_TO>)
           (tk2=<S_IDENTIFIER>    | tk2=<S_QUOTED_IDENTIFIER>) { alterExp.setColumnName(tk2.image);}

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -879,7 +879,7 @@ Update Update():
     List<SelectExpressionItem> returning = null;
 }
 {
-    <K_UPDATE> table=TableWithAlias()
+   <K_UPDATE> { update.setOracleHint(getOracleHint()); } table=TableWithAlias()  
         startJoins=JoinsList()
 
     <K_SET>
@@ -1023,7 +1023,7 @@ Insert Insert( List<WithItem> with ):
     boolean useAs = false;
 }
 {    
-    <K_INSERT>
+    <K_INSERT> { insert.setOracleHint(getOracleHint()); }
     [(tk = <K_LOW_PRIORITY> | tk = <K_DELAYED> | tk = <K_HIGH_PRIORITY>)
     {if (tk!=null)
         modifierPriority = InsertModifierPriority.valueOf(tk.image.toUpperCase());
@@ -1209,7 +1209,7 @@ Delete Delete():
     List<OrderByElement> orderByElements;
 }
 {
-    <K_DELETE> [LOOKAHEAD(2) (table=TableWithAlias() { tables.add(table); }
+    <K_DELETE> { delete.setOracleHint(getOracleHint()); } [LOOKAHEAD(2) (table=TableWithAlias() { tables.add(table); }
           ("," table=TableWithAlias() { tables.add(table); } )*
     <K_FROM> | <K_FROM>)]
 
@@ -1235,7 +1235,7 @@ Statement Merge() : {
     MergeInsert insert;
 }
 {
-    <K_MERGE> <K_INTO> table=TableWithAlias() { merge.setTable(table); }
+    <K_MERGE> { merge.setOracleHint(getOracleHint()); } <K_INTO> table=TableWithAlias() { merge.setTable(table); }
     <K_USING>
         ( table=Table() { merge.setUsingTable(table); }
             | "(" select=SubSelect() { merge.setUsingSelect(select); } ")" )

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4026,7 +4026,7 @@ CreateIndex CreateIndex():
     Index index = null;
     //String name = null;
     List<String> parameter = new ArrayList<String>();
-    List<String> tailParameter = null;
+    List<String> tailParameters = new ArrayList<String>();
     List<String> name;
 }
 {
@@ -4047,13 +4047,15 @@ CreateIndex CreateIndex():
 
     colNames = ColumnNamesWithParamsList()
 
-    [ tailParameter = CreateParameter() {} ]
+    /* [ tailParameter = CreateParameter() {} ] */
+
+    ( parameter=CreateParameter() { tailParameters.addAll(parameter); } )*
 
     {
         index.setColumns(colNames);
         createIndex.setIndex(index);
         createIndex.setTable(table);
-        createIndex.setTailParameters(tailParameter);
+        createIndex.setTailParameters(tailParameters);
         return createIndex;
     }
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1287,14 +1287,18 @@ MergeInsert MergeInsertClause() : {
     List<Expression> expList = new ArrayList<Expression>();
     Column col;
     Expression exp;
+    Expression condition;
 }
 {
     <K_WHEN> <K_NOT> <K_MATCHED> <K_THEN>
         <K_INSERT> ["(" col=Column() { columns.add(col); } ("," col=Column() { columns.add(col); } )* ")"]  <K_VALUES>
            "(" exp=SimpleExpression() { expList.add(exp); } ("," exp=SimpleExpression() { expList.add(exp); } )* ")"
-    {
-        return mi.withColumns(columns).withValues(expList);
-    }
+
+        { mi.withColumns(columns).withValues(expList); }
+        
+        [ <K_WHERE> condition = Expression() { mi.setWhereCondition(condition); }]
+        
+        { return mi; }
 }
 
 List<String> RelObjectNameList() : {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4796,8 +4796,16 @@ AlterExpression AlterExpression():
             |
     //following two choices regarding foreign keys should be merged
             ( <K_FOREIGN> <K_KEY> columnNames=ColumnsNamesList() { alterExp.setFkColumns(columnNames); columnNames = null; }
-                 <K_REFERENCES> tk=<S_IDENTIFIER> [ columnNames=ColumnsNamesList() ]
+                 /*
+                    <K_REFERENCES> tk=<S_IDENTIFIER> [ columnNames=ColumnsNamesList() ]
                         { alterExp.setFkSourceTable(tk.image); alterExp.setFkSourceColumns(columnNames); }
+                 */
+                 <K_REFERENCES> fkTable=Table() [ columnNames=ColumnsNamesList() ]
+                    {
+                        alterExp.setFkSourceSchema(fkTable.getSchemaName());
+                        alterExp.setFkSourceTable(fkTable.getName());
+                        alterExp.setFkSourceColumns(columnNames); 
+                    }
                                 
                 [LOOKAHEAD(2) (<K_ON> (tk=<K_DELETE> | tk=<K_UPDATE>) action = Action()
                         		  { alterExp.setReferentialAction(ReferentialAction.Type.valueOf(tk.image), action); }

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -146,6 +146,20 @@ public class AlterTest {
     public void testAlterTableForgeignKey4() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE test ADD FOREIGN KEY (user_id) REFERENCES ra_user (id) ON DELETE SET NULL");
     }
+    
+    @Test
+    public void testAlterTableForgeignWithFkSchema() throws JSQLParserException {
+      final String FK_SCHEMA_NAME = "my_schema";
+      final String FK_TABLE_NAME= "ra_user";
+      String sql = "ALTER TABLE test ADD FOREIGN KEY (user_id) REFERENCES " + FK_SCHEMA_NAME +"." + FK_TABLE_NAME + " (id) ON DELETE SET NULL";
+      assertSqlCanBeParsedAndDeparsed(sql);
+      
+      Alter alter = (Alter) CCJSqlParserUtil.parse(sql);
+      AlterExpression alterExpression = alter.getAlterExpressions().get(0);
+
+      assertEquals(alterExpression.getFkSourceSchema(), FK_SCHEMA_NAME);
+      assertEquals(alterExpression.getFkSourceTable(), FK_TABLE_NAME);
+    }
 
     @Test
     public void testAlterTableDropColumn() throws JSQLParserException {

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
@@ -10,6 +10,7 @@
 package net.sf.jsqlparser.statement.create;
 
 import java.io.StringReader;
+import java.util.List;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
@@ -119,4 +120,20 @@ public class CreateIndexTest {
     public void testFullIndexNameIssue936_2() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("CREATE INDEX \"TS\".\"IDX\" ON \"TEST\" (\"ID\") TABLESPACE \"TS\"");
     }
+
+  @Test
+  public void testCreateIndexTrailingOptions() throws JSQLParserException {
+    String statement =
+        "CREATE UNIQUE INDEX cfe.version_info_idx2\n"
+            + "    ON cfe.version_info ( major_version\n"
+            + "                            , minor_version\n"
+            + "                            , patch_level ) parallel compress nologging\n"
+            + ";";
+    CreateIndex createIndex = (CreateIndex) parserManager.parse(new StringReader(statement));
+    List<String> tailParameters = createIndex.getTailParameters();
+    assertEquals(3, tailParameters.size());
+    assertEquals(tailParameters.get(0), "parallel");
+    assertEquals(tailParameters.get(1), "compress");
+    assertEquals(tailParameters.get(2), "nologging");
+  }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
@@ -21,6 +21,7 @@ import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
 import net.sf.jsqlparser.schema.Column;
+import static net.sf.jsqlparser.test.TestUtils.assertOracleHintExists;
 import org.junit.Test;
 
 public class DeleteTest {
@@ -93,5 +94,14 @@ public class DeleteTest {
      @Test
     public void testDeleteMultiTableIssue878() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("DELETE table1, table2 FROM table1, table2");
+    }
+    
+    @Test
+    public void testOracleHint() throws JSQLParserException {
+        String sql = "DELETE /*+ SOMEHINT */ FROM mytable WHERE mytable.col = 9";
+        
+        assertOracleHintExists(sql, true, "SOMEHINT");
+       
+       //@todo: add a testcase supposed to not finding a misplaced hint
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
@@ -34,6 +34,7 @@ import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.select.AllColumns;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
+import static net.sf.jsqlparser.test.TestUtils.assertOracleHintExists;
 
 public class InsertTest {
 
@@ -349,5 +350,12 @@ public class InsertTest {
     @Test
     public void testWithListIssue282() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("WITH myctl AS (SELECT a, b FROM mytable) INSERT INTO mytable SELECT a, b FROM myctl");
+    }
+    
+    @Test
+    public void testOracleHint() throws JSQLParserException {
+        assertOracleHintExists("INSERT /*+ SOMEHINT */ INTO mytable VALUES (1, 2, 3)", true, "SOMEHINT");
+       
+       //@todo: add a testcase supposed to not finding a misplaced hint
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/merge/MergeTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/merge/MergeTest.java
@@ -13,6 +13,7 @@ import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
 import static net.sf.jsqlparser.test.TestUtils.*;
+import org.assertj.core.api.Assertions;
 import static org.junit.Assert.fail;
 import org.junit.Test;
 
@@ -151,9 +152,6 @@ public class MergeTest {
                 + "    )\n";
 
         Statement statement = CCJSqlParserUtil.parse(sql);
-
-        System.out.println(statement.toString());
-
         assertSqlCanBeParsedAndDeparsed(sql, true);
     }
 
@@ -195,4 +193,32 @@ public class MergeTest {
        
        //@todo: add a testcase supposed to not finding a misplaced hint
     }
+
+  @Test
+  public void testInsertMergeWhere() throws JSQLParserException {
+    String sql =
+        "-- Both clauses present.\n"
+            + "MERGE INTO test1 a\n"
+            + "  USING all_objects b\n"
+            + "    ON (a.object_id = b.object_id)\n"
+            + "  WHEN MATCHED THEN\n"
+            + "    UPDATE SET a.status = b.status\n"
+            + "    WHERE  b.status != 'VALID'\n"
+            + "  WHEN NOT MATCHED THEN\n"
+            + "    INSERT (object_id, status)\n"
+            + "    VALUES (b.object_id, b.status)\n"
+            + "\n"
+            + "    WHERE  b.status != 'VALID'\n"
+            ;
+
+    Statement statement = CCJSqlParserUtil.parse(sql);
+    assertSqlCanBeParsedAndDeparsed(sql, true);
+    
+    Merge merge = (Merge) statement;
+    MergeInsert mergeInsert = merge.getMergeInsert();
+    Assertions.assertThat( mergeInsert.getWhereCondition() );
+    
+    MergeUpdate mergeUpdate = merge.getMergeUpdate();
+    Assertions.assertThat( mergeUpdate.getWhereCondition() );
+  }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/merge/MergeTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/merge/MergeTest.java
@@ -176,4 +176,23 @@ public class MergeTest {
             //expected to fail
         }
     }
+    
+    @Test
+    public void testOracleHint() throws JSQLParserException {
+        String sql = "MERGE /*+ SOMEHINT */ INTO bonuses B\n"
+                + "USING (\n"
+                + "  SELECT employee_id, salary\n"
+                + "  FROM employee\n"
+                + "  WHERE dept_no =20) E\n"
+                + "ON (B.employee_id = E.employee_id)\n"
+                + "WHEN MATCHED THEN\n"
+                + "  UPDATE SET B.bonus = E.salary * 0.1\n"
+                + "WHEN NOT MATCHED THEN\n"
+                + "  INSERT (B.employee_id, B.bonus)\n"
+                + "  VALUES (E.employee_id, E.salary * 0.05)  ";
+        
+        assertOracleHintExists(sql, true, "SOMEHINT");
+       
+       //@todo: add a testcase supposed to not finding a misplaced hint
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/update/UpdateTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/update/UpdateTest.java
@@ -165,4 +165,12 @@ public class UpdateTest {
     public void testUpdateVariableAssignment() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("UPDATE transaction_id SET latest_id_wallet = (@cur_id_wallet := latest_id_wallet) + 1");
     }
+    
+    @Test
+    public void testOracleHint() throws JSQLParserException {
+        assertOracleHintExists("UPDATE /*+ SOMEHINT */ mytable set col1='as', col2=?, col3=565 Where o >= 3", true, "SOMEHINT");
+       
+       //@todo: add a testcase supposed to not finding a misplaced hint
+       // assertOracleHintExists("UPDATE  mytable /*+ SOMEHINT */ set col1='as', col2=?, col3=565 Where o >= 3", true, "SOMEHINT");
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/test/TestUtils.java
+++ b/src/test/java/net/sf/jsqlparser/test/TestUtils.java
@@ -29,9 +29,12 @@ import net.sf.jsqlparser.parser.CCJSqlParser;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.parser.Node;
 import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.delete.Delete;
+import net.sf.jsqlparser.statement.insert.Insert;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.select.SetOperationList;
+import net.sf.jsqlparser.statement.update.Update;
 import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
 import net.sf.jsqlparser.util.deparser.SelectDeParser;
 import net.sf.jsqlparser.util.deparser.StatementDeParser;
@@ -281,31 +284,55 @@ public class TestUtils {
         assertEquals(expression, stringBuilder.toString());
     }
 
-    public static void assertOracleHintExists(String sql, boolean assertDeparser, String... hints) throws JSQLParserException {
-        if (assertDeparser) {
-            assertSqlCanBeParsedAndDeparsed(sql, true);
-        }
-        Select stmt = (Select) CCJSqlParserUtil.parse(sql);
-        if (stmt.getSelectBody() instanceof PlainSelect) {
-            PlainSelect ps = (PlainSelect) stmt.getSelectBody();
-            OracleHint hint = ps.getOracleHint();
-            assertNotNull(hint);
-            assertEquals(hints[0], hint.getValue());
-        } else {
-            if (stmt.getSelectBody() instanceof SetOperationList) {
-                SetOperationList setop = (SetOperationList) stmt.getSelectBody();
-                for (int i = 0; i < setop.getSelects().size(); i++) {
-                    PlainSelect pselect = (PlainSelect) setop.getSelects().get(i);
-                    OracleHint hint = pselect.getOracleHint();
-                    if (hints[i] == null) {
-                        Assert.assertNull(hint);
-                    } else {
-                        assertNotNull(hint);
-                        assertEquals(hints[i], hint.getValue());
-                    }
-                }
-            }
-        }
+  public static void assertOracleHintExists(String sql, boolean assertDeparser, String... hints)
+      throws JSQLParserException {
+    if (assertDeparser) {
+      assertSqlCanBeParsedAndDeparsed(sql, true);
     }
 
+    Statement statement = CCJSqlParserUtil.parse(sql);
+    if (statement instanceof Select) {
+      Select stmt = (Select) statement;
+      if (stmt.getSelectBody() instanceof PlainSelect) {
+        PlainSelect ps = (PlainSelect) stmt.getSelectBody();
+        OracleHint hint = ps.getOracleHint();
+        assertNotNull(hint);
+        assertEquals(hints[0], hint.getValue());
+      } else {
+        if (stmt.getSelectBody() instanceof SetOperationList) {
+          SetOperationList setop = (SetOperationList) stmt.getSelectBody();
+          for (int i = 0; i < setop.getSelects().size(); i++) {
+            PlainSelect pselect = (PlainSelect) setop.getSelects().get(i);
+            OracleHint hint = pselect.getOracleHint();
+            if (hints[i] == null) {
+              Assert.assertNull(hint);
+            } else {
+              assertNotNull(hint);
+              assertEquals(hints[i], hint.getValue());
+            }
+          }
+        }
+      }
+    } else if (statement instanceof Update) {
+      Update stmt = (Update) statement;
+      OracleHint hint = stmt.getOracleHint();
+      assertNotNull(hint);
+      assertEquals(hints[0], hint.getValue());
+    } else if (statement instanceof Insert) {
+      Insert stmt = (Insert) statement;
+      OracleHint hint = stmt.getOracleHint();
+      assertNotNull(hint);
+      assertEquals(hints[0], hint.getValue());
+    } else if (statement instanceof Update) {
+      Update stmt = (Update) statement;
+      OracleHint hint = stmt.getOracleHint();
+      assertNotNull(hint);
+      assertEquals(hints[0], hint.getValue());
+    } else if (statement instanceof Delete) {
+      Delete stmt = (Delete) statement;
+      OracleHint hint = stmt.getOracleHint();
+      assertNotNull(hint);
+      assertEquals(hints[0], hint.getValue());
+    }
+  }
 }


### PR DESCRIPTION
Fix Issue #1157: Oracle does not accept COLUMN keyword in ALTER TABLE ADD/MODIFY
Correct the test cases accepting a non existing COLUMN keyword
Add a specific test cases
