### PR TITLE
Delete queries without from, with a schema identifier fails

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
+++ b/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
@@ -37,6 +37,7 @@ public class Delete implements Statement {
     private Expression where;
     private Limit limit;
     private List<OrderByElement> orderByElements;
+    private boolean hasFrom = true;
     public List<WithItem> getWithItemsList() {
         return withItemsList;
     }
@@ -123,6 +124,14 @@ public class Delete implements Statement {
         this.joins = joins;
     }
 
+    public boolean isHasFrom() {
+        return this.hasFrom;
+    }
+
+    public void setHasFrom(boolean hasFrom) {
+        this.hasFrom = hasFrom;
+    }
+
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     public String toString() {
@@ -148,8 +157,10 @@ public class Delete implements Statement {
                     .collect(joining(", ")));
         }
 
-        b.append(" FROM ");
-        b.append(table);
+        if (hasFrom) {
+            b.append(" FROM");
+        }
+        b.append(" ").append(table);
 
         if (joins != null) {
             for (Join join : joins) {
@@ -202,6 +213,11 @@ public class Delete implements Statement {
 
     public Delete withWhere(Expression where) {
         this.setWhere(where);
+        return this;
+    }
+
+    public Delete withHasFrom(boolean hasFrom) {
+        this.setHasFrom(hasFrom);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
@@ -51,7 +51,10 @@ public class DeleteDeParser extends AbstractDeParser<Delete> {
             buffer.append(
                     delete.getTables().stream().map(Table::getFullyQualifiedName).collect(joining(", ", " ", "")));
         }
-        buffer.append(" FROM ").append(delete.getTable().toString());
+        if (delete.isHasFrom()) {
+            buffer.append(" FROM");
+        }
+        buffer.append(" ").append(delete.getTable().toString());
 
         if (delete.getJoins() != null) {
             for (Join join : delete.getJoins()) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1206,11 +1206,12 @@ Delete Delete( List<WithItem> with ):
     Expression where = null;
     Limit limit = null;
     List<OrderByElement> orderByElements;
+    boolean hasFrom = false;
 }
 {
     <K_DELETE> { delete.setOracleHint(getOracleHint()); } [LOOKAHEAD(4) (table=TableWithAlias() { tables.add(table); }
           ("," table=TableWithAlias() { tables.add(table); } )*
-    <K_FROM> | <K_FROM>)]
+    <K_FROM> | <K_FROM>) { hasFrom = true; }]
 
     [ LOOKAHEAD(3) table=TableWithAlias()  joins=JoinsList() ]
     [where=WhereClause() { delete.setWhere(where); } ]
@@ -1221,7 +1222,7 @@ Delete Delete( List<WithItem> with ):
             delete.setJoins(joins);
         }
         return delete.withWithItemsList(with)
-              .withTables(tables).withTable(table);
+              .withTables(tables).withTable(table).withHasFrom(hasFrom);
     }
 }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1208,7 +1208,7 @@ Delete Delete( List<WithItem> with ):
     List<OrderByElement> orderByElements;
 }
 {
-    <K_DELETE> { delete.setOracleHint(getOracleHint()); } [LOOKAHEAD(2) (table=TableWithAlias() { tables.add(table); }
+    <K_DELETE> { delete.setOracleHint(getOracleHint()); } [LOOKAHEAD(4) (table=TableWithAlias() { tables.add(table); }
           ("," table=TableWithAlias() { tables.add(table); } )*
     <K_FROM> | <K_FROM>)]
 

--- a/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
@@ -9,7 +9,6 @@
  */
 package net.sf.jsqlparser.statement.delete;
 
-import static net.sf.jsqlparser.test.TestUtils.assertStatementCanBeDeparsedAs;
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
 import static net.sf.jsqlparser.test.TestUtils.assertOracleHintExists;
 import static org.junit.Assert.assertEquals;
@@ -21,10 +20,8 @@ import net.sf.jsqlparser.expression.LongValue;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
-import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
 
-import net.sf.jsqlparser.statement.Statement;
 import org.junit.Test;
 
 public class DeleteTest {
@@ -125,15 +122,13 @@ public class DeleteTest {
 
     @Test
     public void testNoFrom() throws JSQLParserException {
-        String sql = "DELETE A WHERE Z=1";
-        Statement statement = CCJSqlParserUtil.parse(sql);
-        assertStatementCanBeDeparsedAs(statement, "DELETE FROM A WHERE Z = 1");
+        String statement = "DELETE A WHERE Z = 1";
+        assertSqlCanBeParsedAndDeparsed(statement);
     }
 
     @Test
     public void testNoFromWithSchema() throws JSQLParserException {
-        String sql = "DELETE A.B WHERE Z=1";
-        Statement statement = CCJSqlParserUtil.parse(sql);
-        assertStatementCanBeDeparsedAs(statement, "DELETE FROM A.B WHERE Z = 1");
+        String statement = "DELETE A.B WHERE Z = 1";
+        assertSqlCanBeParsedAndDeparsed(statement);
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
@@ -20,6 +20,7 @@ import net.sf.jsqlparser.expression.LongValue;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
 import static net.sf.jsqlparser.test.TestUtils.assertOracleHintExists;
 import org.junit.Test;
@@ -118,5 +119,17 @@ public class DeleteTest {
             + "                            FROM   a)";
 
     assertSqlCanBeParsedAndDeparsed(statement, true);
+    }
+
+    @Test
+    public void testNoFrom() throws JSQLParserException {
+        String sql = "DELETE A WHERE Z=1";
+        CCJSqlParserUtil.parse(sql);
+    }
+
+    @Test
+    public void testNoFromWithSchema() throws JSQLParserException {
+        String sql = "DELETE A.B WHERE Z=1";
+        CCJSqlParserUtil.parse(sql);
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
@@ -9,8 +9,7 @@
  */
 package net.sf.jsqlparser.statement.delete;
 
-import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
-
+import static net.sf.jsqlparser.test.TestUtils.*;
 import static org.junit.Assert.assertEquals;
 
 import java.io.StringReader;
@@ -22,7 +21,8 @@ import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
-import static net.sf.jsqlparser.test.TestUtils.assertOracleHintExists;
+
+import net.sf.jsqlparser.statement.Statement;
 import org.junit.Test;
 
 public class DeleteTest {
@@ -124,12 +124,14 @@ public class DeleteTest {
     @Test
     public void testNoFrom() throws JSQLParserException {
         String sql = "DELETE A WHERE Z=1";
-        CCJSqlParserUtil.parse(sql);
+        Statement statement = CCJSqlParserUtil.parse(sql);
+        assertStatementCanBeDeparsedAs(statement, "DELETE FROM A WHERE Z = 1");
     }
 
     @Test
     public void testNoFromWithSchema() throws JSQLParserException {
         String sql = "DELETE A.B WHERE Z=1";
-        CCJSqlParserUtil.parse(sql);
+        Statement statement = CCJSqlParserUtil.parse(sql);
+        assertStatementCanBeDeparsedAs(statement, "DELETE FROM A.B WHERE Z = 1");
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
@@ -9,7 +9,9 @@
  */
 package net.sf.jsqlparser.statement.delete;
 
-import static net.sf.jsqlparser.test.TestUtils.*;
+import static net.sf.jsqlparser.test.TestUtils.assertStatementCanBeDeparsedAs;
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static net.sf.jsqlparser.test.TestUtils.assertOracleHintExists;
 import static org.junit.Assert.assertEquals;
 
 import java.io.StringReader;


### PR DESCRIPTION
Hello,

It is currently possible to analyze this query:

delete a where z=1

However, it fails if the schema is determined:

delete a.b where z=1