### PR TITLE
Statement Classification QUERY, DML, DDL, BLOCK, UNPARSED

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@
 *.yml~
 /nbproject/
 
+/gradle
 /.gradle

--- a/build.gradle
+++ b/build.gradle
@@ -62,15 +62,33 @@ jacocoTestReport {
         csv.required = false
         html.outputLocation = layout.buildDirectory.dir('reports/jacoco')
     }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    "**/*Adapter.class",
+                    "**/SimpleCharStream.class",
+            ])
+        }))
+    }
 }
 
 jacocoTestCoverageVerification {
     violationRules {
         rule {
             limit {
-                minimum = 0.840
+                minimum = 0.845
             }
         }
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    "**/*Adapter.class",
+                    "**/SimpleCharStream.class",
+            ])
+        }))
     }
 }
 
@@ -133,7 +151,7 @@ task renderRR() {
         
         javaexec { 
           standardOutput = new FileOutputStream("${buildDir}/rr/JSqlParserCC.ebnf")
-          main="-jar";
+          main="-jar"
           args = [
               "$buildDir/rr/convert.war",
               "$buildDir/generated/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jj"
@@ -141,7 +159,7 @@ task renderRR() {
         }
         
         javaexec {
-          main="-jar";
+          main="-jar"
           args = [
               "$buildDir/rr/rr.war",
               "-noepsilon",

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ compileJavacc {
 java {
     withSourcesJar()
     withJavadocJar()
+
+    spotbugs
+    pmd
 }
 
 jacoco {
@@ -113,8 +116,9 @@ spotbugs {
 pmd {
     consoleOutput = false
     toolVersion = "6.36.0"
-    
-    sourceSets = [sourceSets.main]
+
+    // run only over the main sources for now, but not over the tests
+    sourceSets = [sourceSets.main /*, sourceSets.test */]
     
     // clear the ruleset in order to use configured rules only, although we should apply the Prio 1 rules eventually
     ruleSets = []

--- a/src/main/java/net/sf/jsqlparser/statement/Block.java
+++ b/src/main/java/net/sf/jsqlparser/statement/Block.java
@@ -9,7 +9,7 @@
  */
 package net.sf.jsqlparser.statement;
 
-public class Block implements Statement {
+public class Block extends StatementImpl {
 
     private Statements statements;
 
@@ -27,8 +27,19 @@ public class Block implements Statement {
     }
 
     @Override
-    public String toString() {
-        return "BEGIN\n" + (statements != null ? statements.toString() : "") + "END";
+    public boolean isBlock() {
+        return true;
+    }
+
+    @Override
+    public StatementType getStatementType() {
+        return StatementType.BLOCK;
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("BEGIN\n").append(statements != null ? statements.toString() : "").append("END");
+        return builder;
     }
 
     public Block withStatements(Statements statements) {

--- a/src/main/java/net/sf/jsqlparser/statement/Commit.java
+++ b/src/main/java/net/sf/jsqlparser/statement/Commit.java
@@ -9,14 +9,15 @@
  */
 package net.sf.jsqlparser.statement;
 
-public class Commit implements Statement {
+public class Commit extends DMLStatement {
     @Override
     public void accept(StatementVisitor statementVisitor) {
         statementVisitor.visit(this);
     }
-    
+
     @Override
-    public String toString() {
-        return "COMMIT";
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("COMMIT");
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/CreateFunctionalStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/CreateFunctionalStatement.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 /**
  * A base for the declaration of function like statements
  */
-public abstract class CreateFunctionalStatement implements Statement {
+public abstract class CreateFunctionalStatement extends DDLStatement {
 
     private String kind;
     private boolean orReplace = false;
@@ -89,11 +89,9 @@ public abstract class CreateFunctionalStatement implements Statement {
         statementVisitor.visit(this);
     }
 
-    @Override
-    public String toString() {
-        return "CREATE " 
-                + (orReplace?"OR REPLACE ":"")
-                + kind + " " + formatDeclaration();
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("CREATE ").append(orReplace ? "OR REPLACE " : "").append(kind).append(" ").append(formatDeclaration());
+        return builder;
     }
 
     public CreateFunctionalStatement withFunctionDeclarationParts(List<String> functionDeclarationParts) {

--- a/src/main/java/net/sf/jsqlparser/statement/DDLStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/DDLStatement.java
@@ -1,0 +1,24 @@
+/*
+ * To change this license header, choose License Headers in Project Properties. To change this
+ * template file, choose Tools | Templates and open the template in the editor.
+ */
+
+package net.sf.jsqlparser.statement;
+
+/**
+ *
+ * @author <a href="mailto:andreas@manticore-projects.com">Andreas Reichel</a>
+ */
+public abstract class DDLStatement extends StatementImpl {
+    @Override
+    public boolean isDDL() {
+        return true;
+    }
+
+    @Override
+    public StatementType getStatementType() {
+        return StatementType.DDL;
+    }
+
+    public abstract StringBuilder appendTo(StringBuilder builder);
+}

--- a/src/main/java/net/sf/jsqlparser/statement/DDLStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/DDLStatement.java
@@ -1,3 +1,12 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2021 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
 /*
  * To change this license header, choose License Headers in Project Properties. To change this
  * template file, choose Tools | Templates and open the template in the editor.

--- a/src/main/java/net/sf/jsqlparser/statement/DMLStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/DMLStatement.java
@@ -1,0 +1,22 @@
+/*
+ * To change this license header, choose License Headers in Project Properties. To change this
+ * template file, choose Tools | Templates and open the template in the editor.
+ */
+
+package net.sf.jsqlparser.statement;
+
+/**
+ *
+ * @author <a href="mailto:andreas@manticore-projects.com">Andreas Reichel</a>
+ */
+public abstract class DMLStatement extends StatementImpl {
+    @Override
+    public boolean isDML() {
+        return true;
+    }
+
+    @Override
+    public StatementType getStatementType() {
+        return StatementType.DML;
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/DMLStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/DMLStatement.java
@@ -1,3 +1,12 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2021 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
 /*
  * To change this license header, choose License Headers in Project Properties. To change this
  * template file, choose Tools | Templates and open the template in the editor.

--- a/src/main/java/net/sf/jsqlparser/statement/DeclareStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/DeclareStatement.java
@@ -19,7 +19,7 @@ import net.sf.jsqlparser.expression.UserVariable;
 import net.sf.jsqlparser.statement.create.table.ColDataType;
 import net.sf.jsqlparser.statement.create.table.ColumnDefinition;
 
-public final class DeclareStatement implements Statement {
+public final class DeclareStatement extends StatementImpl {
 
     private UserVariable userVariable = null;
     private DeclareType declareType = DeclareType.TYPE;
@@ -46,6 +46,8 @@ public final class DeclareStatement implements Statement {
     public DeclareType getType() {
         return getDeclareType();
     }
+
+
 
     /**
      * @return the {@link DeclareType}
@@ -116,39 +118,50 @@ public final class DeclareStatement implements Statement {
     }
 
     @Override
-    public String toString() {
-        StringBuilder b = new StringBuilder("DECLARE ");
+    public boolean isBlock() {
+        return true;
+    }
+
+    @Override
+    public StatementType getStatementType() {
+        return StatementType.BLOCK;
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("DECLARE ");
         if (declareType == DeclareType.AS) {
-            b.append(userVariable.toString());
-            b.append(" AS ").append(typeName);
+            builder.append(userVariable.toString());
+            builder.append(" AS ").append(typeName);
         } else {
             if (declareType == DeclareType.TABLE) {
-                b.append(userVariable.toString());
-                b.append(" TABLE (");
+                builder.append(userVariable.toString());
+                builder.append(" TABLE (");
                 for (int i = 0; i < columnDefinitions.size(); i++) {
                     if (i > 0) {
-                        b.append(", ");
+                        builder.append(", ");
                     }
-                    b.append(columnDefinitions.get(i).toString());
+                    builder.append(columnDefinitions.get(i).toString());
                 }
-                b.append(")");
+                builder.append(")");
             } else {
                 for (int i = 0; i < typeDefExprList.size(); i++) {
                     if (i > 0) {
-                        b.append(", ");
+                        builder.append(", ");
                     }
                     final TypeDefExpr type = typeDefExprList.get(i);
                     if (type.userVariable != null) {
-                        b.append(type.userVariable.toString()).append(" ");
+                        builder.append(type.userVariable).append(" ");
                     }
-                    b.append(type.colDataType.toString());
+                    builder.append(type.colDataType.toString());
                     if (type.defaultExpr != null) {
-                        b.append(" = ").append(type.defaultExpr.toString());
+                        builder.append(" = ").append(type.defaultExpr);
                     }
                 }
             }
         }
-        return b.toString();
+
+        return builder;
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/statement/DescribeStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/DescribeStatement.java
@@ -11,12 +11,12 @@ package net.sf.jsqlparser.statement;
 
 import net.sf.jsqlparser.schema.Table;
 
-public class DescribeStatement implements Statement {
+public class DescribeStatement extends DDLStatement {
 
     private Table table;
 
     public DescribeStatement() {
-        // empty constructor
+        table = null;
     }
 
     public DescribeStatement(Table table) {
@@ -32,11 +32,6 @@ public class DescribeStatement implements Statement {
     }
 
     @Override
-    public String toString() {
-        return "DESCRIBE " + table.getFullyQualifiedName();
-    }
-
-    @Override
     public void accept(StatementVisitor statementVisitor) {
         statementVisitor.visit(this);
     }
@@ -44,5 +39,11 @@ public class DescribeStatement implements Statement {
     public DescribeStatement withTable(Table table) {
         this.setTable(table);
         return this;
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("DESCRIBE ").append(table.getFullyQualifiedName());
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/ExplainStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/ExplainStatement.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 /**
  * An {@code EXPLAIN} statement
  */
-public class ExplainStatement implements Statement {
+public class ExplainStatement extends DDLStatement {
 
     private Select select;
     private LinkedHashMap<OptionType, Option> options;
@@ -63,21 +63,21 @@ public class ExplainStatement implements Statement {
     }
 
     @Override
-    public String toString() {
-        StringBuilder statementBuilder = new StringBuilder("EXPLAIN");
-        if (options != null) {
-            statementBuilder.append(" ");
-            statementBuilder.append(options.values().stream().map(Option::formatOption).collect(Collectors.joining(" ")));
-        }
-
-        statementBuilder.append(" ");
-        statementBuilder.append(select.toString());
-        return statementBuilder.toString();
+    public void accept(StatementVisitor statementVisitor) {
+        statementVisitor.visit(this);
     }
 
     @Override
-    public void accept(StatementVisitor statementVisitor) {
-        statementVisitor.visit(this);
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("EXPLAIN");
+        if (options != null) {
+            builder.append(" ");
+            builder.append(options.values().stream().map(Option::formatOption).collect(Collectors.joining(" ")));
+        }
+
+        builder.append(" ");
+        select.appendTo(builder);
+        return builder;
     }
 
     public enum OptionType {

--- a/src/main/java/net/sf/jsqlparser/statement/IfElseStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/IfElseStatement.java
@@ -17,7 +17,7 @@ import net.sf.jsqlparser.expression.Expression;
  *
  * @author <a href="mailto:andreas@manticore-projects.com">Andreas Reichel</a>
  */
-public class IfElseStatement implements Statement {
+public class IfElseStatement extends StatementImpl {
   private final Expression condition;
   private final Statement ifStatement;
   private Statement elseStatement;
@@ -63,6 +63,16 @@ public class IfElseStatement implements Statement {
     return usingSemicolonForIfStatement;
   }
 
+  @Override
+  public boolean isBlock() {
+    return true;
+  }
+
+  @Override
+  public StatementType getStatementType() {
+    return StatementType.BLOCK;
+  }
+
   public StringBuilder appendTo(StringBuilder builder) {
     builder.append("IF ").append(condition).append(" ").append(ifStatement)
         .append(usingSemicolonForIfStatement ? ";" : "");
@@ -72,11 +82,6 @@ public class IfElseStatement implements Statement {
           .append(usingSemicolonForElseStatement ? ";" : "");
     }
     return builder;
-  }
-
-  @Override
-  public String toString() {
-    return appendTo(new StringBuilder()).toString();
   }
 
   @Override

--- a/src/main/java/net/sf/jsqlparser/statement/PurgeStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/PurgeStatement.java
@@ -20,7 +20,7 @@ import net.sf.jsqlparser.statement.create.table.Index;
  * @see  <a href="https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_9018.htm">Purge</a>
  */
 
-public class PurgeStatement implements Statement {
+public class PurgeStatement extends DDLStatement {
     private final PurgeObjectType purgeObjectType;
     private final Object object;
     private String userName;
@@ -78,11 +78,6 @@ public class PurgeStatement implements Statement {
                 break;
         }
         return builder;
-    }
-
-    @Override
-    public String toString() {
-        return appendTo(new StringBuilder()).toString();
     }
 
     public String getUserName() {

--- a/src/main/java/net/sf/jsqlparser/statement/QueryStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/QueryStatement.java
@@ -1,0 +1,22 @@
+/*
+ * To change this license header, choose License Headers in Project Properties. To change this
+ * template file, choose Tools | Templates and open the template in the editor.
+ */
+
+package net.sf.jsqlparser.statement;
+
+/**
+ *
+ * @author <a href="mailto:andreas@manticore-projects.com">Andreas Reichel</a>
+ */
+public abstract class QueryStatement extends StatementImpl {
+    @Override
+    public boolean isQuery() {
+        return true;
+    }
+
+    @Override
+    public StatementType getStatementType() {
+        return StatementType.QUERY;
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/QueryStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/QueryStatement.java
@@ -1,3 +1,12 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2021 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
 /*
  * To change this license header, choose License Headers in Project Properties. To change this
  * template file, choose Tools | Templates and open the template in the editor.

--- a/src/main/java/net/sf/jsqlparser/statement/ResetStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/ResetStatement.java
@@ -10,18 +10,19 @@
 package net.sf.jsqlparser.statement;
 
 
-public final class ResetStatement implements Statement {
+public final class ResetStatement extends DDLStatement {
 
-    private String name = "";
+    private String name;
 
     public ResetStatement() {
-        // empty constructor
+        name = "";
     }
 
     public ResetStatement(String name) {
-        add(name);
+        this.name = name;
     }
 
+    @Deprecated
     public void add(String name) {
         this.name = name;
     }
@@ -35,9 +36,9 @@ public final class ResetStatement implements Statement {
     }
 
     @Override
-    public String toString() {
-        StringBuilder b = new StringBuilder("RESET ").append(name);
-        return b.toString();
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("RESET ").append(name);
+        return builder;
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/statement/RollbackStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/RollbackStatement.java
@@ -27,9 +27,9 @@ package net.sf.jsqlparser.statement;
 
 /**
  *
- * @author are
+ * @author <a href="mailto:andreas@manticore-projects.com">Andreas Reichel</a>
  */
-public class RollbackStatement implements Statement {
+public class RollbackStatement extends DMLStatement {
     private boolean usingWorkKeyword=false;
     private boolean usingSavepointKeyword=false;
     private String savepointName=null;
@@ -88,25 +88,21 @@ public class RollbackStatement implements Statement {
     }
 
     @Override
-    public String toString() {
-        return "ROLLBACK " 
-          + ( usingWorkKeyword 
-                ? "WORK "
-                : "" )
-          + (savepointName!=null && savepointName.trim().length()!=0
-                ? "TO " + (usingSavepointKeyword
-                               ? "SAVEPOINT "
-                               : "") + savepointName
-                : forceDistributedTransactionIdentifier!=null && forceDistributedTransactionIdentifier.trim().length()!=0
-                       ? "FORCE " + forceDistributedTransactionIdentifier
-                        : ""
-                        
-                );
-    }
-
-    @Override
     public void accept(StatementVisitor statementVisitor) {
          statementVisitor.visit(this);
     }
 
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("ROLLBACK ").append(usingWorkKeyword
+                ? "WORK "
+                : "").append(savepointName != null && savepointName.trim().length() != 0
+                ? "TO " + (usingSavepointKeyword
+                ? "SAVEPOINT "
+                : "") + savepointName
+                : forceDistributedTransactionIdentifier != null && forceDistributedTransactionIdentifier.trim().length() != 0
+                ? "FORCE " + forceDistributedTransactionIdentifier
+                : "");
+        return builder;
+    }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/SavepointStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/SavepointStatement.java
@@ -16,7 +16,7 @@ import java.util.Objects;
  *
  * @author <a href="mailto:andreas@manticore-projects.com">Andreas Reichel</a>
  */
-public class SavepointStatement implements Statement {
+public class SavepointStatement extends DMLStatement {
     private String savepointName;
 
     public String getSavepointName() {
@@ -32,12 +32,13 @@ public class SavepointStatement implements Statement {
     }
 
     @Override
-    public String toString() {
-        return "SAVEPOINT " + savepointName;
+    public void accept(StatementVisitor statementVisitor) {
+         statementVisitor.visit(this);
     }
 
     @Override
-    public void accept(StatementVisitor statementVisitor) {
-         statementVisitor.visit(this);
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("SAVEPOINT ").append(savepointName);
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/SetStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/SetStatement.java
@@ -14,7 +14,7 @@ import java.util.List;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 
-public final class SetStatement implements Statement {
+public final class SetStatement extends DDLStatement {
 
     private String effectParameter;
     private final List<NameExpr> values = new ArrayList<>();
@@ -104,22 +104,21 @@ public final class SetStatement implements Statement {
     }
 
     @Override
-    public String toString() {
-        StringBuilder b = new StringBuilder("SET ");
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("SET ");
         if (effectParameter != null) {
-            b.append(effectParameter).append(" ");
+            builder.append(effectParameter).append(" ");
         }
         boolean addComma = false;
         for (NameExpr ne : values) {
             if (addComma) {
-                b.append(", ");
+                builder.append(", ");
             } else {
                 addComma = true;
             }
-            b.append(toString(ne));
+            builder.append(toString(ne));
         }
-
-        return b.toString();
+        return builder;
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/statement/ShowColumnsStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/ShowColumnsStatement.java
@@ -9,7 +9,7 @@
  */
 package net.sf.jsqlparser.statement;
 
-public class ShowColumnsStatement implements Statement {
+public class ShowColumnsStatement extends DDLStatement {
 
     private String tableName;
 
@@ -30,11 +30,6 @@ public class ShowColumnsStatement implements Statement {
     }
 
     @Override
-    public String toString() {
-        return "SHOW COLUMNS FROM " + tableName;
-    }
-
-    @Override
     public void accept(StatementVisitor statementVisitor) {
         statementVisitor.visit(this);
     }
@@ -42,5 +37,11 @@ public class ShowColumnsStatement implements Statement {
     public ShowColumnsStatement withTableName(String tableName) {
         this.setTableName(tableName);
         return this;
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("SHOW COLUMNS FROM ").append(tableName);
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/ShowStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/ShowStatement.java
@@ -9,7 +9,7 @@
  */
 package net.sf.jsqlparser.statement;
 
-public class ShowStatement implements Statement {
+public class ShowStatement extends DDLStatement {
 
     private String name;
 
@@ -30,11 +30,6 @@ public class ShowStatement implements Statement {
     }
 
     @Override
-    public String toString() {
-        return "SHOW " + name;
-    }
-
-    @Override
     public void accept(StatementVisitor statementVisitor) {
         statementVisitor.visit(this);
     }
@@ -42,5 +37,11 @@ public class ShowStatement implements Statement {
     public ShowStatement withName(String name) {
         this.setName(name);
         return this;
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("SHOW ").append(name);
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/Statement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/Statement.java
@@ -12,5 +12,14 @@ package net.sf.jsqlparser.statement;
 import net.sf.jsqlparser.Model;
 
 public interface Statement extends Model {
+    enum StatementType { QUERY, DML, DDL, BLOCK, UNPARSED }
+
+    boolean isQuery();
+    boolean isDML();
+    boolean isDDL();
+    boolean isBlock();
+    boolean isUnparsed();
+    StatementType getStatementType();
+
     void accept(StatementVisitor statementVisitor);
 }

--- a/src/main/java/net/sf/jsqlparser/statement/StatementImpl.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementImpl.java
@@ -1,0 +1,27 @@
+package net.sf.jsqlparser.statement;
+
+/**
+ *
+ * @author <a href="mailto:andreas@manticore-projects.com">Andreas Reichel</a>
+ */
+public abstract class StatementImpl implements Statement {
+
+    public boolean isQuery() { return false; }
+
+    public boolean isDML() { return false; }
+
+    public boolean isDDL() { return false; }
+
+    public boolean isBlock() { return false; }
+
+    public boolean isUnparsed() { return false; }
+
+    public abstract StatementType getStatementType();
+
+    public abstract StringBuilder appendTo(StringBuilder builder);
+
+    @Override
+    public String toString() {
+        return appendTo(new StringBuilder()).toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/StatementImpl.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementImpl.java
@@ -1,3 +1,12 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2021 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
 package net.sf.jsqlparser.statement;
 
 /**
@@ -6,22 +15,32 @@ package net.sf.jsqlparser.statement;
  */
 public abstract class StatementImpl implements Statement {
 
-    public boolean isQuery() { return false; }
+    public boolean isQuery() {
+        return false;
+    }
 
-    public boolean isDML() { return false; }
+    public boolean isDML() {
+        return false;
+    }
 
-    public boolean isDDL() { return false; }
+    public boolean isDDL() {
+        return false;
+    }
 
-    public boolean isBlock() { return false; }
+    public boolean isBlock() {
+        return false;
+    }
 
-    public boolean isUnparsed() { return false; }
+    public boolean isUnparsed() {
+        return false;
+    }
 
     public abstract StatementType getStatementType();
 
-    public abstract StringBuilder appendTo(StringBuilder builder);
+    public abstract StringBuilder appendTo(final StringBuilder builder);
 
     @Override
-    public String toString() {
+    public final String toString() {
         return appendTo(new StringBuilder()).toString();
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
@@ -9,7 +9,6 @@
  */
 package net.sf.jsqlparser.statement;
 
-import net.sf.jsqlparser.parser.JSqlParser;
 import net.sf.jsqlparser.statement.alter.Alter;
 import net.sf.jsqlparser.statement.alter.AlterSession;
 import net.sf.jsqlparser.statement.alter.AlterSystemStatement;

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
@@ -9,6 +9,7 @@
  */
 package net.sf.jsqlparser.statement;
 
+import net.sf.jsqlparser.parser.JSqlParser;
 import net.sf.jsqlparser.statement.alter.Alter;
 import net.sf.jsqlparser.statement.alter.AlterSession;
 import net.sf.jsqlparser.statement.alter.AlterSystemStatement;

--- a/src/main/java/net/sf/jsqlparser/statement/UnparsedStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/UnparsedStatement.java
@@ -1,3 +1,12 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2021 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
 /*
  * To change this license header, choose License Headers in Project Properties. To change this
  * template file, choose Tools | Templates and open the template in the editor.

--- a/src/main/java/net/sf/jsqlparser/statement/UnparsedStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/UnparsedStatement.java
@@ -1,0 +1,22 @@
+/*
+ * To change this license header, choose License Headers in Project Properties. To change this
+ * template file, choose Tools | Templates and open the template in the editor.
+ */
+
+package net.sf.jsqlparser.statement;
+
+/**
+ *
+ * @author <a href="mailto:andreas@manticore-projects.com">Andreas Reichel</a>
+ */
+public abstract class UnparsedStatement extends StatementImpl {
+    @Override
+    public boolean isUnparsed() {
+        return true;
+    }
+
+    @Override
+    public StatementType getStatementType() {
+        return StatementType.UNPARSED;
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/UseStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/UseStatement.java
@@ -9,7 +9,7 @@
  */
 package net.sf.jsqlparser.statement;
 
-public class UseStatement implements Statement {
+public class UseStatement extends DDLStatement {
 
     private String name;
 
@@ -30,11 +30,6 @@ public class UseStatement implements Statement {
     }
 
     @Override
-    public String toString() {
-        return "USE " + name;
-    }
-
-    @Override
     public void accept(StatementVisitor statementVisitor) {
         statementVisitor.visit(this);
     }
@@ -42,5 +37,11 @@ public class UseStatement implements Statement {
     public UseStatement withName(String name) {
         this.setName(name);
         return this;
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("USE ").append(name);
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/alter/Alter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/Alter.java
@@ -16,10 +16,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
-public class Alter implements Statement {
+public class Alter extends DDLStatement {
 
     private Table table;
     private boolean useOnly = false;
@@ -44,7 +45,7 @@ public class Alter implements Statement {
 
     public void addAlterExpression(AlterExpression alterExpression) {
         if (alterExpressions == null) {
-            alterExpressions = new ArrayList<AlterExpression>();
+            alterExpressions = new ArrayList<>();
         }
         alterExpressions.add(alterExpression);
     }
@@ -60,31 +61,6 @@ public class Alter implements Statement {
     @Override
     public void accept(StatementVisitor statementVisitor) {
         statementVisitor.visit(this);
-    }
-
-    @Override
-    public String toString() {
-
-        StringBuilder b = new StringBuilder();
-        b.append("ALTER TABLE ");
-        if (useOnly) {
-            b.append("ONLY ");
-        }
-        b.append(table.getFullyQualifiedName()).append(" ");
-
-        Iterator<AlterExpression> altIter = alterExpressions.iterator();
-
-        while (altIter.hasNext()) {
-            b.append(altIter.next().toString());
-
-            // Need to append whitespace after each ADD or DROP statement
-            // but not the last one
-            if (altIter.hasNext()) {
-                b.append(", ");
-            }
-        }
-
-        return b.toString();
     }
 
     public Alter withTable(Table table) {
@@ -112,5 +88,27 @@ public class Alter implements Statement {
         List<AlterExpression> collection = Optional.ofNullable(getAlterExpressions()).orElseGet(ArrayList::new);
         collection.addAll(alterExpressions);
         return this.withAlterExpressions(collection);
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("ALTER TABLE ");
+        if (useOnly) {
+            builder.append("ONLY ");
+        }
+        builder.append(table.getFullyQualifiedName()).append(" ");
+
+        Iterator<AlterExpression> altIter = alterExpressions.iterator();
+
+        while (altIter.hasNext()) {
+            builder.append(altIter.next().toString());
+
+            // Need to append whitespace after each ADD or DROP statement
+            // but not the last one
+            if (altIter.hasNext()) {
+                builder.append(", ");
+            }
+        }
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/alter/Alter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/Alter.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Optional;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 public class Alter extends DDLStatement {

--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterSession.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterSession.java
@@ -11,15 +11,16 @@
 package net.sf.jsqlparser.statement.alter;
 
 import java.util.List;
-import net.sf.jsqlparser.statement.Statement;
+
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 /**
  *
- * @author are
+ * @author <a href="mailto:andreas@manticore-projects.com">Andreas Reichel</a>
  * @see  <a href="https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_2012.htm">ALTER SESSION</a>
  */
-public class AlterSession implements Statement  {
+public class AlterSession extends DDLStatement {
     private AlterSessionOperation operation;
     private List<String> parameters;
 
@@ -44,16 +45,20 @@ public class AlterSession implements Statement  {
         this.parameters = parameters;
     }
     
-    private static void appendParamaters(StringBuilder builder, List<String> parameters) {
+    private static void appendParameters(StringBuilder builder, List<String> parameters) {
         for (String s: parameters) {
             builder.append(" ").append(s);
         }
     }
 
     @Override
-    @SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.CyclomaticComplexity"})  
-    public String toString() {
-        StringBuilder builder = new StringBuilder();
+    public void accept(StatementVisitor statementVisitor) {
+        statementVisitor.visit(this);
+    }
+
+    @Override
+    @SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.CyclomaticComplexity"})
+    public StringBuilder appendTo(StringBuilder builder) {
         builder.append("ALTER SESSION ");
         switch (operation) {
             case ADVISE_COMMIT:
@@ -67,7 +72,7 @@ public class AlterSession implements Statement  {
                 break;
             case CLOSE_DATABASE_LINK:
                 builder.append("CLOSE DATABASE LINK ");
-                appendParamaters(builder, parameters);
+                appendParameters(builder, parameters);
                 break;
             case ENABLE_COMMIT_IN_PROCEDURE:
                 builder.append("ENABLE COMMIT IN PROCEDURE");
@@ -81,72 +86,67 @@ public class AlterSession implements Statement  {
             case DISABLE_GUARD:
                 builder.append("DISABLE GUARD");
                 break;
-            
+
             case ENABLE_PARALLEL_DML:
                 builder.append("ENABLE PARALLEL DML");
-                appendParamaters(builder, parameters);
+                appendParameters(builder, parameters);
                 break;
-                
+
             case DISABLE_PARALLEL_DML:
                 builder.append("DISABLE PARALLEL DML");
-                appendParamaters(builder, parameters);
+                appendParameters(builder, parameters);
                 break;
-                
+
             case FORCE_PARALLEL_DML:
                 builder.append("FORCE PARALLEL DML");
-                appendParamaters(builder, parameters);
+                appendParameters(builder, parameters);
                 break;
-                
+
             case ENABLE_PARALLEL_DDL:
                 builder.append("ENABLE PARALLEL DDL");
-                appendParamaters(builder, parameters);
+                appendParameters(builder, parameters);
                 break;
-                
+
             case DISABLE_PARALLEL_DDL:
                 builder.append("DISABLE PARALLEL DDL");
                 break;
-                
+
             case FORCE_PARALLEL_DDL:
                 builder.append("FORCE PARALLEL DDL");
-                appendParamaters(builder, parameters);
+                appendParameters(builder, parameters);
                 break;
-                
+
             case ENABLE_PARALLEL_QUERY:
                 builder.append("ENABLE PARALLEL QUERY");
-                appendParamaters(builder, parameters);
+                appendParameters(builder, parameters);
                 break;
-                
+
             case DISABLE_PARALLEL_QUERY:
                 builder.append("DISABLE PARALLEL QUERY");
                 break;
-                
+
             case FORCE_PARALLEL_QUERY:
                 builder.append("FORCE PARALLEL QUERY");
-                appendParamaters(builder, parameters);
+                appendParameters(builder, parameters);
                 break;
-                
+
             case ENABLE_RESUMABLE:
                 builder.append("ENABLE RESUMABLE");
-                appendParamaters(builder, parameters);
+                appendParameters(builder, parameters);
                 break;
-            
+
             case DISABLE_RESUMABLE:
                 builder.append("DISABLE RESUMABLE");
                 break;
-            
+
             case SET:
                 builder.append("SET");
-                appendParamaters(builder, parameters);
+                appendParameters(builder, parameters);
                 break;
             default:
                 // not going to happen
-                
-        }
-        return builder.toString();
-    }
 
-    @Override
-    public void accept(StatementVisitor statementVisitor) {
-        statementVisitor.visit(this);
+        }
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterSystemStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterSystemStatement.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Objects;
 
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 /**

--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterSystemStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterSystemStatement.java
@@ -11,6 +11,8 @@ package net.sf.jsqlparser.statement.alter;
 
 import java.util.List;
 import java.util.Objects;
+
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
@@ -20,7 +22,7 @@ import net.sf.jsqlparser.statement.StatementVisitor;
  * @see  <a href="https://docs.oracle.com/cd/B12037_01/server.101/b10759/statements_2013.htm">ALTER SESSION</a>
  */
 
-public class AlterSystemStatement implements Statement {
+public class AlterSystemStatement extends DDLStatement {
     private final AlterSystemOperation operation;
     private final List<String> parameters;
 
@@ -52,11 +54,6 @@ public class AlterSystemStatement implements Statement {
         builder.append("ALTER SYSTEM ").append(operation);
         appendParameters(builder, parameters);
         return builder;
-    }
-    
-    @Override
-    public String toString() {
-        return appendTo(new StringBuilder()).toString();
     }
 
 }

--- a/src/main/java/net/sf/jsqlparser/statement/alter/RenameTableStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/RenameTableStatement.java
@@ -16,15 +16,15 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import net.sf.jsqlparser.schema.Table;
-import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 /**
  *
- * @author are
+ * @author <a href="mailto:andreas@manticore-projects.com">Andreas Reichel</a>
  * @see  <a href="https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_9019.htm">Rename</a>
  */
-public class RenameTableStatement implements Statement {
+public class RenameTableStatement extends DDLStatement {
     private final LinkedHashMap<Table, Table> tableNames = new LinkedHashMap<>();
     
     private boolean usingTableKeyword = false;
@@ -113,7 +113,8 @@ public class RenameTableStatement implements Statement {
     public void accept(StatementVisitor statementVisitor) {
         statementVisitor.visit(this);
       }
-    
+
+    @Override
     public StringBuilder appendTo(StringBuilder builder) {
         int i=0;
         for (Entry<Table, Table> e : tableNames.entrySet()) {
@@ -137,10 +138,5 @@ public class RenameTableStatement implements Statement {
             i++;
         }
         return builder;
-    }
-
-    @Override
-    public String toString() {
-        return appendTo(new StringBuilder()).toString();
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/alter/sequence/AlterSequence.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/sequence/AlterSequence.java
@@ -10,13 +10,14 @@
 package net.sf.jsqlparser.statement.alter.sequence;
 
 import net.sf.jsqlparser.schema.Sequence;
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 /**
  * An {@code ALTER SEQUENCE} statement
  */
-public class AlterSequence implements Statement {
+public class AlterSequence extends DDLStatement {
 
     public Sequence sequence;
 
@@ -33,15 +34,14 @@ public class AlterSequence implements Statement {
         statementVisitor.visit(this);
     }
 
-    @Override
-    public String toString() {
-        String sql;
-        sql = "ALTER SEQUENCE " + sequence;
-        return sql;
-    }
-
     public AlterSequence withSequence(Sequence sequence) {
         this.setSequence(sequence);
         return this;
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("ALTER SEQUENCE ").append(sequence);
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/alter/sequence/AlterSequence.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/sequence/AlterSequence.java
@@ -11,7 +11,6 @@ package net.sf.jsqlparser.statement.alter.sequence;
 
 import net.sf.jsqlparser.schema.Sequence;
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 /**

--- a/src/main/java/net/sf/jsqlparser/statement/comment/Comment.java
+++ b/src/main/java/net/sf/jsqlparser/statement/comment/Comment.java
@@ -13,9 +13,7 @@ import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
-import net.sf.jsqlparser.statement.UnparsedStatement;
 
 public class Comment extends DDLStatement {
 

--- a/src/main/java/net/sf/jsqlparser/statement/comment/Comment.java
+++ b/src/main/java/net/sf/jsqlparser/statement/comment/Comment.java
@@ -12,10 +12,12 @@ package net.sf.jsqlparser.statement.comment;
 import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
+import net.sf.jsqlparser.statement.UnparsedStatement;
 
-public class Comment implements Statement {
+public class Comment extends DDLStatement {
 
     private Table table;
     private Column column;
@@ -60,17 +62,17 @@ public class Comment implements Statement {
     }
 
     @Override
-    public String toString() {
-        String sql = "COMMENT ON ";
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("COMMENT ON ");
         if (table != null) {
-            sql += "TABLE " + table + " ";
+            builder.append("TABLE ").append(table).append(" ");
         } else if (column != null) {
-            sql += "COLUMN " + column + " ";
+            builder.append("COLUMN ").append(column).append(" ");
         } else if (view != null) {
-            sql += "VIEW " + view + " ";
+            builder.append("VIEW ").append(view).append(" ");
         }
-        sql += "IS " + comment;
-        return sql;
+        builder.append("IS ").append(comment);
+        return builder;
     }
 
     public Comment withTable(Table table) {

--- a/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
@@ -16,7 +16,7 @@ import net.sf.jsqlparser.statement.create.table.*;
 import java.util.*;
 import static java.util.stream.Collectors.joining;
 
-public class CreateIndex implements Statement {
+public class CreateIndex extends DDLStatement {
 
     private Table table;
     private Index index;
@@ -51,47 +51,6 @@ public class CreateIndex implements Statement {
         this.tailParameters = tailParameters;
     }
 
-    @Override
-    public String toString() {
-        StringBuilder buffer = new StringBuilder();
-
-        buffer.append("CREATE ");
-
-        if (index.getType() != null) {
-            buffer.append(index.getType());
-            buffer.append(" ");
-        }
-
-        buffer.append("INDEX ");
-        buffer.append(index.getName());
-        buffer.append(" ON ");
-        buffer.append(table.getFullyQualifiedName());
-
-        if (index.getUsing() != null) {
-            buffer.append(" USING ");
-            buffer.append(index.getUsing());
-        }
-
-        if (index.getColumnsNames() != null) {
-            buffer.append(" (");
-
-            buffer.append(
-                    index.getColumns().stream()
-                            .map(cp -> cp.columnName + (cp.getParams() != null ? " " + String.join(" ", cp.getParams()) : "")).collect(joining(", "))
-            );
-
-            buffer.append(")");
-
-            if (tailParameters != null) {
-                for (String param : tailParameters) {
-                    buffer.append(" ").append(param);
-                }
-            }
-        }
-
-        return buffer.toString();
-    }
-
     public CreateIndex withTable(Table table) {
         this.setTable(table);
         return this;
@@ -105,5 +64,43 @@ public class CreateIndex implements Statement {
     public CreateIndex withTailParameters(List<String> tailParameters) {
         this.setTailParameters(tailParameters);
         return this;
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("CREATE ");
+
+        if (index.getType() != null) {
+            builder.append(index.getType());
+            builder.append(" ");
+        }
+
+        builder.append("INDEX ");
+        builder.append(index.getName());
+        builder.append(" ON ");
+        builder.append(table.getFullyQualifiedName());
+
+        if (index.getUsing() != null) {
+            builder.append(" USING ");
+            builder.append(index.getUsing());
+        }
+
+        if (index.getColumnsNames() != null) {
+            builder.append(" (");
+
+            builder.append(
+                    index.getColumns().stream()
+                            .map(cp -> cp.columnName + (cp.getParams() != null ? " " + String.join(" ", cp.getParams()) : "")).collect(joining(", "))
+            );
+
+            builder.append(")");
+
+            if (tailParameters != null) {
+                for (String param : tailParameters) {
+                    builder.append(" ").append(param);
+                }
+            }
+        }
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/create/schema/CreateSchema.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/schema/CreateSchema.java
@@ -14,10 +14,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
-public class CreateSchema implements Statement {
+public class CreateSchema extends DDLStatement {
 
     private String authorization;
     private String schemaName;
@@ -109,17 +111,6 @@ public class CreateSchema implements Statement {
         this.schemaPath = schemaPath;
     }
 
-    public String toString() {
-        String sql = "CREATE SCHEMA";
-        if (schemaName != null) {
-            sql += " " + schemaName;
-        }
-        if (authorization != null) {
-            sql += " AUTHORIZATION " + authorization;
-        }
-        return sql;
-    }
-
     public CreateSchema withAuthorization(String authorization) {
         this.setAuthorization(authorization);
         return this;
@@ -145,5 +136,17 @@ public class CreateSchema implements Statement {
         List<String> collection = Optional.ofNullable(getSchemaPath()).orElseGet(ArrayList::new);
         collection.addAll(schemaPath);
         return this.withSchemaPath(collection);
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+       builder.append("CREATE SCHEMA");
+        if (schemaName != null) {
+            builder.append(" ").append(schemaName);
+        }
+        if (authorization != null) {
+            builder.append(" AUTHORIZATION ").append(authorization);
+        }
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/create/sequence/CreateSequence.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/sequence/CreateSequence.java
@@ -10,13 +10,14 @@
 package net.sf.jsqlparser.statement.create.sequence;
 
 import net.sf.jsqlparser.schema.Sequence;
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 /**
  * A {@code CREATE SEQUENCE} statement
  */
-public class CreateSequence implements Statement {
+public class CreateSequence extends DDLStatement {
 
     public Sequence sequence;
 
@@ -33,15 +34,14 @@ public class CreateSequence implements Statement {
         statementVisitor.visit(this);
     }
 
-    @Override
-    public String toString() {
-        String sql;
-        sql = "CREATE SEQUENCE " + sequence;
-        return sql;
-    }
-
     public CreateSequence withSequence(Sequence sequence) {
         this.setSequence(sequence);
         return this;
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("CREATE SEQUENCE ").append(sequence);
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/create/sequence/CreateSequence.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/sequence/CreateSequence.java
@@ -11,7 +11,6 @@ package net.sf.jsqlparser.statement.create.sequence;
 
 import net.sf.jsqlparser.schema.Sequence;
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 /**

--- a/src/main/java/net/sf/jsqlparser/statement/create/synonym/CreateSynonym.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/synonym/CreateSynonym.java
@@ -11,7 +11,6 @@ package net.sf.jsqlparser.statement.create.synonym;
 
 import net.sf.jsqlparser.schema.Synonym;
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 import java.util.ArrayList;

--- a/src/main/java/net/sf/jsqlparser/statement/create/synonym/CreateSynonym.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/synonym/CreateSynonym.java
@@ -10,13 +10,14 @@
 package net.sf.jsqlparser.statement.create.synonym;
 
 import net.sf.jsqlparser.schema.Synonym;
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class CreateSynonym implements Statement {
+public class CreateSynonym extends DDLStatement {
 
     private boolean orReplace;
     private boolean publicSynonym;
@@ -71,24 +72,25 @@ public class CreateSynonym implements Statement {
         statementVisitor.visit(this);
     }
 
-    @Override
-    public String toString() {
-        StringBuilder sqlBuilder = new StringBuilder();
-        sqlBuilder.append("CREATE ");
-        if (orReplace) {
-            sqlBuilder.append("OR REPLACE ");
-        }
-        if (publicSynonym) {
-            sqlBuilder.append("PUBLIC ");
-        }
-        sqlBuilder.append("SYNONYM " + synonym);
-        sqlBuilder.append(' ');
-        sqlBuilder.append("FOR " + getFor());
-        return sqlBuilder.toString();
-    }
-
     public CreateSynonym withSynonym(Synonym synonym) {
         this.setSynonym(synonym);
         return this;
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+
+        builder.append("CREATE ");
+        if (orReplace) {
+            builder.append("OR REPLACE ");
+        }
+        if (publicSynonym) {
+            builder.append("PUBLIC ");
+        }
+        builder.append("SYNONYM ").append(synonym);
+        builder.append(' ');
+        builder.append("FOR ").append(getFor());
+
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/CreateTable.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/CreateTable.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
@@ -252,7 +251,6 @@ public class CreateTable extends DDLStatement {
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     public StringBuilder appendTo(StringBuilder builder) {
-        String sql;
         String createOps = PlainSelect.getStringList(createOptionsStrings, false, false);
 
         builder.append("CREATE ")

--- a/src/main/java/net/sf/jsqlparser/statement/create/view/AlterView.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/view/AlterView.java
@@ -15,12 +15,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.SelectBody;
 
-public class AlterView implements Statement {
+public class AlterView extends DDLStatement {
 
     private Table view;
     private SelectBody selectBody;
@@ -64,23 +65,6 @@ public class AlterView implements Statement {
         this.useReplace = useReplace;
     }
 
-    @Override
-    public String toString() {
-        StringBuilder sql;
-        if (useReplace) {
-            sql = new StringBuilder("REPLACE ");
-        } else {
-            sql = new StringBuilder("ALTER ");
-        }
-        sql.append("VIEW ");
-        sql.append(view);
-        if (columnNames != null) {
-            sql.append(PlainSelect.getStringList(columnNames, true, true));
-        }
-        sql.append(" AS ").append(selectBody);
-        return sql.toString();
-    }
-
     public AlterView withView(Table view) {
         this.setView(view);
         return this;
@@ -115,5 +99,21 @@ public class AlterView implements Statement {
 
     public <E extends SelectBody> E getSelectBody(Class<E> type) {
         return type.cast(getSelectBody());
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        if (useReplace) {
+            builder = new StringBuilder("REPLACE ");
+        } else {
+            builder = new StringBuilder("ALTER ");
+        }
+        builder.append("VIEW ");
+        builder.append(view);
+        if (columnNames != null) {
+            builder.append(PlainSelect.getStringList(columnNames, true, true));
+        }
+        builder.append(" AS ").append(selectBody);
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/create/view/AlterView.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/view/AlterView.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Optional;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.SelectBody;
@@ -104,9 +103,9 @@ public class AlterView extends DDLStatement {
     @Override
     public StringBuilder appendTo(StringBuilder builder) {
         if (useReplace) {
-            builder = new StringBuilder("REPLACE ");
+            builder.append("REPLACE ");
         } else {
-            builder = new StringBuilder("ALTER ");
+            builder.append("ALTER ");
         }
         builder.append("VIEW ");
         builder.append(view);

--- a/src/main/java/net/sf/jsqlparser/statement/create/view/CreateView.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/view/CreateView.java
@@ -15,12 +15,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 
-public class CreateView implements Statement {
+public class CreateView extends DDLStatement {
 
     private Table view;
     private Select select;
@@ -103,42 +104,6 @@ public class CreateView implements Statement {
         this.withReadOnly = withReadOnly;
     }
 
-    @Override
-    public String toString() {
-        StringBuilder sql = new StringBuilder("CREATE ");
-        if (isOrReplace()) {
-            sql.append("OR REPLACE ");
-        }
-        switch (force) {
-            case FORCE:
-                sql.append("FORCE ");
-                break;
-            case NO_FORCE:
-                sql.append("NO FORCE ");
-                break;
-            default:
-                // nothing
-        }
-
-        if (temp != TemporaryOption.NONE) {
-            sql.append(temp.name()).append(" ");
-        }
-
-        if (isMaterialized()) {
-            sql.append("MATERIALIZED ");
-        }
-        sql.append("VIEW ");
-        sql.append(view);
-        if (columnNames != null) {
-            sql.append(PlainSelect.getStringList(columnNames, true, true));
-        }
-        sql.append(" AS ").append(select);
-        if (isWithReadOnly()) {
-            sql.append(" WITH READ ONLY");
-        }
-        return sql.toString();
-    }
-
     public CreateView withView(Table view) {
         this.setView(view);
         return this;
@@ -184,5 +149,41 @@ public class CreateView implements Statement {
         List<String> collection = Optional.ofNullable(getColumnNames()).orElseGet(ArrayList::new);
         collection.addAll(columnNames);
         return this.withColumnNames(collection);
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder .append("CREATE ");
+        if (isOrReplace()) {
+            builder.append("OR REPLACE ");
+        }
+        switch (force) {
+            case FORCE:
+                builder.append("FORCE ");
+                break;
+            case NO_FORCE:
+                builder.append("NO FORCE ");
+                break;
+            default:
+                // nothing
+        }
+
+        if (temp != TemporaryOption.NONE) {
+            builder.append(temp.name()).append(" ");
+        }
+
+        if (isMaterialized()) {
+            builder.append("MATERIALIZED ");
+        }
+        builder.append("VIEW ");
+        builder.append(view);
+        if (columnNames != null) {
+            builder.append(PlainSelect.getStringList(columnNames, true, true));
+        }
+        builder.append(" AS ").append(select);
+        if (isWithReadOnly()) {
+            builder.append(" WITH READ ONLY");
+        }
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/create/view/CreateView.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/view/CreateView.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Optional;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;

--- a/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
+++ b/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
@@ -20,6 +20,7 @@ import static java.util.stream.Collectors.joining;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.DMLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.Join;
@@ -28,7 +29,7 @@ import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.WithItem;
 
-public class Delete implements Statement {
+public class Delete extends DMLStatement {
 
     private List<WithItem> withItemsList;
     private Table table;
@@ -144,37 +145,36 @@ public class Delete implements Statement {
 
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
-    public String toString() {
-        StringBuilder b = new StringBuilder();
+    public StringBuilder appendTo(StringBuilder builder) {
         if (withItemsList != null && !withItemsList.isEmpty()) {
-            b.append("WITH ");
+            builder.append("WITH ");
             for (Iterator<WithItem> iter = withItemsList.iterator(); iter.hasNext();) {
                 WithItem withItem = iter.next();
-                b.append(withItem);
+                builder.append(withItem);
                 if (iter.hasNext()) {
-                    b.append(",");
+                    builder.append(",");
                 }
-                b.append(" ");
+                builder.append(" ");
             }
         }
-        
-        b.append("DELETE");
+
+        builder.append("DELETE");
 
         if (tables != null && tables.size() > 0) {
-            b.append(" ");
-            b.append(tables.stream()
-                    .map(t -> t.toString())
+            builder.append(" ");
+            builder.append(tables.stream()
+                    .map(Table::toString)
                     .collect(joining(", ")));
         }
 
         if (hasFrom) {
-            b.append(" FROM");
+            builder.append(" FROM");
         }
-        b.append(" ").append(table);
+        builder.append(" ").append(table);
 
         if (usingList != null && usingList.size()>0) {
-            b.append(" USING ");
-            b.append(usingList.stream()
+            builder.append(" USING ");
+            builder.append(usingList.stream()
                     .map(Table::toString)
                     .collect(joining(", ")));
         }
@@ -182,25 +182,25 @@ public class Delete implements Statement {
         if (joins != null) {
             for (Join join : joins) {
                 if (join.isSimple()) {
-                    b.append(", ").append(join);
+                    builder.append(", ").append(join);
                 } else {
-                    b.append(" ").append(join);
+                    builder.append(" ").append(join);
                 }
             }
         }
 
         if (where != null) {
-            b.append(" WHERE ").append(where);
+            builder.append(" WHERE ").append(where);
         }
 
         if (orderByElements != null) {
-            b.append(PlainSelect.orderByToString(orderByElements));
+            builder.append(PlainSelect.orderByToString(orderByElements));
         }
 
         if (limit != null) {
-            b.append(limit);
+            builder.append(limit);
         }
-        return b.toString();
+        return builder;
     }
 
     public Delete withTables(List<Table> tables) {

--- a/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
+++ b/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
@@ -21,7 +21,6 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.DMLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.Join;
 import net.sf.jsqlparser.statement.select.Limit;

--- a/src/main/java/net/sf/jsqlparser/statement/drop/Drop.java
+++ b/src/main/java/net/sf/jsqlparser/statement/drop/Drop.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Optional;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 

--- a/src/main/java/net/sf/jsqlparser/statement/drop/Drop.java
+++ b/src/main/java/net/sf/jsqlparser/statement/drop/Drop.java
@@ -15,11 +15,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 
-public class Drop implements Statement {
+public class Drop extends DDLStatement {
 
     private String type;
     private Table name;
@@ -63,18 +64,6 @@ public class Drop implements Statement {
         this.ifExists = ifExists;
     }
 
-    @Override
-    public String toString() {
-        String sql = "DROP " + type + " "
-                + (ifExists ? "IF EXISTS " : "") + name.toString();
-
-        if (parameters != null && !parameters.isEmpty()) {
-            sql += " " + PlainSelect.getStringList(parameters);
-        }
-
-        return sql;
-    }
-
     public Drop withIfExists(boolean ifExists) {
         this.setIfExists(ifExists);
         return this;
@@ -105,5 +94,15 @@ public class Drop implements Statement {
         List<String> collection = Optional.ofNullable(getParameters()).orElseGet(ArrayList::new);
         collection.addAll(parameters);
         return this.withParameters(collection);
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("DROP ").append(type).append(" ").append(ifExists ? "IF EXISTS " : "").append(name.toString());
+
+        if (parameters != null && !parameters.isEmpty()) {
+            builder.append(" ").append(PlainSelect.getStringList(parameters));
+        }
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/execute/Execute.java
+++ b/src/main/java/net/sf/jsqlparser/statement/execute/Execute.java
@@ -12,7 +12,6 @@ package net.sf.jsqlparser.statement.execute;
 import java.util.List;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 

--- a/src/main/java/net/sf/jsqlparser/statement/execute/Execute.java
+++ b/src/main/java/net/sf/jsqlparser/statement/execute/Execute.java
@@ -11,11 +11,12 @@ package net.sf.jsqlparser.statement.execute;
 
 import java.util.List;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 
-public class Execute implements Statement {
+public class Execute extends DDLStatement {
 
     private ExecType execType = ExecType.EXECUTE;
     private String name;
@@ -69,13 +70,6 @@ public class Execute implements Statement {
         statementVisitor.visit(this);
     }
 
-    @Override
-    public String toString() {
-        return execType.name() + " " + name
-                + (exprList != null && exprList.getExpressions() != null ? " "
-                + PlainSelect.getStringList(exprList.getExpressions(), true, parenthesis) : "");
-    }
-
     public Execute withExecType(ExecType execType) {
         this.setExecType(execType);
         return this;
@@ -94,6 +88,13 @@ public class Execute implements Statement {
     public Execute withParenthesis(boolean parenthesis) {
         this.setParenthesis(parenthesis);
         return this;
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append(execType.name()).append(" ").append(name).append(exprList != null && exprList.getExpressions() != null ? " "
+                + PlainSelect.getStringList(exprList.getExpressions(), true, parenthesis) : "");
+        return builder;
     }
 
     public enum ExecType {

--- a/src/main/java/net/sf/jsqlparser/statement/grant/Grant.java
+++ b/src/main/java/net/sf/jsqlparser/statement/grant/Grant.java
@@ -17,7 +17,6 @@ import java.util.Optional;
 import static java.util.stream.Collectors.joining;
 
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 public class Grant extends DDLStatement {

--- a/src/main/java/net/sf/jsqlparser/statement/grant/Grant.java
+++ b/src/main/java/net/sf/jsqlparser/statement/grant/Grant.java
@@ -15,10 +15,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import static java.util.stream.Collectors.joining;
+
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
-public class Grant implements Statement {
+public class Grant extends DDLStatement {
 
     private String role;
     private List<String> privileges;
@@ -74,33 +76,6 @@ public class Grant implements Statement {
         this.users = users;
     }
 
-    @Override
-    public String toString() {
-        StringBuilder buffer = new StringBuilder();
-
-        buffer.append("GRANT ");
-        if (role != null) {
-            buffer.append(role);
-        } else {
-            for (int i = 0; i < getPrivileges().size(); i++) {
-                if (i != 0) {
-                    buffer.append(", ");
-                }
-                buffer.append(privileges.get(i));
-            }
-            buffer.append(" ON ");
-            buffer.append(getObjectName());
-        }
-        buffer.append(" TO ");
-        for (int i = 0; i < getUsers().size(); i++) {
-            if (i != 0) {
-                buffer.append(", ");
-            }
-            buffer.append(users.get(i));
-        }
-        return buffer.toString();
-    }
-
     public Grant withRole(String role) {
         this.setRole(role);
         return this;
@@ -148,5 +123,30 @@ public class Grant implements Statement {
         List<String> collection = Optional.ofNullable(getUsers()).orElseGet(ArrayList::new);
         collection.addAll(users);
         return this.withUsers(collection);
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("GRANT ");
+        if (role != null) {
+            builder.append(role);
+        } else {
+            for (int i = 0; i < getPrivileges().size(); i++) {
+                if (i != 0) {
+                    builder.append(", ");
+                }
+                builder.append(privileges.get(i));
+            }
+            builder.append(" ON ");
+            builder.append(getObjectName());
+        }
+        builder.append(" TO ");
+        for (int i = 0; i < getUsers().size(); i++) {
+            if (i != 0) {
+                builder.append(", ");
+            }
+            builder.append(users.get(i));
+        }
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
@@ -21,7 +21,6 @@ import net.sf.jsqlparser.expression.operators.relational.ItemsList;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.DMLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;

--- a/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
@@ -20,6 +20,7 @@ import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.expression.operators.relational.ItemsList;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.DMLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
@@ -28,7 +29,7 @@ import net.sf.jsqlparser.statement.select.SelectExpressionItem;
 import net.sf.jsqlparser.statement.select.WithItem;
 
 @SuppressWarnings({"PMD.CyclomaticComplexity"})
-public class Insert implements Statement {
+public class Insert extends DMLStatement {
 
     private Table table;
     private OracleHint oracleHint = null;
@@ -208,82 +209,80 @@ public class Insert implements Statement {
 
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
-    public String toString() {
-        StringBuilder sql = new StringBuilder();
+    public StringBuilder appendTo(StringBuilder builder) {
         if (withItemsList != null && !withItemsList.isEmpty()) {
-            sql.append("WITH ");
+            builder.append("WITH ");
             for (Iterator<WithItem> iter = withItemsList.iterator(); iter.hasNext();) {
                 WithItem withItem = iter.next();
-                sql.append(withItem);
+                builder.append(withItem);
                 if (iter.hasNext()) {
-                    sql.append(",");
+                    builder.append(",");
                 }
-                sql.append(" ");
+                builder.append(" ");
             }
         }
-        sql.append("INSERT ");
+        builder.append("INSERT ");
         if (modifierPriority != null) {
-            sql.append(modifierPriority.name()).append(" ");
+            builder.append(modifierPriority.name()).append(" ");
         }
         if (modifierIgnore) {
-            sql.append("IGNORE ");
+            builder.append("IGNORE ");
         }
-        sql.append("INTO ");
-        sql.append(table).append(" ");
+        builder.append("INTO ");
+        builder.append(table).append(" ");
         if (columns != null) {
-            sql.append(PlainSelect.getStringList(columns, true, true)).append(" ");
+            builder.append(PlainSelect.getStringList(columns, true, true)).append(" ");
         }
 
         if (useValues) {
-            sql.append("VALUES ");
+            builder.append("VALUES ");
         }
 
         if (itemsList != null) {
-            sql.append(itemsList);
+            builder.append(itemsList);
         } else {
             if (useSelectBrackets) {
-                sql.append("(");
+                builder.append("(");
             }
             if (select != null) {
-                sql.append(select);
+                builder.append(select);
             }
             if (useSelectBrackets) {
-                sql.append(")");
+                builder.append(")");
             }
         }
-        
+
         if (useSet) {
-            sql.append("SET ");
+            builder.append("SET ");
             for (int i = 0; i < getSetColumns().size(); i++) {
                 if (i != 0) {
-                    sql.append(", ");
+                    builder.append(", ");
                 }
-                sql.append(setColumns.get(i)).append(" = ");
-                sql.append(setExpressionList.get(i));
+                builder.append(setColumns.get(i)).append(" = ");
+                builder.append(setExpressionList.get(i));
             }
         }
 
         if (useDuplicate) {
-            sql.append(" ON DUPLICATE KEY UPDATE ");
+            builder.append(" ON DUPLICATE KEY UPDATE ");
             for (int i = 0; i < getDuplicateUpdateColumns().size(); i++) {
                 if (i != 0) {
-                    sql.append(", ");
+                    builder.append(", ");
                 }
-                sql.append(duplicateUpdateColumns.get(i)).append(" = ");
-                sql.append(duplicateUpdateExpressionList.get(i));
+                builder.append(duplicateUpdateColumns.get(i)).append(" = ");
+                builder.append(duplicateUpdateExpressionList.get(i));
             }
         }
 
         if (isReturningAllColumns()) {
-            sql.append(" RETURNING *");
+            builder.append(" RETURNING *");
         } else if (getReturningExpressionList() != null) {
-            sql.append(" RETURNING ").append(PlainSelect.
+            builder.append(" RETURNING ").append(PlainSelect.
                     getStringList(getReturningExpressionList(), true, false));
         }
-
-        return sql.toString();
+        return builder;
     }
-    
+
     public Insert withWithItemsList(List<WithItem> withList) {
         this.withItemsList = withList;
         return this;

--- a/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
@@ -19,12 +19,13 @@ import net.sf.jsqlparser.expression.Alias;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.DMLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.SubSelect;
 import net.sf.jsqlparser.statement.select.WithItem;
 
-public class Merge implements Statement {
+public class Merge extends DMLStatement {
 
     private List<WithItem> withItemsList;
     private Table table;
@@ -144,48 +145,46 @@ public class Merge implements Statement {
 
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
-    public String toString() {
-        StringBuilder b = new StringBuilder();
+    public StringBuilder appendTo(StringBuilder builder) {
         if (withItemsList != null && !withItemsList.isEmpty()) {
-            b.append("WITH ");
+            builder.append("WITH ");
             for (Iterator<WithItem> iter = withItemsList.iterator(); iter.hasNext();) {
                 WithItem withItem = iter.next();
-                b.append(withItem);
+                builder.append(withItem);
                 if (iter.hasNext()) {
-                    b.append(",");
+                    builder.append(",");
                 }
-                b.append(" ");
+                builder.append(" ");
             }
         }
-        b.append("MERGE INTO ");
-        b.append(table);
-        b.append(" USING ");
+        builder.append("MERGE INTO ");
+        builder.append(table);
+        builder.append(" USING ");
         if (usingTable != null) {
-            b.append(usingTable.toString());
+            builder.append(usingTable);
         } else if (usingSelect != null) {
-            b.append("(").append(usingSelect.toString()).append(")");
+            builder.append("(").append(usingSelect).append(")");
         }
 
         if (usingAlias != null) {
-            b.append(usingAlias.toString());
+            builder.append(usingAlias);
         }
-        b.append(" ON (");
-        b.append(onCondition);
-        b.append(")");
+        builder.append(" ON (");
+        builder.append(onCondition);
+        builder.append(")");
 
         if (insertFirst && mergeInsert != null) {
-            b.append(mergeInsert.toString());
+            builder.append(mergeInsert);
         }
 
         if (mergeUpdate != null) {
-            b.append(mergeUpdate.toString());
+            builder.append(mergeUpdate);
         }
 
         if (!insertFirst && mergeInsert != null) {
-            b.append(mergeInsert.toString());
+            builder.append(mergeInsert);
         }
-
-        return b.toString();
+        return builder;
     }
 
     public Merge withUsingTable(Table usingTable) {

--- a/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
@@ -20,7 +20,6 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.DMLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.SubSelect;
 import net.sf.jsqlparser.statement.select.WithItem;

--- a/src/main/java/net/sf/jsqlparser/statement/replace/Replace.java
+++ b/src/main/java/net/sf/jsqlparser/statement/replace/Replace.java
@@ -19,7 +19,6 @@ import net.sf.jsqlparser.expression.operators.relational.ItemsList;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 

--- a/src/main/java/net/sf/jsqlparser/statement/replace/Replace.java
+++ b/src/main/java/net/sf/jsqlparser/statement/replace/Replace.java
@@ -18,11 +18,12 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.operators.relational.ItemsList;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 
-public class Replace implements Statement {
+public class Replace extends DDLStatement {
 
     private Table table;
     private List<Column> columns;
@@ -89,44 +90,6 @@ public class Replace implements Statement {
         this.useValues = useValues;
     }
 
-    @Override
-    public String toString() {
-        StringBuilder sql = new StringBuilder();
-        sql.append("REPLACE ");
-        if (isUseIntoTables()) {
-            sql.append("INTO ");
-        }
-        sql.append(table);
-
-        if (expressions != null && columns != null) {
-            // the SET col1=exp1, col2=exp2 case
-            sql.append(" SET ");
-            // each element from expressions match up with a column from columns.
-            for (int i = 0, s = columns.size(); i < s; i++) {
-                sql.append(columns.get(i)).append("=").append(expressions.get(i));
-                sql.append( i < s - 1 
-                                      ? ", " 
-                                      : "" );
-            }
-        } else if (columns != null) {
-            // the REPLACE mytab (col1, col2) [...] case
-            sql.append(" ").append(PlainSelect.getStringList(columns, true, true));
-        }
-
-        if (itemsList != null) {
-            // REPLACE mytab SELECT * FROM mytab2
-            // or VALUES ('as', ?, 565)
-
-            if (useValues) {
-                sql.append(" VALUES");
-            }
-
-            sql.append(" ").append(itemsList);
-        }
-
-        return sql.toString();
-    }
-
     public Replace withUseValues(boolean useValues) {
         this.setUseValues(useValues);
         return this;
@@ -183,5 +146,41 @@ public class Replace implements Statement {
 
     public <E extends ItemsList> E getItemsList(Class<E> type) {
         return type.cast(getItemsList());
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("REPLACE ");
+        if (isUseIntoTables()) {
+            builder.append("INTO ");
+        }
+        builder.append(table);
+
+        if (expressions != null && columns != null) {
+            // the SET col1=exp1, col2=exp2 case
+            builder.append(" SET ");
+            // each element from expressions match up with a column from columns.
+            for (int i = 0, s = columns.size(); i < s; i++) {
+                builder.append(columns.get(i)).append("=").append(expressions.get(i));
+                builder.append( i < s - 1
+                        ? ", "
+                        : "" );
+            }
+        } else if (columns != null) {
+            // the REPLACE mytab (col1, col2) [...] case
+            builder.append(" ").append(PlainSelect.getStringList(columns, true, true));
+        }
+
+        if (itemsList != null) {
+            // REPLACE mytab SELECT * FROM mytab2
+            // or VALUES ('as', ?, 565)
+
+            if (useValues) {
+                builder.append(" VALUES");
+            }
+
+            builder.append(" ").append(itemsList);
+        }
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/select/Select.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Select.java
@@ -15,10 +15,10 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.QueryStatement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
-public class Select implements Statement {
+public class Select extends QueryStatement {
 
     private SelectBody selectBody;
     private List<WithItem> withItemsList;
@@ -42,22 +42,20 @@ public class Select implements Statement {
     }
 
     @Override
-    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
-    public String toString() {
-        StringBuilder retval = new StringBuilder();
+    public StringBuilder appendTo(StringBuilder builder) {
         if (withItemsList != null && !withItemsList.isEmpty()) {
-            retval.append("WITH ");
+            builder.append("WITH ");
             for (Iterator<WithItem> iter = withItemsList.iterator(); iter.hasNext();) {
                 WithItem withItem = iter.next();
-                retval.append(withItem);
+                builder.append(withItem);
                 if (iter.hasNext()) {
-                    retval.append(",");
+                    builder.append(",");
                 }
-                retval.append(" ");
+                builder.append(" ");
             }
         }
-        retval.append(selectBody);
-        return retval.toString();
+        builder.append(selectBody);
+        return builder;
     }
 
     public List<WithItem> getWithItemsList() {

--- a/src/main/java/net/sf/jsqlparser/statement/show/ShowTablesStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/show/ShowTablesStatement.java
@@ -11,7 +11,6 @@ package net.sf.jsqlparser.statement.show;
 
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 import java.util.EnumSet;

--- a/src/main/java/net/sf/jsqlparser/statement/show/ShowTablesStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/show/ShowTablesStatement.java
@@ -10,6 +10,7 @@
 package net.sf.jsqlparser.statement.show;
 
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
@@ -19,7 +20,7 @@ import java.util.EnumSet;
  * A {@code SHOW TABLES} statement
  * @see <a href="https://dev.mysql.com/doc/refman/8.0/en/show-tables.html">MySQL show tables</a>
  */
-public class ShowTablesStatement implements Statement {
+public class ShowTablesStatement extends DDLStatement {
 
     private EnumSet<Modifiers> modifiers;
     private SelectionMode selectionMode;
@@ -68,8 +69,12 @@ public class ShowTablesStatement implements Statement {
     }
 
     @Override
-    public String toString() {
-        StringBuilder builder = new StringBuilder();
+    public void accept(StatementVisitor statementVisitor) {
+        statementVisitor.visit(this);
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
         builder.append("SHOW");
 
         if (modifiers.contains(Modifiers.EXTENDED)) {
@@ -92,13 +97,7 @@ public class ShowTablesStatement implements Statement {
         if (whereCondition != null) {
             builder.append(" ").append("WHERE").append(" ").append(whereCondition);
         }
-
-        return builder.toString();
-    }
-
-    @Override
-    public void accept(StatementVisitor statementVisitor) {
-        statementVisitor.visit(this);
+        return builder;
     }
 
     public enum SelectionMode {

--- a/src/main/java/net/sf/jsqlparser/statement/truncate/Truncate.java
+++ b/src/main/java/net/sf/jsqlparser/statement/truncate/Truncate.java
@@ -10,10 +10,11 @@
 package net.sf.jsqlparser.statement.truncate;
 
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.DDLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
-public class Truncate implements Statement {
+public class Truncate extends DDLStatement {
 
     private Table table;
     boolean cascade;  // to support TRUNCATE TABLE ... CASCADE
@@ -39,14 +40,6 @@ public class Truncate implements Statement {
         cascade = c;
     }
 
-    @Override
-    public String toString() {
-        if (cascade) {
-            return "TRUNCATE TABLE " + table + " CASCADE";
-        }
-        return "TRUNCATE TABLE " + table;
-    }
-
     public Truncate withTable(Table table) {
         this.setTable(table);
         return this;
@@ -55,5 +48,14 @@ public class Truncate implements Statement {
     public Truncate withCascade(boolean cascade) {
         this.setCascade(cascade);
         return this;
+    }
+
+    @Override
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("TRUNCATE TABLE ").append(table);
+        if (cascade) {
+            builder.append(" CASCADE");
+        }
+        return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/truncate/Truncate.java
+++ b/src/main/java/net/sf/jsqlparser/statement/truncate/Truncate.java
@@ -11,7 +11,6 @@ package net.sf.jsqlparser.statement.truncate;
 
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.DDLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 public class Truncate extends DDLStatement {

--- a/src/main/java/net/sf/jsqlparser/statement/update/Update.java
+++ b/src/main/java/net/sf/jsqlparser/statement/update/Update.java
@@ -20,7 +20,6 @@ import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.DMLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.FromItem;
 import net.sf.jsqlparser.statement.select.Join;

--- a/src/main/java/net/sf/jsqlparser/statement/update/Update.java
+++ b/src/main/java/net/sf/jsqlparser/statement/update/Update.java
@@ -19,6 +19,7 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.DMLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.FromItem;
@@ -31,7 +32,7 @@ import net.sf.jsqlparser.statement.select.SelectExpressionItem;
 import net.sf.jsqlparser.statement.select.WithItem;
 
 @SuppressWarnings({"PMD.CyclomaticComplexity"})
-public class Update implements Statement {
+public class Update extends DMLStatement {
 
     private List<WithItem> withItemsList;
     private Table table;
@@ -202,90 +203,88 @@ public class Update implements Statement {
 
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
-    public String toString() {
-        StringBuilder b = new StringBuilder();
-
+    public StringBuilder appendTo(StringBuilder builder) {
         if (withItemsList != null && !withItemsList.isEmpty()) {
-            b.append("WITH ");
+            builder.append("WITH ");
             for (Iterator<WithItem> iter = withItemsList.iterator(); iter.hasNext();) {
                 WithItem withItem = iter.next();
-                b.append(withItem);
+                builder.append(withItem);
                 if (iter.hasNext()) {
-                    b.append(",");
+                    builder.append(",");
                 }
-                b.append(" ");
+                builder.append(" ");
             }
         }
-        b.append("UPDATE ");
-        b.append(table);
+        builder.append("UPDATE ");
+        builder.append(table);
         if (startJoins != null) {
             for (Join join : startJoins) {
                 if (join.isSimple()) {
-                    b.append(", ").append(join);
+                    builder.append(", ").append(join);
                 } else {
-                    b.append(" ").append(join);
+                    builder.append(" ").append(join);
                 }
             }
         }
-        b.append(" SET ");
+        builder.append(" SET ");
 
         if (!useSelect) {
             for (int i = 0; i < getColumns().size(); i++) {
                 if (i != 0) {
-                    b.append(", ");
+                    builder.append(", ");
                 }
-                b.append(columns.get(i)).append(" = ");
-                b.append(expressions.get(i));
+                builder.append(columns.get(i)).append(" = ");
+                builder.append(expressions.get(i));
             }
         } else {
             if (useColumnsBrackets) {
-                b.append("(");
+                builder.append("(");
             }
             for (int i = 0; i < getColumns().size(); i++) {
                 if (i != 0) {
-                    b.append(", ");
+                    builder.append(", ");
                 }
-                b.append(columns.get(i));
+                builder.append(columns.get(i));
             }
             if (useColumnsBrackets) {
-                b.append(")");
+                builder.append(")");
             }
-            b.append(" = ");
-            b.append("(").append(select).append(")");
+            builder.append(" = ");
+            builder.append("(").append(select).append(")");
         }
 
         if (fromItem != null) {
-            b.append(" FROM ").append(fromItem);
+            builder.append(" FROM ").append(fromItem);
             if (joins != null) {
                 for (Join join : joins) {
                     if (join.isSimple()) {
-                        b.append(", ").append(join);
+                        builder.append(", ").append(join);
                     } else {
-                        b.append(" ").append(join);
+                        builder.append(" ").append(join);
                     }
                 }
             }
         }
 
         if (where != null) {
-            b.append(" WHERE ");
-            b.append(where);
+            builder.append(" WHERE ");
+            builder.append(where);
         }
         if (orderByElements != null) {
-            b.append(PlainSelect.orderByToString(orderByElements));
+            builder.append(PlainSelect.orderByToString(orderByElements));
         }
         if (limit != null) {
-            b.append(limit);
+            builder.append(limit);
         }
 
         if (isReturningAllColumns()) {
-            b.append(" RETURNING *");
+            builder.append(" RETURNING *");
         } else if (getReturningExpressionList() != null) {
-            b.append(" RETURNING ").append(PlainSelect.
+            builder.append(" RETURNING ").append(PlainSelect.
                     getStringList(getReturningExpressionList(), true, false));
         }
 
-        return b.toString();
+        return builder;
     }
 
     public Update withTable(Table table) {

--- a/src/main/java/net/sf/jsqlparser/statement/upsert/Upsert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/upsert/Upsert.java
@@ -19,7 +19,6 @@ import net.sf.jsqlparser.expression.operators.relational.ItemsList;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.DMLStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;

--- a/src/main/java/net/sf/jsqlparser/statement/upsert/Upsert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/upsert/Upsert.java
@@ -18,12 +18,13 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.operators.relational.ItemsList;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.DMLStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 
-public class Upsert implements Statement {
+public class Upsert extends DMLStatement {
 
     private Table table;
     private List<Column> columns;
@@ -111,47 +112,45 @@ public class Upsert implements Statement {
     public List<Expression> getDuplicateUpdateExpressionList() {
         return duplicateUpdateExpressionList;
     }
-    
+
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity"})
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        
-        sb.append("UPSERT INTO ");
-        sb.append(table).append(" ");
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("UPSERT INTO ");
+        builder.append(table).append(" ");
         if (columns != null) {
-            sb.append(PlainSelect.getStringList(columns, true, true)).append(" ");
+            builder.append(PlainSelect.getStringList(columns, true, true)).append(" ");
         }
         if (useValues) {
-            sb.append("VALUES ");
+            builder.append("VALUES ");
         }
-        
+
         if (itemsList != null) {
-            sb.append(itemsList);
+            builder.append(itemsList);
         } else {
             if (useSelectBrackets) {
-                sb.append("(");
+                builder.append("(");
             }
             if (select != null) {
-                sb.append(select);
+                builder.append(select);
             }
             if (useSelectBrackets) {
-                sb.append(")");
+                builder.append(")");
             }
         }
 
         if (useDuplicate) {
-            sb.append(" ON DUPLICATE KEY UPDATE ");
+            builder.append(" ON DUPLICATE KEY UPDATE ");
             for (int i = 0; i < getDuplicateUpdateColumns().size(); i++) {
                 if (i != 0) {
-                    sb.append(", ");
+                    builder.append(", ");
                 }
-                sb.append(duplicateUpdateColumns.get(i)).append(" = ");
-                sb.append(duplicateUpdateExpressionList.get(i));
+                builder.append(duplicateUpdateColumns.get(i)).append(" = ");
+                builder.append(duplicateUpdateExpressionList.get(i));
             }
         }
-        
-        return sb.toString();
+
+        return builder;
     }
 
     public Upsert withUseValues(boolean useValues) {

--- a/src/main/java/net/sf/jsqlparser/statement/values/ValuesStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/values/ValuesStatement.java
@@ -14,12 +14,13 @@ import java.util.Collection;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
 import net.sf.jsqlparser.expression.operators.relational.ItemsList;
+import net.sf.jsqlparser.statement.QueryStatement;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.SelectBody;
 import net.sf.jsqlparser.statement.select.SelectVisitor;
 
-public class ValuesStatement implements Statement, SelectBody {
+public class ValuesStatement extends QueryStatement implements SelectBody {
 
     private ItemsList expressions;
 
@@ -45,11 +46,10 @@ public class ValuesStatement implements Statement, SelectBody {
     }
 
     @Override
-    public String toString() {
-        StringBuilder sql = new StringBuilder();
-        sql.append("VALUES ");
-        sql.append(expressions.toString());
-        return sql.toString();
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("VALUES ");
+        builder.append(expressions.toString());
+        return builder;
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/statement/values/ValuesStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/values/ValuesStatement.java
@@ -15,7 +15,6 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
 import net.sf.jsqlparser.expression.operators.relational.ItemsList;
 import net.sf.jsqlparser.statement.QueryStatement;
-import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.SelectBody;
 import net.sf.jsqlparser.statement.select.SelectVisitor;

--- a/src/test/java/net/sf/jsqlparser/statement/ExplainTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/ExplainTest.java
@@ -65,5 +65,8 @@ public class ExplainTest {
 
         ExplainStatement.Option buffers = explain.getOption(ExplainStatement.OptionType.BUFFERS);
         assertThat(buffers).isNotNull().extracting(ExplainStatement.Option::getValue).isEqualTo("FALSE");
+
+        explain = (ExplainStatement) CCJSqlParserUtil.parse("EXPLAIN SELECT * FROM mytable");
+        assertThat(explain.getOption(ExplainStatement.OptionType.ANALYZE)).isNull();
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/IfElseStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/IfElseStatementTest.java
@@ -50,6 +50,11 @@ public class IfElseStatementTest {
 
     Statements result = CCJSqlParserUtil.parseStatements(sqlStr);
     Assert.assertEquals(sqlStr, result.toString());
+
+    for (Statement statement: result.getStatements()) {
+      Assert.assertTrue(statement.isBlock());
+      Assert.assertEquals(Statement.StatementType.BLOCK, statement.getStatementType());
+    }
   }
 
   @Test
@@ -82,7 +87,7 @@ public class IfElseStatementTest {
   }
 
   @Test
-  public void testValidation() throws JSQLParserException {
+  public void testValidation() {
     String sqlStr = "IF OBJECT_ID('tOrigin', 'U') IS NOT NULL DROP TABLE tOrigin1;";
     List<ValidationError> errors =
         Validation.validate(Arrays.asList(DatabaseType.SQLSERVER, FeaturesAllowed.DROP), sqlStr);

--- a/src/test/java/net/sf/jsqlparser/statement/ResetStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/ResetStatementTest.java
@@ -10,6 +10,7 @@
 package net.sf.jsqlparser.statement;
 
 import net.sf.jsqlparser.JSQLParserException;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
@@ -23,6 +24,16 @@ public class ResetStatementTest {
     @Test
     public void tesResetAll() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("RESET ALL");
+    }
+
+    @Test
+    public void testObject() {
+        ResetStatement resetStatement=new ResetStatement();
+        Assert.assertNotNull(resetStatement.getName());
+
+        resetStatement.add("something");
+        resetStatement.setName("somethingElse");
+        Assert.assertEquals("somethingElse", resetStatement.getName());
     }
 
 }

--- a/src/test/java/net/sf/jsqlparser/statement/RollbackStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/RollbackStatementTest.java
@@ -12,8 +12,6 @@ package net.sf.jsqlparser.statement;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
 public class RollbackStatementTest {
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/statement/RollbackStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/RollbackStatementTest.java
@@ -1,3 +1,12 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2021 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
 package net.sf.jsqlparser.statement;
 
 import org.junit.Assert;

--- a/src/test/java/net/sf/jsqlparser/statement/RollbackStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/RollbackStatementTest.java
@@ -1,0 +1,23 @@
+package net.sf.jsqlparser.statement;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class RollbackStatementTest {
+
+    @Test
+    public void testObject() {
+        RollbackStatement rollbackStatement = new RollbackStatement()
+                .withUsingWorkKeyword(true)
+                .withUsingSavepointKeyword(true)
+                .withSavepointName("mySavePoint")
+                .withForceDistributedTransactionIdentifier("$ForceDistributedTransactionIdentifier");
+
+        Assert.assertTrue(rollbackStatement.isUsingSavepointKeyword());
+        Assert.assertEquals("mySavePoint", rollbackStatement.getSavepointName());
+        Assert.assertEquals("$ForceDistributedTransactionIdentifier", rollbackStatement.getForceDistributedTransactionIdentifier());
+    }
+
+}

--- a/src/test/java/net/sf/jsqlparser/statement/SetStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/SetStatementTest.java
@@ -12,13 +12,11 @@ package net.sf.jsqlparser.statement;
 import net.sf.jsqlparser.JSQLParserException;
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
 
-import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.StringValue;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.Set;
 
 /**
  *

--- a/src/test/java/net/sf/jsqlparser/statement/SetStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/SetStatementTest.java
@@ -11,7 +11,14 @@ package net.sf.jsqlparser.statement;
 
 import net.sf.jsqlparser.JSQLParserException;
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.StringValue;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
 
 /**
  *
@@ -56,5 +63,14 @@ public class SetStatementTest {
     @Test
     public void testValueOnIssue927() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SET standard_conforming_strings = on");
+    }
+
+    @Test
+    public void testObject() {
+        SetStatement setStatement = new SetStatement();
+        setStatement.add("standard_conforming_strings", Collections.singletonList(new StringValue("ON")), false);
+        setStatement.withUseEqual(0, true).remove(0);
+
+        Assert.assertEquals(0, setStatement.getCount());
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/StatementImplTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/StatementImplTest.java
@@ -1,3 +1,12 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2021 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
 package net.sf.jsqlparser.statement;
 
 import net.sf.jsqlparser.JSQLParserException;

--- a/src/test/java/net/sf/jsqlparser/statement/StatementImplTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/StatementImplTest.java
@@ -14,8 +14,6 @@ import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-
 public class StatementImplTest {
     @Test
     public void testObject() throws JSQLParserException {

--- a/src/test/java/net/sf/jsqlparser/statement/StatementImplTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/StatementImplTest.java
@@ -1,0 +1,26 @@
+package net.sf.jsqlparser.statement;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class StatementImplTest {
+    @Test
+    public void testObject() throws JSQLParserException {
+        Statement statement = CCJSqlParserUtil.parse("SELECT * FROM DUAL");
+        Assert.assertEquals(Statement.StatementType.QUERY, statement.getStatementType());
+        Assert.assertTrue(statement.isQuery());
+
+        statement = CCJSqlParserUtil.parse("UPDATE foo SET bar=1");
+        Assert.assertEquals(Statement.StatementType.DML, statement.getStatementType());
+        Assert.assertTrue(statement.isDML());
+
+        statement = CCJSqlParserUtil.parse("CREATE TABLE foo ( bar DECIMAL(1))");
+        Assert.assertEquals(Statement.StatementType.DDL, statement.getStatementType());
+        Assert.assertTrue(statement.isDDL());
+    }
+
+}

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterSessionTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterSessionTest.java
@@ -11,7 +11,11 @@ package net.sf.jsqlparser.statement.alter;
 
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.test.TestUtils;
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 public class AlterSessionTest {
     @Test
@@ -64,4 +68,26 @@ public class AlterSessionTest {
         TestUtils.assertSqlCanBeParsedAndDeparsed("ALTER SESSION SET ddl_lock_timeout=7200", true);
         TestUtils.assertSqlCanBeParsedAndDeparsed("ALTER SESSION SET ddl_lock_timeout = 7200", true);
     }
+
+    @Test
+    public void testAlterSessionResumable() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed("ALTER SESSION ENABLE RESUMABLE", true);
+        TestUtils.assertSqlCanBeParsedAndDeparsed("ALTER SESSION DISABLE RESUMABLE", true);
+    }
+
+    @Test
+    public void testObject() {
+        AlterSession alterSession = new AlterSession(AlterSessionOperation.FORCE_PARALLEL_QUERY, Collections.emptyList());
+        Assert.assertEquals(AlterSessionOperation.FORCE_PARALLEL_QUERY, alterSession.getOperation());
+
+        alterSession.setOperation(AlterSessionOperation.DISABLE_PARALLEL_DML);
+        Assert.assertEquals(AlterSessionOperation.DISABLE_PARALLEL_DML, alterSession.getOperation());
+
+        Assert.assertEquals(0, alterSession.getParameters().size());
+
+        alterSession.setParameters(Arrays.asList("PARALLEL", "6"));
+        Assert.assertEquals(2, alterSession.getParameters().size());
+    }
+
+
 }

--- a/src/test/java/net/sf/jsqlparser/statement/create/synonym/CreateSynonymTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/synonym/CreateSynonymTest.java
@@ -11,7 +11,9 @@ package net.sf.jsqlparser.statement.create.synonym;
 
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Synonym;
 import org.assertj.core.api.Assertions;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
@@ -51,5 +53,9 @@ public class CreateSynonymTest {
         Assertions.assertThat(createSynonym.isPublicSynonym()).isTrue();
         Assertions.assertThat(createSynonym.getSynonym().getFullyQualifiedName()).isEqualTo("TBL_TABLE_NAME");
         Assertions.assertThat(createSynonym.getFor()).isEqualTo("SCHEMA.T_TBL_NAME");
+
+        Assert.assertEquals(2, createSynonym.getForList().size());
+        Assert.assertEquals("NEW_TBL_TABLE_NAME", createSynonym.withSynonym(new Synonym().withName("NEW_TBL_TABLE_NAME")).getSynonym().getName());
+
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SpecialOracleTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SpecialOracleTest.java
@@ -14,6 +14,7 @@ import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.util.Arrays;
 import java.util.Date;
@@ -115,10 +116,12 @@ public class SpecialOracleTest {
             "condition14.sql",
             "condition19.sql",
             "condition20.sql",
+            "connect_by01.sql",
             "connect_by02.sql",
             "connect_by03.sql",
             "connect_by04.sql",
             "connect_by05.sql",
+            "connect_by06.sql",
             "connect_by07.sql",
             "datetime01.sql",
             "datetime02.sql",
@@ -250,10 +253,12 @@ public class SpecialOracleTest {
         
         boolean foundUnexpectedFailures = false;
 
+        assert sqlTestFiles != null;
+
         for (File file : sqlTestFiles) {
             if (file.isFile()) {
                 count++;
-                String sql = FileUtils.readFileToString(file, Charset.forName("UTF-8"));
+                String sql = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
                 try {
                     assertSqlCanBeParsedAndDeparsed(sql, true);
                     success++;
@@ -278,7 +283,7 @@ public class SpecialOracleTest {
                     foundUnexpectedFailures = true;
                 } catch (ComparisonFailure ex) {
                     if (sql.contains("@SUCCESSFULLY_PARSED_AND_DEPARSED") || EXPECTED_SUCCESSES.contains(file.getName())) {
-                        LOG.log(Level.SEVERE, "UNEXPECTED DE-PARSING FAILURE: {0}\n" + ex.toString(), file.getName());
+                        LOG.log(Level.SEVERE, "UNEXPECTED DE-PARSING FAILURE: {0}\n" + ex, file.getName());
                         foundUnexpectedFailures = true;
                     } else {
                         LOG.log(Level.FINE, "EXPECTED DE-PARSING FAILURE: {0}", file.getName());
@@ -304,9 +309,11 @@ public class SpecialOracleTest {
             }
         });
 
+        assert sqlTestFiles != null;
+
         for (File file : sqlTestFiles) {
             if (file.isFile()) {
-                String sql = FileUtils.readFileToString(file, Charset.forName("UTF-8"));
+                String sql = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
                 assertSqlCanBeParsedAndDeparsed(sql, true);
             }
         }
@@ -314,7 +321,7 @@ public class SpecialOracleTest {
 
     public void recordSuccessOnSourceFile(File file) throws IOException {
         File sourceFile = new File(SQL_SOURCE_DIR, file.getName());
-        String sourceSql = FileUtils.readFileToString(sourceFile, Charset.forName("UTF-8"));
+        String sourceSql = FileUtils.readFileToString(sourceFile, StandardCharsets.UTF_8);
         if (!sourceSql.contains("@SUCCESSFULLY_PARSED_AND_DEPARSED")) {
             LOG.log(Level.INFO, "NEW SUCCESS: {0}", file.getName());
             if (sourceFile.exists() && sourceFile.canWrite()) {
@@ -334,11 +341,11 @@ public class SpecialOracleTest {
     
     public void recordFailureOnSourceFile(File file, String message) throws IOException {
         File sourceFile = new File(SQL_SOURCE_DIR, file.getName());
-        String sourceSql = FileUtils.readFileToString(sourceFile, Charset.forName("UTF-8"));
+        String sourceSql = FileUtils.readFileToString(sourceFile, StandardCharsets.UTF_8);
         if (!sourceSql.contains("@FAILURE: " + message)
              && sourceFile.canWrite() ) {
             try (FileWriter writer = new FileWriter(sourceFile, true)) {
-                writer.append("\n--@FAILURE: " + message + " recorded first on ")
+                writer.append("\n--@FAILURE: ").append(message).append(" recorded first on ")
                   .append(DateFormat.getDateTimeInstance().format(new Date()));
             }
         } 
@@ -349,8 +356,9 @@ public class SpecialOracleTest {
         File[] sqlTestFiles = new File(SQLS_DIR, "only-parse-test").listFiles();
 
         List<String> regressionFiles = new LinkedList<>();
+        assert sqlTestFiles != null;
         for (File file : sqlTestFiles) {
-            String sql = FileUtils.readFileToString(file, Charset.forName("UTF-8"));
+            String sql = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
             try {
                 CCJSqlParserUtil.parse(sql);
                 LOG.log(Level.FINE, "EXPECTED SUCCESS: {0}", file.getName());

--- a/src/test/java/net/sf/jsqlparser/statement/select/SpecialOracleTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SpecialOracleTest.java
@@ -13,7 +13,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.util.Arrays;

--- a/src/test/java/net/sf/jsqlparser/statement/show/ShowTablesStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/show/ShowTablesStatementTest.java
@@ -9,8 +9,12 @@
  */
 package net.sf.jsqlparser.statement.show;
 
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import org.junit.Assert;
 import org.junit.Test;
 
+import static net.sf.jsqlparser.test.TestUtils.assertExpressionCanBeDeparsedAs;
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
 
 public class ShowTablesStatementTest {
@@ -43,5 +47,19 @@ public class ShowTablesStatementTest {
     @Test
     public void showTablesWhereExpression() throws Exception {
         assertSqlCanBeParsedAndDeparsed("SHOW TABLES WHERE table_name = 'FOO'");
+    }
+
+    @Test
+    public void testObject() throws JSQLParserException {
+        ShowTablesStatement showTablesStatement = (ShowTablesStatement) CCJSqlParserUtil.parse("SHOW TABLES WHERE table_name = 'FOO'");
+        Assert.assertEquals(0, showTablesStatement.getModifiers().size());
+        assertExpressionCanBeDeparsedAs(showTablesStatement.getWhereCondition(), "table_name = 'FOO'");
+
+        showTablesStatement = (ShowTablesStatement) CCJSqlParserUtil.parse("SHOW FULL TABLES IN db_name");
+        Assert.assertEquals(1, showTablesStatement.getModifiers().size());
+        Assert.assertEquals(ShowTablesStatement.SelectionMode.IN, showTablesStatement.getSelectionMode());
+
+        showTablesStatement = (ShowTablesStatement) CCJSqlParserUtil.parse("SHOW TABLES LIKE '%FOO%'");
+        assertExpressionCanBeDeparsedAs(showTablesStatement.getLikeExpression(), "'%FOO%'");
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/values/ValuesTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/values/ValuesTest.java
@@ -21,7 +21,6 @@ import net.sf.jsqlparser.statement.select.SetOperationList;
 
 import static net.sf.jsqlparser.test.TestUtils.*;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/src/test/java/net/sf/jsqlparser/statement/values/ValuesTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/values/ValuesTest.java
@@ -15,12 +15,16 @@ import net.sf.jsqlparser.expression.RowConstructor;
 import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
 import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.StatementVisitorAdapter;
 import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.select.SetOperationList;
 
 import static net.sf.jsqlparser.test.TestUtils.*;
 
+import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Arrays;
 
 public class ValuesTest {
 
@@ -47,5 +51,13 @@ public class ValuesTest {
     @Test
     public void testComplexWithQueryIssue561() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("WITH split (word, str, hascomma) AS (VALUES ('', 'Auto,A,1234444', 1) UNION ALL SELECT substr(str, 0, CASE WHEN instr(str, ',') THEN instr(str, ',') ELSE length(str) + 1 END), ltrim(substr(str, instr(str, ',')), ','), instr(str, ',') FROM split WHERE hascomma) SELECT trim(word) FROM split WHERE word != ''");
+    }
+
+    @Test
+    public void testObject() {
+        ValuesStatement valuesStatement=new ValuesStatement().addExpressions(new StringValue("1"), new StringValue("2"));
+        valuesStatement.addExpressions(Arrays.asList(new StringValue("3"), new StringValue("4")));
+
+        valuesStatement.accept(new StatementVisitorAdapter());
     }
 }

--- a/src/test/java/net/sf/jsqlparser/util/deparser/StatementDeParserTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/deparser/StatementDeParserTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.spy;
 import java.util.ArrayList;
 import java.util.List;
 
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,7 +31,6 @@ import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.IfElseStatement;
 import net.sf.jsqlparser.statement.SetStatement;
 import net.sf.jsqlparser.statement.delete.Delete;
-import net.sf.jsqlparser.statement.drop.Drop;
 import net.sf.jsqlparser.statement.execute.Execute;
 import net.sf.jsqlparser.statement.insert.Insert;
 import net.sf.jsqlparser.statement.replace.Replace;
@@ -367,12 +367,9 @@ public class StatementDeParserTest {
     
     @Test
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-    public void shouldUseProvidedDeparsersWhenDeParsingIfThenStatement() {
-        Expression condition = mock(Expression.class);
-        Drop ifStatement = mock(Drop.class);
-        
-        IfElseStatement ifElseStatement = new IfElseStatement(condition, ifStatement);
-
+    public void shouldUseProvidedDeparsersWhenDeParsingIfThenStatement() throws JSQLParserException {
+        String sqlStr = "IF OBJECT_ID('tOrigin', 'U') IS NOT NULL DROP TABLE tOrigin1";
+        IfElseStatement ifElseStatement  = (IfElseStatement) CCJSqlParserUtil.parse(sqlStr);
         statementDeParser.deParse(ifElseStatement);
       }
     

--- a/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/connect_by01.sql
+++ b/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/connect_by01.sql
@@ -29,3 +29,4 @@ start with obj='a'
 
 
 --@FAILURE: Encountered unexpected token: "root" <S_IDENTIFIER> recorded first on Aug 3, 2021, 7:20:08 AM
+--@SUCCESSFULLY_PARSED_AND_DEPARSED first on Aug 10, 2021, 6:39:53 AM

--- a/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/connect_by06.sql
+++ b/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/connect_by06.sql
@@ -16,3 +16,4 @@ select last_name "Employee", connect_by_root last_name "Manager",
    
 
 --@FAILURE: Encountered unexpected token: "\"Manager\"" <S_QUOTED_IDENTIFIER> recorded first on Aug 3, 2021, 7:20:08 AM
+--@SUCCESSFULLY_PARSED_AND_DEPARSED first on Aug 10, 2021, 6:39:53 AM


### PR DESCRIPTION
Introduce a Statement Classification in order to distinguish QUERY, DML, DDL, BLOCK, UNPARSED
--> Each statement now **extends** either `QueryStatement` or `DMLStatement` or `DDLStatement` or `BlockStatement` and will return a `StatementType` accordingly

Introduce streamlined appendTo() method in order to avoid the creation of multiple StringBuilders
--> Each statement implements the method `StringBuilder appendTo(StringBilder builder)` and so does not need to implement `toString()` any longer (because that is done in `StatementImpl` only)

Improve Test Coverage for all Statements

Very sorry for touching many files, but this is an 'all or nothing' thing.