### PR TITLE
CROSS JOIN is used without conditions

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -285,6 +285,8 @@ public class Join extends ASTNodeAccessImpl {
             return "OUTER " + rightItem;
         } else if (isSimple()) {
             return "" + rightItem;
+        } else if (isCross()) {
+            return "CROSS JOIN " + rightItem;
         } else {
             String type = "";
 
@@ -296,8 +298,6 @@ public class Join extends ASTNodeAccessImpl {
                 type += "FULL ";
             } else if (isLeft()) {
                 type += "LEFT ";
-            } else if (isCross()) {
-                type += "CROSS ";
             }
 
             if (isOuter()) {


### PR DESCRIPTION
Thanks for the great library!

I found a small issue, which prevents me from generating statements with CROSS JOINs. 
This happens when I first have any other JOIN with conditions, but then I want to change it on Cross JOIN.

I know that the tests are welcome here, but the CROSS JOIN test is already in the code, so I didn't add it.

Thanks for your attention.