### PR TITLE
Fixes #1385 and PR#1380

### DIFF
--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -307,10 +307,12 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
         boolean showOptions = unpivot.getIncludeNullsSpecified();
         boolean includeNulls = unpivot.getIncludeNulls();
         List<Column> unpivotForClause = unpivot.getUnPivotForClause();
-        buffer.append(" UNPIVOT").append(showOptions && includeNulls ? " INCLUDE NULLS" : "")
-                .append(showOptions && !includeNulls ? " EXCULDE NULLS" : "").append(" (")
-                .append(unpivot.getUnPivotClause()).append(" FOR ")
-                .append(PlainSelect.getStringList(unpivotForClause, true,
+        buffer
+                .append(" UNPIVOT")
+                .append(showOptions && includeNulls ? " INCLUDE NULLS" : "")
+                .append(showOptions && !includeNulls ? " EXCLUDE NULLS" : "")
+                .append(" (").append(unpivot.getUnPivotClause())
+                .append(" FOR ").append(PlainSelect.getStringList(unpivotForClause, true,
                         unpivotForClause != null && unpivotForClause.size() > 1))
                 .append(" IN ").append(PlainSelect.getStringList(unpivot.getUnPivotInClause(), true, true)).append(")");
         if (unpivot.getAlias() != null) {
@@ -532,20 +534,6 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
     public void visit(ParenthesisFromItem parenthesis) {
         buffer.append("(");
         parenthesis.getFromItem().accept(this);
-        
-        //@todo: investigate, why the Pivot is handled already
-        // while the UnPivot is NOT handled.
-        // Something here is wrong and the code below is just a work around
-        
-        /* handled already somehow somewhere, see Special Oracle Test "pivot07_Parenthesis.sql"
-        if (parenthesis.getFromItem().getPivot()!=null) {
-            parenthesis.getFromItem().getPivot().accept(this);
-        }
-        */
-        
-        if (parenthesis.getFromItem().getUnPivot()!=null) {
-            parenthesis.getFromItem().getUnPivot().accept(this);
-        }
         
         buffer.append(")");
         if (parenthesis.getAlias() != null) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2285,7 +2285,7 @@ UnPivot UnPivot():
     unpivotInClause = PivotSingleInItems()
     ")"
     ")"
-    [ alias = Alias() ]
+    [ LOOKAHEAD(2) alias = Alias() ]
     {
         retval.setUnPivotClause(unpivotClause);
         retval.setUnPivotForClause(unpivotForClause);


### PR DESCRIPTION
Fixes #1385 and PR#1380

Add another Alias() Keyword related LOOKAHEAD
Fix a Keyword Spelling Error in the Deparser
Remove UNPIVOT from the PARENTHESIS Deparser, as it was an ugly workaround made obsolete by PR #1380