### PR TITLE
Separate MySQL Special String Functions colliding with InExpression

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/Function.java
+++ b/src/main/java/net/sf/jsqlparser/expression/Function.java
@@ -52,6 +52,11 @@ public class Function extends ASTNodeAccessImpl implements Expression {
         nameparts = Arrays.asList(string);
     }
     
+    public Function withName(String name) {
+        this.setName(name);
+        return this;
+    }
+    
     public void setName(List<String> string) {
         nameparts = string;
     }

--- a/src/main/java/net/sf/jsqlparser/parser/CCJSqlParserUtil.java
+++ b/src/main/java/net/sf/jsqlparser/parser/CCJSqlParserUtil.java
@@ -120,7 +120,7 @@ public final class CCJSqlParserUtil {
             consumer.accept(parser);
         }
         try {
-            Expression expr = parser.SimpleExpression();
+            Expression expr = parser.Expression();
             if (!allowPartialParse && parser.getNextToken().kind != CCJSqlParserTokenManager.EOF) {
                 throw new JSQLParserException("could only parse partial expression " + expr.toString());
             }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -378,6 +378,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_SQL_NO_CACHE: "SQL_NO_CACHE">
 |   <K_USING:"USING">
 |   <K_SIGNED:"SIGNED">
+|   <K_STRING_FUNCTION_NAME: ("SUBSTR" | "SUBSTRING" | "TRIM" | "POSITION" | "OVERLAY")>
 |   <K_UNSIGNED:"UNSIGNED">
 |   <K_VALIDATE : "VALIDATE">
 |   <K_VALUE:"VALUE">
@@ -1439,6 +1440,7 @@ String RelObjectNameWithoutValue() :
     /*| tk=<K_PLACING> | tk=<K_BOTH> | tk=<K_LEADING> | tk=<K_TRAILING> */
       | tk=<K_FORMAT> | tk=<K_DIV> | tk=<K_UNSIGNED> | tk=<K_CASE> | tk=<K_LOCAL>
       | tk=<K_ARRAY_LITERAL>
+      | tk=<K_STRING_FUNCTION_NAME>
 
       /* Keywords for ALTER SESSION */
       /* | tk=<K_NAME> */ | tk=<K_TIMEOUT> | tk=<K_PARALLEL>
@@ -1455,7 +1457,7 @@ String RelObjectName() :
 {
     (result = RelObjectNameWithoutValue()
 		| tk=<K_GROUP> | tk=<K_INTERVAL> | tk=<K_ON> | tk=<K_ORDER> | tk=<K_START> | tk=<K_TOP> | tk=<K_VALUE> 
-                | tk=<K_VALUES> | tk=<K_CREATE> | tk=<K_TABLES> )
+        | tk=<K_VALUES> | tk=<K_CREATE> | tk=<K_TABLES>  )
 
     {
 		if (tk!=null) result=tk.image;
@@ -1485,7 +1487,7 @@ String RelObjectNameExt():
 {
     ( result=RelObjectName() | tk=<K_ALL> | tk=<K_ANY>  | tk=<K_SOME> | tk=<K_LEFT> | tk=<K_RIGHT> | tk=<K_SET>
         | tk=<K_DOUBLE> | tk=<K_IF> | tk=<K_IIF> | tk=<K_OPTIMIZE> | tk=<K_LIMIT>
-        | tk=<K_OFFSET> | tk=<K_PROCEDURE> | tk=<K_PUBLIC> 
+        | tk=<K_OFFSET> | tk=<K_PROCEDURE> | tk=<K_PUBLIC>  
         | tk=<K_CASEWHEN> | tk=<K_IN> )
     {
         if (tk!=null) result=tk.image;
@@ -4201,11 +4203,39 @@ Function Function() #Function:
 {
     (
         "{" <K_FN> { retval.setEscaped(true); }  InternalFunction(retval) "}"
+        | LOOKAHEAD(3) retval = SpecialStringFunctionWithNamedParameters()
         | InternalFunction(retval)
     )
     {
         linkAST(retval,jjtThis);
         return retval;
+    }
+}
+
+Function SpecialStringFunctionWithNamedParameters() :
+{
+    Token funcName;
+    NamedExpressionList namedExpressionList = null;
+    ExpressionList expressionList = null;
+    List<OrderByElement> orderByList;
+}
+{
+        funcName = <K_STRING_FUNCTION_NAME> 
+
+        "(" 
+        (
+            LOOKAHEAD(NamedExpressionList1()) namedExpressionList=NamedExpressionList1()
+            |
+            LOOKAHEAD(NamedExpressionListExprFirst(), { getAsBoolean(Feature.allowComplexParsing) }) namedExpressionList = NamedExpressionListExprFirst()
+            |
+            LOOKAHEAD(3, { getAsBoolean(Feature.allowComplexParsing) }) expressionList=ComplexExpressionList() {expressionList.setUsingBrackets(false);}
+            |
+            LOOKAHEAD(3) expressionList=SimpleExpressionList(false) 
+        )
+        ")"
+
+    {
+        return new Function().withName(funcName.image).withNamedParameters(namedExpressionList).withParameters(expressionList);
     }
 }
 
@@ -4231,10 +4261,6 @@ Function InternalFunction(Function retval) :
         ( LOOKAHEAD(4)
             "*" { retval.setAllColumns(true); }
             |
-            LOOKAHEAD(NamedExpressionList1()) namedExpressionList=NamedExpressionList1()
-            |
-            LOOKAHEAD(NamedExpressionListExprFirst(), { getAsBoolean(Feature.allowComplexParsing) }) namedExpressionList = NamedExpressionListExprFirst()
-            |
             LOOKAHEAD(3, { getAsBoolean(Feature.allowComplexParsing) }) (expressionList=ComplexExpressionList() {expressionList.setUsingBrackets(false);} [ orderByList = OrderByElements() { retval.setOrderByElements(orderByList); } ])
             |
             LOOKAHEAD(3) (expressionList=SimpleExpressionList(false) [ orderByList = OrderByElements() { retval.setOrderByElements(orderByList); } ])
@@ -4243,7 +4269,7 @@ Function InternalFunction(Function retval) :
 
         )]
         [ <K_IGNORE> <K_NULLS> {retval.setIgnoreNulls(true); }]
-	")"
+        ")"
 
     [ "." (
             LOOKAHEAD(2) expr1=Function() { retval.setAttribute(expr1); }
@@ -4255,7 +4281,6 @@ Function InternalFunction(Function retval) :
 
     {
         retval.setParameters(expressionList);
-        retval.setNamedParameters(namedExpressionList);
         retval.setName(funcName);
         retval.setKeep(keep);
         return retval;

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -4664,4 +4664,20 @@ public class SelectTest {
     public void testKeywordFilterIssue1255() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT col1 AS filter FROM table");
     }
+    
+    @Test
+    public void testCollisionWithSpecialStringFunctionsIssue1284() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+          "SELECT test( a in (1) AND 2=2) ", true);
+        
+        assertSqlCanBeParsedAndDeparsed(
+            "select\n" +
+            "sum(if(column1 in('value1', 'value2'), 1, 0)) as tcp_logs,\n" +
+            "sum(if(column1 in ('value1', 'value2') and column2 = 'value3', 1, 0)) as base_tcp_logs\n" +
+            "from\n" +
+            "table1\n" +
+            "where\n" +
+            "recv_time >= toDateTime('2021-07-20 00:00:00')\n" +
+            "and recv_time < toDateTime('2021-07-21 00:00:00')", true);
+    }
 }


### PR DESCRIPTION
Separate MySQL Special String Functions accepting Named Argument Separation as this could collide with ComplexExpressionList when InExpression is involved

```SQL

-- this is a ComplexExpressionList which must NOT be parsed as NamedParameterList
SELECT test('foo' in ('bar') and 1=1); 

-- this is a NamedParameterList but only for a few Special String Functions
SELECT substring('foo' in 'bar'); 
```

Fixes #1284