### PR TITLE
CREATE TABLE AS (...) UNION (...) fails

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4947,10 +4947,7 @@ CreateTable CreateTable():
     // see https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_7002.htm#i2126725
     // table properties , all these are optional
     [ rowMovement = RowMovement() { createTable.setRowMovement(rowMovement); }]
-    [
-    <K_AS> ( LOOKAHEAD("(" SelectWithWithItems( ) ")") "(" select = SelectWithWithItems( ) { createTable.setSelect(select, true); } ")"
-             | select = SelectWithWithItems( ) { createTable.setSelect(select, false); } )
-    ]
+    [<K_AS> select = SelectWithWithItems( ) { createTable.setSelect(select, false); }]
     [
     <K_LIKE> ( LOOKAHEAD("(" Table() ")") "(" likeTable=Table() { createTable.setLikeTable(likeTable, true); } ")"
                  | likeTable=Table() { createTable.setLikeTable(likeTable, false); } )

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
@@ -435,6 +435,12 @@ public class CreateTableTest {
   }
 
   @Test
+  public void testCreateUnionIssue() throws JSQLParserException {
+    assertSqlCanBeParsedAndDeparsed(
+        "CREATE TABLE temp.abc AS (SELECT c FROM t1) UNION (SELECT c FROM t2)");
+  }
+
+  @Test
   public void testTimestampWithTimezone() throws JSQLParserException {
     assertSqlCanBeParsedAndDeparsed(
         "CREATE TABLE country_region ("


### PR DESCRIPTION
This test query is failing so far:
CREATE TABLE temp.abc AS (SELECT c FROM t1) UNION (SELECT c FROM t2)