### PR TITLE
Function to use AllColumns or AllTableColumns Expression

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -113,5 +113,5 @@ under the License.
 	<rule ref="category/java/performance.xml/BooleanInstantiation" />
     
     <!-- for Codazy -->
-	<rule ref="category/java/documentation.xml/UncommentedEmptyMethodBody" />
+	<!-- <rule ref="category/java/documentation.xml/UncommentedEmptyMethodBody" /> -->
 </ruleset>

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -15,6 +15,8 @@ import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
 import net.sf.jsqlparser.expression.operators.conditional.XorExpression;
 import net.sf.jsqlparser.expression.operators.relational.*;
 import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.select.AllColumns;
+import net.sf.jsqlparser.statement.select.AllTableColumns;
 import net.sf.jsqlparser.statement.select.SubSelect;
 
 public interface ExpressionVisitor {
@@ -174,5 +176,10 @@ public interface ExpressionVisitor {
     void visit(JsonFunction aThis);
 
     void visit(ConnectByRootOperator aThis);
+
     void visit(OracleNamedFunctionParameter aThis);
+
+    void visit(AllColumns allColumns);
+
+    void visit(AllTableColumns allTableColumns);
 }

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -489,12 +489,12 @@ public class ExpressionVisitorAdapter implements ExpressionVisitor, ItemsListVis
 
     @Override
     public void visit(AllColumns allColumns) {
-
+        allColumns.accept((ExpressionVisitor) this);
     }
 
     @Override
     public void visit(AllTableColumns allTableColumns) {
-
+        allTableColumns.accept((ExpressionVisitor) this);
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/expression/Function.java
+++ b/src/main/java/net/sf/jsqlparser/expression/Function.java
@@ -207,8 +207,6 @@ public class Function extends ASTNodeAccessImpl implements Expression {
             } else {
                 params = namedParameters.toString();
             }
-        } else if (isAllColumns()) {
-            params = "(*)";
         } else {
             params = "()";
         }

--- a/src/main/java/net/sf/jsqlparser/statement/select/AllColumns.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/AllColumns.java
@@ -9,9 +9,11 @@
  */
 package net.sf.jsqlparser.statement.select;
 
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
-public class AllColumns extends ASTNodeAccessImpl implements SelectItem {
+public class AllColumns extends ASTNodeAccessImpl implements SelectItem, Expression {
 
     @Override
     public void accept(SelectItemVisitor selectItemVisitor) {
@@ -23,4 +25,8 @@ public class AllColumns extends ASTNodeAccessImpl implements SelectItem {
         return "*";
     }
 
+    @Override
+    public void accept(ExpressionVisitor expressionVisitor) {
+        expressionVisitor.visit(this);
+    }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/select/AllTableColumns.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/AllTableColumns.java
@@ -9,10 +9,12 @@
  */
 package net.sf.jsqlparser.statement.select;
 
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 import net.sf.jsqlparser.schema.*;
 
-public class AllTableColumns extends ASTNodeAccessImpl implements SelectItem {
+public class AllTableColumns extends ASTNodeAccessImpl implements SelectItem, Expression {
 
     private Table table;
 
@@ -44,5 +46,10 @@ public class AllTableColumns extends ASTNodeAccessImpl implements SelectItem {
     public AllTableColumns withTable(Table table) {
         this.setTable(table);
         return this;
+    }
+
+    @Override
+    public void accept(ExpressionVisitor expressionVisitor) {
+        expressionVisitor.visit(this);
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -104,11 +104,7 @@ import net.sf.jsqlparser.expression.operators.relational.SupportsOldOracleJoinSy
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.create.table.ColumnDefinition;
-import net.sf.jsqlparser.statement.select.OrderByElement;
-import net.sf.jsqlparser.statement.select.PlainSelect;
-import net.sf.jsqlparser.statement.select.SelectVisitor;
-import net.sf.jsqlparser.statement.select.SubSelect;
-import net.sf.jsqlparser.statement.select.WithItem;
+import net.sf.jsqlparser.statement.select.*;
 
 @SuppressWarnings({"PMD.CyclomaticComplexity"})
 public class ExpressionDeParser extends AbstractDeParser<Expression>
@@ -486,9 +482,7 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
         }
 
         buffer.append(function.getName());
-        if (function.isAllColumns() && function.getParameters() == null) {
-            buffer.append("(*)");
-        } else if (function.getParameters() == null && function.getNamedParameters() == null) {
+        if (function.getParameters() == null && function.getNamedParameters() == null) {
             buffer.append("()");
         } else {
             buffer.append("(");
@@ -1033,5 +1027,15 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
           .append(" => ");
         
         oracleNamedFunctionParameter.getExpression().accept(this);
+    }
+
+    @Override
+    public void visit(AllColumns allColumns) {
+        buffer.append(allColumns.toString());
+    }
+
+    @Override
+    public void visit(AllTableColumns allTableColumns) {
+        buffer.append(allTableColumns.toString());
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
@@ -98,6 +98,8 @@ import net.sf.jsqlparser.expression.operators.relational.SupportsOldOracleJoinSy
 import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.create.table.ColumnDefinition;
+import net.sf.jsqlparser.statement.select.AllColumns;
+import net.sf.jsqlparser.statement.select.AllTableColumns;
 import net.sf.jsqlparser.statement.select.SubSelect;
 import net.sf.jsqlparser.util.validation.ValidationCapability;
 import net.sf.jsqlparser.util.validation.metadata.NamedObject;
@@ -608,6 +610,14 @@ public class ExpressionValidator extends AbstractValidator<Expression> implement
     @Override
     public void visit(OracleNamedFunctionParameter oracleNamedFunctionParameter) {
         oracleNamedFunctionParameter.getExpression().accept(this);
+    }
+
+    @Override
+    public void visit(AllColumns allColumns) {
+    }
+
+    @Override
+    public void visit(AllTableColumns allTableColumns) {
     }
 
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1642,6 +1642,8 @@ String RelObjectNameWithoutValue() :
       | tk=<K_LOG> | tk=<K_DUMP> | tk=<K_FLUSH> | tk=<K_ACTIVE> | tk=<K_RESUME> | tk=<K_SWITCH> | tk=<K_SUSPEND>
       | tk=<K_ARCHIVE> | tk=<K_QUIESCE> | tk=<K_HISTORY> | tk=<K_SHUTDOWN> | tk=<K_REGISTER> | tk=<K_UNQIESCE>
       | tk=<K_RESTRICTED> | tk=<K_CHECKPOINT> | tk=<K_DISCONNECT>
+
+      | tk=<K_TABLESPACE>
       )
 
     { return tk.image; }
@@ -4522,7 +4524,9 @@ Function InternalFunction(Function retval) :
 
     "(" [ [ LOOKAHEAD(2)(<K_DISTINCT> { retval.setDistinct(true); } | <K_ALL> { retval.setAllColumns(true); } | <K_UNIQUE> { retval.setUnique(true); }) ]
         ( LOOKAHEAD(4)
-            "*" { retval.setAllColumns(true); }
+            "*" { expr1 = new AllColumns(); expressionList = new ExpressionList(expr1).withUsingBrackets(false); }
+            |
+            LOOKAHEAD(AllTableColumns()) expr1=AllTableColumns() { expressionList = new ExpressionList(expr1).withUsingBrackets(false); }
             |
             LOOKAHEAD(3, { getAsBoolean(Feature.allowComplexParsing) }) (expressionList=ComplexExpressionList() {expressionList.setUsingBrackets(false);} [ orderByList = OrderByElements() { retval.setOrderByElements(orderByList); } ])
             |

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4973,7 +4973,7 @@ CreateTable CreateTable():
     // see https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_7002.htm#i2126725
     // table properties , all these are optional
     [ rowMovement = RowMovement() { createTable.setRowMovement(rowMovement); }]
-    [ <K_AS> select = SelectWithWithItems( ) { createTable.setSelect(select, fa
+    [ <K_AS> select = SelectWithWithItems( ) { createTable.setSelect(select, false); }]
     [
     <K_LIKE> ( LOOKAHEAD("(" Table() ")") "(" likeTable=Table() { createTable.setLikeTable(likeTable, true); } ")"
                  | likeTable=Table() { createTable.setLikeTable(likeTable, false); } )


### PR DESCRIPTION
Function uses AllColumns expression for `*` and AllTableColumns for `a.*`
Fixes #1346 