### PR TITLE
IN() with complex expressions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,12 +71,63 @@ jacocoTestReport {
 jacocoTestCoverageVerification {
     violationRules {
         rule {
+            //element = 'CLASS'
             limit {
-                minimum = JavaVersion.current().isJava8() // for any reason, different results
-                        ? 0.83                            // depending on the Java Version
-                        : 0.842
+                minimum = 0.84
             }
+            excludes = [
+                    'net.sf.jsqlparser.util.validation.*',
+                    'net.sf.jsqlparser.**.*Adapter',
+                    'net.sf.jsqlparser.parser.JJTCCJSqlParserState',
+                    'net.sf.jsqlparser.parser.TokenMgrError',
+                    'net.sf.jsqlparser.parser.StreamProvider',
+                    'net.sf.jsqlparser.parser.CCJSqlParserTokenManager',
+                    'net.sf.jsqlparser.parser.ParseException',
+                    'net.sf.jsqlparser.parser.SimpleNode',
+                    'net.sf.jsqlparser.parser.SimpleCharStream',
+                    'net.sf.jsqlparser.parser.StringProvider',
+            ]
         }
+        rule {
+            //element = 'CLASS'
+            limit {
+                counter = 'LINE'
+                value = 'MISSEDCOUNT'
+                maximum = 5458
+                }
+            excludes = [
+                    'net.sf.jsqlparser.util.validation.*',
+                    'net.sf.jsqlparser.**.*Adapter',
+                    'net.sf.jsqlparser.parser.JJTCCJSqlParserState',
+                    'net.sf.jsqlparser.parser.TokenMgrError',
+                    'net.sf.jsqlparser.parser.StreamProvider',
+                    'net.sf.jsqlparser.parser.CCJSqlParserTokenManager',
+                    'net.sf.jsqlparser.parser.ParseException',
+                    'net.sf.jsqlparser.parser.SimpleNode',
+                    'net.sf.jsqlparser.parser.SimpleCharStream',
+                    'net.sf.jsqlparser.parser.StringProvider',
+            ]
+        }
+//        rule {
+//            element = 'CLASS'
+//            limit {
+//                counter = 'LINE'
+//                value = 'MISSEDRATIO'
+//                maximum = 0.3
+//            }
+//            excludes = [
+//                    'net.sf.jsqlparser.util.validation.*',
+//                    'net.sf.jsqlparser.**.*Adapter',
+//                    'net.sf.jsqlparser.parser.JJTCCJSqlParserState',
+//                    'net.sf.jsqlparser.parser.TokenMgrError',
+//                    'net.sf.jsqlparser.parser.StreamProvider',
+//                    'net.sf.jsqlparser.parser.CCJSqlParserTokenManager',
+//                    'net.sf.jsqlparser.parser.ParseException',
+//                    'net.sf.jsqlparser.parser.SimpleNode',
+//                    'net.sf.jsqlparser.parser.SimpleCharStream',
+//                    'net.sf.jsqlparser.parser.StringProvider',
+//            ]
+//        }
     }
 }
 

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -185,8 +185,6 @@ public class ExpressionVisitorAdapter implements ExpressionVisitor, ItemsListVis
             expr.getRightExpression().accept(this);
         } else if (expr.getRightItemsList() != null) {
             expr.getRightItemsList().accept(this);
-        } else {
-            expr.getMultiExpressionList().accept(this);
         }
     }
 

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/InExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/InExpression.java
@@ -19,8 +19,6 @@ public class InExpression extends ASTNodeAccessImpl implements Expression, Suppo
     private ItemsList rightItemsList;
     private boolean not = false;
     private Expression rightExpression;
-    private MultiExpressionList multiExpressionList;
-
     private int oldOracleJoinSyntax = NO_ORACLE_JOIN;
 
     public InExpression() {
@@ -105,21 +103,12 @@ public class InExpression extends ASTNodeAccessImpl implements Expression, Suppo
         if (not) {
             statementBuilder.append("NOT ");
         }
-
         statementBuilder.append("IN ");
-
-        if (multiExpressionList != null) {
-            statementBuilder.append("(");
-            statementBuilder.append(multiExpressionList);
-            statementBuilder.append(")");
+        if (rightExpression == null) {
+            statementBuilder.append(rightItemsList);
         } else {
-            if (rightExpression == null) {
-                statementBuilder.append(rightItemsList);
-            } else {
-                statementBuilder.append(rightExpression);
-            }
+            statementBuilder.append(rightExpression);
         }
-
         return statementBuilder.toString();
     }
 
@@ -135,21 +124,8 @@ public class InExpression extends ASTNodeAccessImpl implements Expression, Suppo
         }
     }
 
-    public MultiExpressionList getMultiExpressionList() {
-        return multiExpressionList;
-    }
-
-    public void setMultiExpressionList(MultiExpressionList multiExpressionList) {
-        this.multiExpressionList = multiExpressionList;
-    }
-
     public InExpression withRightExpression(Expression rightExpression) {
         this.setRightExpression(rightExpression);
-        return this;
-    }
-
-    public InExpression withMultiExpressionList(MultiExpressionList multiExpressionList) {
-        this.setMultiExpressionList(multiExpressionList);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -289,8 +289,6 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
             inExpression.getRightExpression().accept(this);
         } else if (inExpression.getRightItemsList() != null) {
             inExpression.getRightItemsList().accept(this);
-        } else {
-            inExpression.getMultiExpressionList().accept(this);
         }
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -234,39 +234,11 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
             buffer.append(" NOT");
         }
         buffer.append(" IN ");
-
-        if (inExpression.getMultiExpressionList() != null) {
-            parseMultiExpressionList(inExpression);
+        if (inExpression.getRightExpression() != null) {
+            inExpression.getRightExpression().accept(this);
         } else {
-            if (inExpression.getRightExpression() != null) {
-                inExpression.getRightExpression().accept(this);
-            } else {
-                inExpression.getRightItemsList().accept(this);
-            }
+            inExpression.getRightItemsList().accept(this);
         }
-    }
-
-    /**
-     * Produces a multi-expression in clause: {@code ((a, b), (c, d))}
-     */
-    private void parseMultiExpressionList(InExpression inExpression) {
-        MultiExpressionList multiExprList = inExpression.getMultiExpressionList();
-        buffer.append("(");
-        for (Iterator<ExpressionList> it = multiExprList.getExprList().iterator(); it.hasNext();) {
-            buffer.append("(");
-            for (Iterator<Expression> iter = it.next().getExpressions().iterator(); iter.hasNext();) {
-                Expression expression = iter.next();
-                expression.accept(this);
-                if (iter.hasNext()) {
-                    buffer.append(", ");
-                }
-            }
-            buffer.append(")");
-            if (it.hasNext()) {
-                buffer.append(", ");
-            }
-        }
-        buffer.append(")");
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
@@ -198,8 +198,6 @@ public class ExpressionValidator extends AbstractValidator<Expression> implement
                 validateFeature(c, Feature.oracleOldJoinSyntax);
             }
         }
-
-        validateOptionalMultiExpressionList(inExpression.getMultiExpressionList());
         validateOptionalExpression(inExpression.getRightExpression(), this);
         validateOptionalItemsList(inExpression.getRightItemsList());
     }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2944,7 +2944,7 @@ Expression XorExpression():
 }
 {
     left=OrExpression() { result = left; }
-    (
+    ( LOOKAHEAD(2)
         <K_XOR>
         right=OrExpression()
         {
@@ -2963,7 +2963,7 @@ Expression OrExpression():
 }
 {
     left=AndExpression() { result = left; }
-    (
+    ( LOOKAHEAD(2)
         <K_OR>
         right=AndExpression()
         {
@@ -2993,7 +2993,7 @@ Expression AndExpression() :
     )
     { result = left; }
 
-    (
+    ( LOOKAHEAD(2)
         { boolean useOperator = false; }
          (<K_AND> | <K_AND_OPERATOR> {useOperator=true;} )
         (
@@ -3120,7 +3120,7 @@ Expression InExpression() #InExpression :
 {
     InExpression result = new InExpression();
     ItemsList leftItemsList = null;
-    ItemsList rightItemsList = null;
+    ExpressionList rightItemsList = null;
     Expression leftExpression = null;
     Expression rightExpression = null;
     Token token;
@@ -3133,17 +3133,16 @@ Expression InExpression() #InExpression :
 
     [<K_NOT> { result.setNot(true); } ] <K_IN>
     (
+      LOOKAHEAD(2) token=<S_CHAR_LITERAL> {  result.setRightExpression(new StringValue(token.image)); }
+      | LOOKAHEAD(3) rightExpression = Function() {  result.setRightExpression(rightExpression); }
+      | LOOKAHEAD( "(" ComplexExpressionList() ")" ) "(" rightItemsList=ComplexExpressionList() { result.setRightItemsList(rightItemsList.withBrackets(true) ); } ")"
+      | LOOKAHEAD(3) "(" rightExpression = SubSelect() {  result.setRightExpression( ((SubSelect) rightExpression).withUseBrackets(true) ); } ")"
       // syntactic lookahead for a multi expression list, ie: ((a,b),(c,d))
-      LOOKAHEAD(3) multiExpressionList = MultiInExpressions()
-      | LOOKAHEAD(3) rightExpression = Function()
-      | LOOKAHEAD(2) token=<S_CHAR_LITERAL> { rightExpression = new StringValue(token.image); }
-      | LOOKAHEAD(3) "(" (LOOKAHEAD(3) rightItemsList=SubSelect() | rightItemsList=SimpleExpressionList(true) )")"
-      | rightExpression = SimpleExpression()
+      | LOOKAHEAD(3) multiExpressionList = MultiInExpressions() { result.setMultiExpressionList(multiExpressionList); }
+      | LOOKAHEAD(2) rightExpression = SimpleExpression() {  result.setRightExpression(rightExpression); }
+
     )
     {
-        result.setRightItemsList(rightItemsList);
-        result.setRightExpression(rightExpression);
-        result.setMultiExpressionList(multiExpressionList);
         linkAST(result,jjtThis);
         return result;
     }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3137,10 +3137,7 @@ Expression InExpression() #InExpression :
       | LOOKAHEAD(3) rightExpression = Function() {  result.setRightExpression(rightExpression); }
       | LOOKAHEAD( "(" ComplexExpressionList() ")" ) "(" rightItemsList=ComplexExpressionList() { result.setRightItemsList(rightItemsList.withBrackets(true) ); } ")"
       | LOOKAHEAD(3) "(" rightExpression = SubSelect() {  result.setRightExpression( ((SubSelect) rightExpression).withUseBrackets(true) ); } ")"
-      // syntactic lookahead for a multi expression list, ie: ((a,b),(c,d))
-      | LOOKAHEAD(3) multiExpressionList = MultiInExpressions() { result.setMultiExpressionList(multiExpressionList); }
       | LOOKAHEAD(2) rightExpression = SimpleExpression() {  result.setRightExpression(rightExpression); }
-
     )
     {
         linkAST(result,jjtThis);

--- a/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
@@ -13,6 +13,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.sf.jsqlparser.expression.operators.conditional.XorExpression;
+import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.statement.select.SubSelect;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -72,7 +74,7 @@ public class ExpressionVisitorAdapterTest {
         });
 
         assertTrue(exprList.get(0) instanceof Expression);
-        assertTrue(exprList.get(1) instanceof ItemsList);
+        assertTrue(exprList.get(1) instanceof ExpressionList);
     }
 
     @Test
@@ -88,12 +90,12 @@ public class ExpressionVisitorAdapterTest {
             public void visit(InExpression expr) {
                 super.visit(expr);
                 exprList.add(expr.getLeftExpression());
-                exprList.add(expr.getRightItemsList());
+                exprList.add(expr.getRightExpression());
             }
         });
 
         assertTrue(exprList.get(0) instanceof RowConstructor);
-        assertTrue(exprList.get(1) instanceof ItemsList);
+        assertTrue(exprList.get(1) instanceof SubSelect);
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.operators.relational.InExpression;
-import net.sf.jsqlparser.expression.operators.relational.ItemsList;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.select.PlainSelect;

--- a/src/test/java/net/sf/jsqlparser/statement/builder/JSQLParserFluentModelTests.java
+++ b/src/test/java/net/sf/jsqlparser/statement/builder/JSQLParserFluentModelTests.java
@@ -59,7 +59,8 @@ public class JSQLParserFluentModelTests {
                 )).withRightExpression(
                 new InExpression()
                         .withLeftExpression(new Column(asList("t1", "col3")))
-                        .withRightItemsList(new ExpressionList().addExpressions(new StringValue("A"))));
+                        .withRightItemsList(new ExpressionList(new StringValue("A"))));
+
         Select select = new Select().withSelectBody(new PlainSelect().addSelectItems(new AllColumns()).withFromItem(t1)
                 .addJoins(new Join().withRightItem(t2)
                         .withOnExpression(
@@ -95,8 +96,7 @@ public class JSQLParserFluentModelTests {
                         .withRightExpression(
                                 new InExpression()
                                         .withLeftExpression(new Column(asList("t1", "col3")))
-                                        .withRightItemsList(new ExpressionList()
-                                                .addExpressions(new StringValue("B"), new StringValue("C")))))
+                                        .withRightItemsList(new ExpressionList(new StringValue("B"), new StringValue("C")))))
                 .withRightExpression(new Column(asList("t2", "col4")));
 
         Select select = new Select().withSelectBody(new PlainSelect().addSelectItems(new AllColumns()).withFromItem(t1)

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -4866,4 +4866,27 @@ public class SelectTest {
         assertSqlCanBeParsedAndDeparsed(
                 "SELECT count(a.*) from a", true);
     }
+
+    @Test
+    public void testComplexInExpressionIssue905() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "select * " +
+                        "from table_a " +
+                        "where other_id in (" +
+                        "   (select id from table_b where name like '%aa%')" +
+                        "   , (select id from table_b where name like '%bb%')" +
+                        ")", true);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "select * from v.e\n" +
+                        "where\n" +
+                        "\tcid <> rid\n" +
+                        "\tand  rid  not in\n" +
+                        "\t(\n" +
+                        "\t\t(select distinct  rid  from  v.s )\n" +
+                        "\t\tunion\n" +
+                        "\t\t(select distinct  rid  from v.p )\n" +
+                        "\t)\n" +
+                        "\tand  \"timestamp\"  <= 1298505600000", true);
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -4888,5 +4888,10 @@ public class SelectTest {
                         "\t\t(select distinct  rid  from v.p )\n" +
                         "\t)\n" +
                         "\tand  \"timestamp\"  <= 1298505600000", true);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "select * " +
+                        "from table_a " +
+                        "where (a, b, c) in ((1, 2, 3), (3, 4, 5))", true);
     }
 }

--- a/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/condition12.sql
+++ b/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/condition12.sql
@@ -20,3 +20,5 @@ where
 
 
 --@SUCCESSFULLY_PARSED_AND_DEPARSED first on Aug 3, 2021, 7:20:08 AM
+--@FAILURE: Encountered unexpected token: "union" "UNION" recorded first on 19 Oct 2021, 18:53:13
+--@FAILURE: select*from v.e where cid<>rid and rid not in(((select distinct rid from v.s)union(select distinct rid from v.p)))and "timestamp"<=1298505600000 recorded first on 19 Oct 2021, 18:54:06

--- a/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/condition12.sql
+++ b/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/condition12.sql
@@ -20,5 +20,3 @@ where
 
 
 --@SUCCESSFULLY_PARSED_AND_DEPARSED first on Aug 3, 2021, 7:20:08 AM
---@FAILURE: Encountered unexpected token: "union" "UNION" recorded first on 19 Oct 2021, 18:53:13
---@FAILURE: select*from v.e where cid<>rid and rid not in(((select distinct rid from v.s)union(select distinct rid from v.p)))and "timestamp"<=1298505600000 recorded first on 19 Oct 2021, 18:54:06


### PR DESCRIPTION
Allows `IN()` to uses Complex Expression Lists including multiple `SubSelects`
Simplifies the `IN()` Statement by removing the Multi Expression List property
Fixes #905 
