### PR TITLE
Fixes #1381

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2022,8 +2022,8 @@ SelectExpressionItem SelectExpressionItem():
     Alias alias = null;
 }
 {
-      expression=Condition() { selectExpressionItem = new SelectExpressionItem(); selectExpressionItem.setExpression(expression); }
-             [alias=Alias() { selectExpressionItem.setAlias(alias); }] { return selectExpressionItem; }
+      expression=Expression() { selectExpressionItem = new SelectExpressionItem(); selectExpressionItem.setExpression(expression); }
+      [alias=Alias() { selectExpressionItem.setAlias(alias); }] { return selectExpressionItem; }
 }
 
 SelectItem SelectItem() #SelectItem:

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -4866,4 +4866,19 @@ public class SelectTest {
         assertSqlCanBeParsedAndDeparsed(
                 "SELECT count(a.*) from a", true);
     }
+
+    @Test
+    public void testLogicalExpressionSelectItemIssue1381() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "SELECT ( 1 + 1 ) = ( 1 + 2 )", true);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "SELECT ( 1 = 1 ) = ( 1 = 2 )", true);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "SELECT ( ( 1 = 1 ) AND ( 1 = 2 ) )", true);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "SELECT ( 1 = 1 ) AND ( 1 = 2 )", true);
+    }
 }


### PR DESCRIPTION
Allow Complex Expressions as SelectItem
Fixes #1381
```sql
SELECT ( 1 = 1 ) AND ( 1 = 2 )
```

Fixes #602