### PR TITLE
Add some flexibility to the Alter Statement

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterOperation.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterOperation.java
@@ -10,5 +10,5 @@
 package net.sf.jsqlparser.statement.alter;
 
 public enum AlterOperation {
-    ADD, ALTER, DROP, MODIFY, CHANGE, ALGORITHM, RENAME, COMMENT;
+    ADD, ALTER, DROP, MODIFY, CHANGE, ALGORITHM, RENAME, COMMENT, UNSPECIFIC;
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -5258,6 +5258,9 @@ AlterExpression AlterExpression():
     AlterExpression.ColumnDataType alterExpressionColumnDataType = null;
     AlterExpression.ColumnDropNotNull alterExpressionColumnDropNotNull = null;
     ReferentialAction.Action action = null;
+
+    // for captureRest()
+    List<String> tokens = new LinkedList<String>();
 }
 {
 
@@ -5467,6 +5470,22 @@ AlterExpression AlterExpression():
       (<K_COMMENT> {alterExp.setOperation(AlterOperation.COMMENT);}
           tk=<S_CHAR_LITERAL> { alterExp.setCommentText(tk.image); }
       )
+      |
+      tokens = captureRest() { 
+                    alterExp.setOperation(AlterOperation.UNSPECIFIC);
+                    StringBuilder optionalSpecifier = new StringBuilder();
+                    int i=0;
+
+                    for (String s: tokens) 
+                        if (!s.equals(";")) {
+                            if (i>0)
+                                optionalSpecifier.append( " " );
+                            optionalSpecifier.append( s );
+                            i++;
+                        }
+
+                    alterExp.setOptionalSpecifier( optionalSpecifier.toString() );
+                }
     )
 
     {

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -747,5 +747,17 @@ public class AlterTest {
             assertNull(alterExpression.getReferentialAction(Type.UPDATE));
         }
     }
+    
+    @Test
+    public void testRowFormatKeywordIssue1033() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE basic_test_case "
+            + "ADD COLUMN display_name varchar(512) NOT NULL DEFAULT '' AFTER name"
+            + ", ADD KEY test_case_status (test_case_status)"
+            + ", add KEY display_name (display_name), ROW_FORMAT=DYNAMIC", true);
+        
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE t1 MOVE TABLESPACE users", true);
+        
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE test_tab MOVE PARTITION test_tab_q2 COMPRESS", true);
+    }
 
 }


### PR DESCRIPTION
in order to allow:
```sql
ALTER TABLE ... MOVE TABLESPACE ...
ALTER TABLE ... COMPRESS NOLOGGING
ALTER TABLE ... ROWFORMAT=DYNAMIC
```

(and similar syntax. We do not parse the details but only forward the provided tokens.)

Fixes #1033