### PR TITLE
Add support for boolean 'XOR' operator

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -12,6 +12,7 @@ package net.sf.jsqlparser.expression;
 import net.sf.jsqlparser.expression.operators.arithmetic.*;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
+import net.sf.jsqlparser.expression.operators.conditional.XorExpression;
 import net.sf.jsqlparser.expression.operators.relational.*;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.select.SubSelect;
@@ -61,6 +62,8 @@ public interface ExpressionVisitor {
     void visit(AndExpression andExpression);
 
     void visit(OrExpression orExpression);
+
+    void visit(XorExpression orExpression);
 
     void visit(Between between);
 

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -12,6 +12,7 @@ package net.sf.jsqlparser.expression;
 import net.sf.jsqlparser.expression.operators.arithmetic.*;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
+import net.sf.jsqlparser.expression.operators.conditional.XorExpression;
 import net.sf.jsqlparser.expression.operators.relational.*;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.select.AllColumns;
@@ -144,6 +145,11 @@ public class ExpressionVisitorAdapter implements ExpressionVisitor, ItemsListVis
 
     @Override
     public void visit(OrExpression expr) {
+        visitBinaryExpression(expr);
+    }
+
+    @Override
+    public void visit(XorExpression expr) {
         visitBinaryExpression(expr);
     }
 

--- a/src/main/java/net/sf/jsqlparser/expression/operators/conditional/XorExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/conditional/XorExpression.java
@@ -1,0 +1,47 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2021 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression.operators.conditional;
+
+import net.sf.jsqlparser.expression.BinaryExpression;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+
+public class XorExpression extends BinaryExpression {
+
+    public XorExpression() {
+        // nothing
+    }
+
+    public XorExpression(Expression leftExpression, Expression rightExpression) {
+        setLeftExpression(leftExpression);
+        setRightExpression(rightExpression);
+    }
+
+    @Override
+    public XorExpression withLeftExpression(Expression expression) {
+        return (XorExpression) super.withLeftExpression(expression);
+    }
+
+    @Override
+    public XorExpression withRightExpression(Expression expression) {
+        return (XorExpression) super.withRightExpression(expression);
+    }
+
+    @Override
+    public void accept(ExpressionVisitor expressionVisitor) {
+        expressionVisitor.visit(this);
+    }
+
+    @Override
+    public String getStringExpression() {
+        return "XOR";
+    }
+
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -56,6 +56,7 @@ import net.sf.jsqlparser.expression.XMLSerializeExpr;
 import net.sf.jsqlparser.expression.operators.arithmetic.*;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
+import net.sf.jsqlparser.expression.operators.conditional.XorExpression;
 import net.sf.jsqlparser.expression.operators.relational.*;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
@@ -345,6 +346,11 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
     @Override
     public void visit(OrExpression orExpression) {
         visitBinaryExpression(orExpression);
+    }
+
+    @Override
+    public void visit(XorExpression xorExpression) {
+        visitBinaryExpression(xorExpression);
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -71,6 +71,7 @@ import net.sf.jsqlparser.expression.operators.arithmetic.Multiplication;
 import net.sf.jsqlparser.expression.operators.arithmetic.Subtraction;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
+import net.sf.jsqlparser.expression.operators.conditional.XorExpression;
 import net.sf.jsqlparser.expression.operators.relational.Between;
 import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
 import net.sf.jsqlparser.expression.operators.relational.ExistsExpression;
@@ -396,6 +397,11 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
     @Override
     public void visit(OrExpression orExpression) {
         visitBinaryExpression(orExpression, " OR ");
+
+    }
+    @Override
+    public void visit(XorExpression xorExpression) {
+        visitBinaryExpression(xorExpression, " XOR ");
 
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
@@ -68,6 +68,7 @@ import net.sf.jsqlparser.expression.operators.arithmetic.Multiplication;
 import net.sf.jsqlparser.expression.operators.arithmetic.Subtraction;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
+import net.sf.jsqlparser.expression.operators.conditional.XorExpression;
 import net.sf.jsqlparser.expression.operators.relational.Between;
 import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
 import net.sf.jsqlparser.expression.operators.relational.ExistsExpression;
@@ -271,6 +272,12 @@ public class ExpressionValidator extends AbstractValidator<Expression> implement
     @Override
     public void visit(OrExpression orExpression) {
         visitBinaryExpression(orExpression, " OR ");
+
+    }
+
+    @Override
+    public void visit(XorExpression xorExpression) {
+        visitBinaryExpression(xorExpression, " XOR ");
 
     }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2,7 +2,7 @@
  * #%L
  * JSQLParser library
  * %%
- * Copyright (C) 2004 - 2019 JSQLParser
+ * Copyright (C) 2004 - 2021 JSQLParser
  * %%
  * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
  * #L%
@@ -358,6 +358,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_WITHIN:"WITHIN">
 |   <K_WITHOUT:"WITHOUT">
 |   <K_XML:"XML">
+|   <K_XOR:"XOR">
 |   <K_XMLSERIALIZE:"XMLSERIALIZE">
 |   <K_XMLAGG:"XMLAGG">
 |   <K_XMLTEXT:"XMLTEXT">
@@ -2621,9 +2622,28 @@ Expression Expression() #Expression :
     Expression retval = null;
 }
 {
-    retval=OrExpression()
+    retval=XorExpression()
 
     { return retval; }
+}
+
+Expression XorExpression():
+{
+    Expression left, right, result;
+}
+{
+    left=OrExpression() { result = left; }
+    (
+        <K_XOR>
+        right=OrExpression()
+        {
+            result = new XorExpression(left, right);
+            left = result;
+        }
+     )*
+     {
+         return result;
+     }
 }
 
 Expression OrExpression():
@@ -2658,7 +2678,7 @@ Expression AndExpression() :
         left=Condition()
         |
         [ <K_NOT> { not=true; } | "!" { not=true; exclamationMarkNot=true; } ]
-        "(" left=OrExpression() ")" {left = new Parenthesis(left); if (not) { left = new NotExpression(left, exclamationMarkNot); not = false; } }
+        "(" left=XorExpression() ")" {left = new Parenthesis(left); if (not) { left = new NotExpression(left, exclamationMarkNot); not = false; } }
     )
     { result = left; }
 
@@ -2670,7 +2690,7 @@ Expression AndExpression() :
             right=Condition()
             |
             [ <K_NOT> { not=true; } | "!" { not=true; exclamationMarkNot=true; } ]
-            "(" right=OrExpression() ")" {right = new Parenthesis(right); if (not) { right = new NotExpression(right, exclamationMarkNot); not = false; } }
+            "(" right=XorExpression() ")" {right = new Parenthesis(right); if (not) { right = new NotExpression(right, exclamationMarkNot); not = false; } }
         )
         {
             result = new AndExpression(left, right);

--- a/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
@@ -11,6 +11,8 @@ package net.sf.jsqlparser.expression;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import net.sf.jsqlparser.expression.operators.conditional.XorExpression;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -98,6 +100,30 @@ public class ExpressionVisitorAdapterTest {
         assertNull(exprList.get(0));
         assertTrue(exprList.get(1) instanceof ItemsList);
         assertTrue(exprList.get(2) instanceof ItemsList);
+    }
+
+    @Test
+    public void testXorExpression() throws JSQLParserException {
+        final List<Expression> exprList = new ArrayList<>();
+        Select select = (Select) CCJSqlParserUtil.
+                parse("SELECT * FROM table WHERE foo XOR bar");
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        Expression where = plainSelect.getWhere();
+        where.accept(new ExpressionVisitorAdapter() {
+
+            @Override
+            public void visit(XorExpression expr) {
+                super.visit(expr);
+                exprList.add(expr.getLeftExpression());
+                exprList.add(expr.getRightExpression());
+            }
+        });
+
+        assertEquals(2, exprList.size());
+        assertTrue(exprList.get(0) instanceof Column);
+        assertEquals("foo",((Column)exprList.get(0)).getColumnName());
+        assertTrue(exprList.get(1) instanceof Column);
+        assertEquals("bar",((Column)exprList.get(1)).getColumnName());
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
@@ -33,7 +33,6 @@ import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
 
 /**
- * 
  * @author tw
  */
 public class ExpressionVisitorAdapterTest {
@@ -121,9 +120,9 @@ public class ExpressionVisitorAdapterTest {
 
         assertEquals(2, exprList.size());
         assertTrue(exprList.get(0) instanceof Column);
-        assertEquals("foo",((Column)exprList.get(0)).getColumnName());
+        assertEquals("foo", ((Column) exprList.get(0)).getColumnName());
         assertTrue(exprList.get(1) instanceof Column);
-        assertEquals("bar",((Column)exprList.get(1)).getColumnName());
+        assertEquals("bar", ((Column) exprList.get(1)).getColumnName());
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/statement/builder/JSQLParserFluentModelTests.java
+++ b/src/test/java/net/sf/jsqlparser/statement/builder/JSQLParserFluentModelTests.java
@@ -9,20 +9,11 @@
  */
 package net.sf.jsqlparser.statement.builder;
 
-import static net.sf.jsqlparser.test.TestUtils.*;
-
-import java.util.List;
-
-import net.sf.jsqlparser.expression.operators.conditional.XorExpression;
-import org.junit.Test;
 import net.sf.jsqlparser.JSQLParserException;
-import net.sf.jsqlparser.expression.Alias;
-import net.sf.jsqlparser.expression.Expression;
-import net.sf.jsqlparser.expression.JdbcParameter;
-import net.sf.jsqlparser.expression.Parenthesis;
-import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.expression.*;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
+import net.sf.jsqlparser.expression.operators.conditional.XorExpression;
 import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
 import net.sf.jsqlparser.expression.operators.relational.InExpression;
@@ -34,41 +25,44 @@ import net.sf.jsqlparser.statement.select.Join;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.test.TestUtils;
+import org.junit.Test;
+
+import java.util.List;
+
+import static net.sf.jsqlparser.test.TestUtils.*;
 
 public class JSQLParserFluentModelTests {
 
     @Test
     public void testParseAndBuild() throws JSQLParserException {
         String statement = "SELECT * FROM tab1 AS t1 " //
-                + "JOIN tab2 t2 ON t1.ref = t2.id WHERE (t1.col1 = ? OR t1.col2 = ?) AND t1.col3 IN ('A') XOR t1.col4";
+                + "JOIN tab2 t2 ON t1.ref = t2.id WHERE (t1.col1 = ? OR t1.col2 = ?) AND t1.col3 IN ('A')";
 
         Statement parsed = TestUtils.assertSqlCanBeParsedAndDeparsed(statement);
 
         Table t1 = new Table("tab1").withAlias(new Alias("t1").withUseAs(true));
         Table t2 = new Table("tab2").withAlias(new Alias("t2", false));
 
-        XorExpression where =
-                new XorExpression().withLeftExpression(new AndExpression().withLeftExpression(
+        AndExpression where = new AndExpression().withLeftExpression(
                 new Parenthesis(new OrExpression().withLeftExpression(
                         new EqualsTo()
-                        .withLeftExpression(new Column(asList("t1", "col1")))
-                        .withRightExpression(new JdbcParameter().withIndex(1)))
+                                .withLeftExpression(new Column(asList("t1", "col1")))
+                                .withRightExpression(new JdbcParameter().withIndex(1)))
                         .withRightExpression(new EqualsTo(
                                 new Column(asList("t1", "col2")),
                                 new JdbcParameter().withIndex(
                                         2)))
-                        )).withRightExpression(
-                                new InExpression()
-                                .withLeftExpression(new Column(asList("t1", "col3")))
-                                .withRightItemsList(new ExpressionList().addExpressions(new StringValue("A")))))
-                .withRightExpression( new Column(asList("t1", "col4")) );
+                )).withRightExpression(
+                new InExpression()
+                        .withLeftExpression(new Column(asList("t1", "col3")))
+                        .withRightItemsList(new ExpressionList().addExpressions(new StringValue("A"))));
         Select select = new Select().withSelectBody(new PlainSelect().addSelectItems(new AllColumns()).withFromItem(t1)
                 .addJoins(new Join().withRightItem(t2)
                         .withOnExpression(
                                 new EqualsTo(new Column(asList("t1", "ref")), new Column(asList("t2", "id")))))
                 .withWhere(where));
 
-        ExpressionList list = select.getSelectBody(PlainSelect.class).getWhere(XorExpression.class).getLeftExpression(AndExpression.class)
+        ExpressionList list = select.getSelectBody(PlainSelect.class).getWhere(AndExpression.class)
                 .getRightExpression(InExpression.class).getRightItemsList(ExpressionList.class);
         List<Expression> elist = list.getExpressions();
         list.setExpressions(elist);
@@ -77,4 +71,44 @@ public class JSQLParserFluentModelTests {
         assertEqualsObjectTree(parsed, select);
     }
 
+    @Test
+    public void testParseAndBuildForXOR() throws JSQLParserException {
+        String statement = "SELECT * FROM tab1 AS t1 JOIN tab2 t2 ON t1.ref = t2.id " +
+                "WHERE (t1.col1 XOR t2.col2) AND t1.col3 IN ('B', 'C') XOR t2.col4";
+
+        Statement parsed = TestUtils.assertSqlCanBeParsedAndDeparsed(statement);
+
+        Table t1 = new Table("tab1").withAlias(new Alias("t1", true));
+        Table t2 = new Table("tab2").withAlias(new Alias("t2", false));
+
+        XorExpression where = new XorExpression()
+                .withLeftExpression(new AndExpression()
+                        .withLeftExpression(
+                                new Parenthesis(
+                                        new XorExpression()
+                                                .withLeftExpression(new Column(asList("t1", "col1")))
+                                                .withRightExpression(new Column(asList("t2", "col2")))))
+                        .withRightExpression(
+                                new InExpression()
+                                        .withLeftExpression(new Column(asList("t1", "col3")))
+                                        .withRightItemsList(new ExpressionList()
+                                                .addExpressions(new StringValue("B"), new StringValue("C")))))
+                .withRightExpression(new Column(asList("t2", "col4")));
+
+        Select select = new Select().withSelectBody(new PlainSelect().addSelectItems(new AllColumns()).withFromItem(t1)
+                .addJoins(new Join().withRightItem(t2)
+                        .withOnExpression(
+                                new EqualsTo(new Column(asList("t1", "ref")), new Column(asList("t2", "id")))))
+                .withWhere(where));
+
+        ExpressionList list = select.getSelectBody(PlainSelect.class).getWhere(XorExpression.class)
+                .getLeftExpression(AndExpression.class)
+                .getRightExpression(InExpression.class)
+                .getRightItemsList(ExpressionList.class);
+        List<Expression> elist = list.getExpressions();
+        list.setExpressions(elist);
+
+        assertDeparse(select, statement);
+        assertEqualsObjectTree(parsed, select);
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/builder/JSQLParserFluentModelTests.java
+++ b/src/test/java/net/sf/jsqlparser/statement/builder/JSQLParserFluentModelTests.java
@@ -10,7 +10,11 @@
 package net.sf.jsqlparser.statement.builder;
 
 import net.sf.jsqlparser.JSQLParserException;
-import net.sf.jsqlparser.expression.*;
+import net.sf.jsqlparser.expression.Alias;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.JdbcParameter;
+import net.sf.jsqlparser.expression.Parenthesis;
+import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
 import net.sf.jsqlparser.expression.operators.conditional.XorExpression;

--- a/src/test/java/net/sf/jsqlparser/statement/builder/JSQLParserFluentModelTests.java
+++ b/src/test/java/net/sf/jsqlparser/statement/builder/JSQLParserFluentModelTests.java
@@ -115,4 +115,55 @@ public class JSQLParserFluentModelTests {
         assertDeparse(select, statement);
         assertEqualsObjectTree(parsed, select);
     }
+
+    @Test
+    public void testParseAndBuildForXORComplexCondition() throws JSQLParserException {
+        String statement = "SELECT * FROM tab1 AS t1 WHERE " +
+                "a AND b OR c XOR d";
+
+        Statement parsed = TestUtils.assertSqlCanBeParsedAndDeparsed(statement);
+
+        Table t1 = new Table("tab1").withAlias(new Alias("t1", true));
+
+        XorExpression where = new XorExpression()
+                .withLeftExpression(
+                        new OrExpression()
+                                .withLeftExpression(
+                                        new AndExpression()
+                                                .withLeftExpression(new Column("a"))
+                                                .withRightExpression(new Column("b"))
+                                )
+                                .withRightExpression(new Column("c")))
+                .withRightExpression(new Column("d")
+                );
+
+        Select select = new Select().withSelectBody(new PlainSelect().addSelectItems(new AllColumns()).withFromItem(t1)
+                .withWhere(where));
+
+        assertDeparse(select, statement);
+        assertEqualsObjectTree(select, parsed);
+    }
+
+    @Test
+    public void testParseAndBuildForXORs() throws JSQLParserException {
+        String statement = "SELECT * FROM tab1 AS t1 WHERE " +
+                "a XOR b XOR c";
+
+        Statement parsed = TestUtils.assertSqlCanBeParsedAndDeparsed(statement);
+
+        Table t1 = new Table("tab1").withAlias(new Alias("t1", true));
+
+        XorExpression where = new XorExpression()
+                .withLeftExpression(
+                        new XorExpression()
+                                .withLeftExpression(new Column("a"))
+                                .withRightExpression(new Column("b")))
+                .withRightExpression(new Column("c"));
+
+        Select select = new Select().withSelectBody(new PlainSelect().addSelectItems(new AllColumns()).withFromItem(t1)
+                .withWhere(where));
+
+        assertDeparse(select, statement);
+        assertEqualsObjectTree(select, parsed);
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/builder/ReflectionModelTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/builder/ReflectionModelTest.java
@@ -78,6 +78,7 @@ public class ReflectionModelTest {
             new net.sf.jsqlparser.expression.operators.arithmetic.Subtraction(),
             new net.sf.jsqlparser.expression.operators.conditional.AndExpression(),
             new net.sf.jsqlparser.expression.operators.conditional.OrExpression(),
+            new net.sf.jsqlparser.expression.operators.conditional.XorExpression(),
             new net.sf.jsqlparser.expression.operators.relational.Between(),
             new net.sf.jsqlparser.expression.operators.relational.EqualsTo(),
             new net.sf.jsqlparser.expression.operators.relational.ExistsExpression(),

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -2550,6 +2550,12 @@ public class SelectTest {
     }
 
     @Test
+    public void testXorCondition() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT * FROM mytable WHERE field = value XOR other_value");
+    }
+
+
+    @Test
     public void testRlike() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT * FROM mytable WHERE first_name RLIKE '^Ste(v|ph)en$'");
     }

--- a/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
@@ -165,6 +165,18 @@ public class TablesNamesFinderTest {
     }
 
     @Test
+    public void testGetTableListWithXor() throws Exception {
+        String sql = "SELECT * FROM MY_TABLE1 WHERE true XOR false";
+        net.sf.jsqlparser.statement.Statement statement = pm.parse(new StringReader(sql));
+
+        Select selectStatement = (Select) statement;
+        TablesNamesFinder tablesNamesFinder = new TablesNamesFinder();
+        List<String> tableList = tablesNamesFinder.getTableList(selectStatement);
+        assertEquals(1, tableList.size());
+        assertEquals("MY_TABLE1", tableList.get(0));
+    }
+
+    @Test
     public void testGetTableListWithStmt() throws Exception {
         String sql = "WITH TESTSTMT as (SELECT * FROM MY_TABLE1 as ALIAS_TABLE1) SELECT * FROM TESTSTMT";
         net.sf.jsqlparser.statement.Statement statement = pm.parse(new StringReader(sql));

--- a/src/test/java/net/sf/jsqlparser/util/validation/ValidationTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/validation/ValidationTest.java
@@ -88,6 +88,14 @@ public class ValidationTest extends ValidationTestAsserts {
 
         assertErrorsSize(errors, 0);
     }
+    @Test
+    public void testWithValidationOnlyParse2() throws JSQLParserException {
+
+        String stmt = "SELECT * FROM tab1, tab2 WHERE value XOR other_value";
+        List<ValidationError> errors = Validation.validate(Collections.emptyList(), stmt);
+
+        assertErrorsSize(errors, 0);
+    }
 
     @Test
     public void testWithValidationOnlyParseInvalid() throws JSQLParserException {

--- a/src/test/java/net/sf/jsqlparser/util/validation/ValidationTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/validation/ValidationTest.java
@@ -91,10 +91,15 @@ public class ValidationTest extends ValidationTestAsserts {
     @Test
     public void testWithValidationOnlyParse2() throws JSQLParserException {
 
-        String stmt = "SELECT * FROM tab1, tab2 WHERE value XOR other_value";
-        List<ValidationError> errors = Validation.validate(Collections.emptyList(), stmt);
-
-        assertErrorsSize(errors, 0);
+        String sql = "SELECT * FROM tab1, tab2 WHERE value XOR other_value";
+        Statement stmt = CCJSqlParserUtil.parse(sql);
+        StatementValidator validator = new StatementValidator();
+        validator.setContext(new ValidationContext()
+                .setCapabilities(Arrays.asList(DatabaseType.SQLSERVER, DatabaseType.MYSQL)));
+        stmt.accept(validator);
+        Map<ValidationCapability, Set<ValidationException>> unsupportedErrors = validator
+                .getValidationErrors(DatabaseType.SQLSERVER);
+        assertErrorsSize(unsupportedErrors, 0);
     }
 
     @Test


### PR DESCRIPTION
The boolean operator `XOR` (exclusive or) is not part of the SQL standard, but many databases have support for them (ex. mySQL).
However, with the current parser these expressions cannot be parsed as the keyword and the expression for it is not part of the grammar.

This pull request adds support for the XOR Expression, that is treated as a Binary Conditional Operator.
The expression behaves the same as the usual `AND` or `OR` expressions, but its precedence is the lowest: `AND` > `OR` > `XOR`.