### PR TITLE
Fixes #1325

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2084,29 +2084,25 @@ MySQLIndexHint MySQLIndexHint():
 	List<String> indexNameList = new ArrayList<String>();
 }
 {
-	(actionToken = <K_USE>
+	(
+	actionToken = <K_USE>
 	| actionToken = <K_SHOW>
 	| actionToken = <K_IGNORE>
-	| actionToken = <K_FORCE> )
-	(indexToken = <K_INDEX>
-	| indexToken = <K_KEY>)
+	| actionToken = <K_FORCE>
+	)
+
+	(
+	indexToken = <K_INDEX>
+	| indexToken = <K_KEY>
+	)
+
 	"("
-	indexName = Identifier() { indexNameList.add(indexName); }
-	("," indexName= Identifier() { indexNameList.add(indexName); })*
+	indexName = RelObjectNameWithoutValue() { indexNameList.add(indexName); }
+	("," indexName= RelObjectNameWithoutValue() { indexNameList.add(indexName); })*
 	")"
 	{
 		return new MySQLIndexHint(actionToken.image, indexToken.image, indexNameList);
 	}
-}
-
-String Identifier():
-{
-	Token tk = null;
-}
-{
-	(tk=<S_IDENTIFIER>
-    | tk=<S_QUOTED_IDENTIFIER>)
-    { return tk.image; }
 }
 
  FunctionItem FunctionItem():

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -4776,4 +4776,11 @@ public class SelectTest {
                         "from dual \n" +
                         "group by (case when 1=1 then 'X' else 'Y' end), column1", true);
     }
+
+    @Test
+    public void testReservedKeywordsMSSQLUseIndexIssue1325() throws JSQLParserException {
+        // without extra brackets
+        assertSqlCanBeParsedAndDeparsed(
+                "SELECT col FROM table USE INDEX(primary)", true);
+    }
 }


### PR DESCRIPTION
Removes redundant production Identifier() and uses RelObjectnameWithoutValue() instead for MS SQL Server Hints

Fixes #1325