### PR TITLE
Add Delete / Update modifiers for MySQL #1254

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
+++ b/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
@@ -27,6 +27,8 @@ import net.sf.jsqlparser.statement.select.Limit;
 import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.WithItem;
+import net.sf.jsqlparser.statement.update.Update;
+import net.sf.jsqlparser.statement.update.UpdateModifierPriority;
 
 public class Delete implements Statement {
 
@@ -43,6 +45,9 @@ public class Delete implements Statement {
     public List<WithItem> getWithItemsList() {
         return withItemsList;
     }
+    private DeleteModifierPriority modifierPriority;
+    private boolean modifierIgnore;
+    private boolean modifierQuick;
 
     public void setWithItemsList(List<WithItem> withItemsList) {
         this.withItemsList = withItemsList;
@@ -160,10 +165,20 @@ public class Delete implements Statement {
         
         b.append("DELETE");
 
+        if (modifierPriority != null) {
+            b.append(" ").append(modifierPriority.name());
+        }
+        if (modifierQuick) {
+            b.append(" QUICK");
+        }
+        if (modifierIgnore) {
+            b.append(" IGNORE");
+        }
+
         if (tables != null && tables.size() > 0) {
             b.append(" ");
             b.append(tables.stream()
-                    .map(t -> t.toString())
+                    .map(Table::toString)
                     .collect(joining(", ")));
         }
 
@@ -241,6 +256,45 @@ public class Delete implements Statement {
     public Delete withHasFrom(boolean hasFrom) {
         this.setHasFrom(hasFrom);
         return this;
+    }
+
+    public Delete withModifierPriority(DeleteModifierPriority modifierPriority){
+        this.setModifierPriority(modifierPriority);
+        return this;
+    }
+
+    public Delete withModifierIgnore(boolean modifierIgnore){
+        this.setModifierIgnore(modifierIgnore);
+        return this;
+    }
+
+    public Delete withModifierQuick(boolean modifierQuick){
+        this.setModifierQuick(modifierQuick);
+        return this;
+    }
+
+    public void setModifierPriority(DeleteModifierPriority modifierPriority) {
+        this.modifierPriority = modifierPriority;
+    }
+
+    public DeleteModifierPriority getModifierPriority() {
+        return modifierPriority;
+    }
+
+    public void setModifierIgnore(boolean modifierIgnore) {
+        this.modifierIgnore = modifierIgnore;
+    }
+
+    public void setModifierQuick(boolean modifierQuick) {
+        this.modifierQuick = modifierQuick;
+    }
+
+    public boolean isModifierIgnore() {
+        return modifierIgnore;
+    }
+
+    public boolean isModifierQuick() {
+        return modifierQuick;
     }
 
     public Delete addTables(Table... tables) {

--- a/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
+++ b/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
@@ -27,8 +27,6 @@ import net.sf.jsqlparser.statement.select.Limit;
 import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.WithItem;
-import net.sf.jsqlparser.statement.update.Update;
-import net.sf.jsqlparser.statement.update.UpdateModifierPriority;
 
 public class Delete implements Statement {
 
@@ -42,12 +40,13 @@ public class Delete implements Statement {
     private Limit limit;
     private List<OrderByElement> orderByElements;
     private boolean hasFrom = true;
-    public List<WithItem> getWithItemsList() {
-        return withItemsList;
-    }
     private DeleteModifierPriority modifierPriority;
     private boolean modifierIgnore;
     private boolean modifierQuick;
+
+    public List<WithItem> getWithItemsList() {
+        return withItemsList;
+    }
 
     public void setWithItemsList(List<WithItem> withItemsList) {
         this.withItemsList = withItemsList;

--- a/src/main/java/net/sf/jsqlparser/statement/delete/DeleteModifierPriority.java
+++ b/src/main/java/net/sf/jsqlparser/statement/delete/DeleteModifierPriority.java
@@ -1,0 +1,14 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.delete;
+
+public enum DeleteModifierPriority {
+    LOW_PRIORITY
+}

--- a/src/main/java/net/sf/jsqlparser/statement/update/Update.java
+++ b/src/main/java/net/sf/jsqlparser/statement/update/Update.java
@@ -21,6 +21,7 @@ import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
+import net.sf.jsqlparser.statement.insert.InsertModifierPriority;
 import net.sf.jsqlparser.statement.select.*;
 
 @SuppressWarnings({"PMD.CyclomaticComplexity"})
@@ -38,6 +39,8 @@ public class Update implements Statement {
     private Limit limit;
     private boolean returningAllColumns = false;
     private List<SelectExpressionItem> returningExpressionList = null;
+    private UpdateModifierPriority modifierPriority;
+    private boolean modifierIgnore;
 
     public ArrayList<UpdateSet> getUpdateSets() {
         return updateSets;
@@ -233,6 +236,23 @@ public class Update implements Statement {
         this.returningExpressionList = returningExpressionList;
     }
 
+    public UpdateModifierPriority getModifierPriority() {
+        return modifierPriority;
+    }
+
+    public void setModifierPriority(UpdateModifierPriority modifierPriority) {
+        this.modifierPriority = modifierPriority;
+    }
+
+    public boolean isModifierIgnore() {
+        return modifierIgnore;
+    }
+
+    public void setModifierIgnore(boolean modifierIgnore) {
+        this.modifierIgnore = modifierIgnore;
+    }
+
+
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity", "PMD.ExcessiveMethodLength"})
     public String toString() {
@@ -250,6 +270,12 @@ public class Update implements Statement {
             }
         }
         b.append("UPDATE ");
+        if (modifierPriority != null) {
+            b.append(modifierPriority.name()).append(" ");
+        }
+        if (modifierIgnore) {
+            b.append("IGNORE ");
+        }
         b.append(table);
         if (startJoins != null) {
             for (Join join : startJoins) {
@@ -402,6 +428,16 @@ public class Update implements Statement {
 
     public Update withExpressions(List<Expression> expressions) {
         this.setExpressions(expressions);
+        return this;
+    }
+
+    public Update withModifierPriority(UpdateModifierPriority modifierPriority){
+        this.setModifierPriority(modifierPriority);
+        return this;
+    }
+
+    public Update withModifierIgnore(boolean modifierIgnore){
+        this.setModifierIgnore(modifierIgnore);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/update/Update.java
+++ b/src/main/java/net/sf/jsqlparser/statement/update/Update.java
@@ -21,7 +21,6 @@ import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
-import net.sf.jsqlparser.statement.insert.InsertModifierPriority;
 import net.sf.jsqlparser.statement.select.*;
 
 @SuppressWarnings({"PMD.CyclomaticComplexity"})

--- a/src/main/java/net/sf/jsqlparser/statement/update/UpdateModifierPriority.java
+++ b/src/main/java/net/sf/jsqlparser/statement/update/UpdateModifierPriority.java
@@ -1,0 +1,14 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.update;
+
+public enum UpdateModifierPriority {
+    LOW_PRIORITY
+}

--- a/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
@@ -47,6 +47,15 @@ public class DeleteDeParser extends AbstractDeParser<Delete> {
       }
     }
         buffer.append("DELETE");
+        if (delete.getModifierPriority() != null) {
+            buffer.append(" ").append(delete.getModifierPriority());
+        }
+        if (delete.isModifierQuick()) {
+            buffer.append(" QUICK");
+        }
+        if (delete.isModifierIgnore()) {
+            buffer.append(" IGNORE");
+        }
         if (delete.getTables() != null && !delete.getTables().isEmpty()) {
             buffer.append(
                     delete.getTables().stream().map(Table::getFullyQualifiedName).collect(joining(", ", " ", "")));

--- a/src/main/java/net/sf/jsqlparser/util/deparser/UpdateDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/UpdateDeParser.java
@@ -48,7 +48,14 @@ public class UpdateDeParser extends AbstractDeParser<Update> implements OrderByV
                 buffer.append(" ");
             }
         }
-        buffer.append("UPDATE ").append(update.getTable());
+        buffer.append("UPDATE ");
+        if (update.getModifierPriority() != null) {
+            buffer.append(update.getModifierPriority()).append(" ");
+        }
+        if (update.isModifierIgnore()) {
+            buffer.append("IGNORE ");
+        }
+        buffer.append(update.getTable());
         if (update.getStartJoins() != null) {
             for (Join join : update.getStartJoins()) {
                 if (join.isSimple()) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -326,6 +326,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_PUBLIC:"PUBLIC">
 |   <K_PURGE:"PURGE">
 |   <K_QUERY:"QUERY">
+|   <K_QUICK : "QUICK">
 |   <K_QUIESCE: "QUIESCE">
 |   <K_RANGE: "RANGE">
 |   <K_READ: "READ" >
@@ -1124,11 +1125,18 @@ Update Update( List<WithItem> with ):
     List<OrderByElement> orderByElements;
     boolean useColumnsBrackets = false;
     List<SelectExpressionItem> returning = null;
+    Token tk = null;
+    UpdateModifierPriority modifierPriority = null;
+    boolean modifierIgnore = false;
 }
 {
-   <K_UPDATE> { update.setOracleHint(getOracleHint()); } table=TableWithAlias()  
-        startJoins=JoinsList()
-
+   <K_UPDATE> { update.setOracleHint(getOracleHint()); }
+    [(tk = <K_LOW_PRIORITY>)
+    {if (tk!=null)
+        modifierPriority = UpdateModifierPriority.valueOf(tk.image.toUpperCase());
+    }]
+    [<K_IGNORE>{ modifierIgnore = true; }]
+    table=TableWithAlias() startJoins=JoinsList()
     <K_SET>
     (
         LOOKAHEAD(3) tableColumn=Column() "=" valueExpression=SimpleExpression() { update.addUpdateSet(tableColumn, valueExpression); }
@@ -1193,6 +1201,8 @@ Update Update( List<WithItem> with ):
               .withStartJoins(startJoins)
               .withFromItem(fromItem)
               .withJoins(joins)
+              .withModifierPriority(modifierPriority)
+              .withModifierIgnore(modifierIgnore)
               .withReturningExpressionList(returning);
    }
 }
@@ -1480,9 +1490,20 @@ Delete Delete( List<WithItem> with ):
     Limit limit = null;
     List<OrderByElement> orderByElements;
     boolean hasFrom = false;
+    Token tk = null;
+    DeleteModifierPriority modifierPriority = null;
+    boolean modifierIgnore = false;
+    boolean modifierQuick = false;
 }
 {
-    <K_DELETE> { delete.setOracleHint(getOracleHint()); } [LOOKAHEAD(4) (table=TableWithAlias() { tables.add(table); }
+    <K_DELETE> { delete.setOracleHint(getOracleHint()); }
+    [(tk = <K_LOW_PRIORITY>)
+    {if (tk!=null)
+        modifierPriority = DeleteModifierPriority.valueOf(tk.image.toUpperCase());
+    }]
+    [<K_QUICK>{ modifierQuick = true; }]
+    [<K_IGNORE>{ modifierIgnore = true; }]
+    [LOOKAHEAD(4) (table=TableWithAlias() { tables.add(table); }
           ("," table=TableWithAlias() { tables.add(table); } )*
     <K_FROM> | <K_FROM>) { hasFrom = true; }]
 
@@ -1497,7 +1518,13 @@ Delete Delete( List<WithItem> with ):
             delete.setJoins(joins);
         }
         return delete.withWithItemsList(with)
-              .withTables(tables).withTable(table).withHasFrom(hasFrom).withUsingList(usingList);
+              .withTables(tables)
+              .withTable(table)
+              .withHasFrom(hasFrom)
+              .withUsingList(usingList)
+              .withModifierPriority(modifierPriority)
+              .withModifierIgnore(modifierIgnore)
+              .withModifierQuick(modifierQuick);
     }
 }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1131,11 +1131,8 @@ Update Update( List<WithItem> with ):
 }
 {
    <K_UPDATE> { update.setOracleHint(getOracleHint()); }
-    [(tk = <K_LOW_PRIORITY>)
-    {if (tk!=null)
-        modifierPriority = UpdateModifierPriority.LOW_PRIORITY;
-    }]
-    [<K_IGNORE>{ modifierIgnore = true; }]
+    [<K_LOW_PRIORITY> { modifierPriority = UpdateModifierPriority.LOW_PRIORITY; }]
+    [<K_IGNORE> { modifierIgnore = true; }]
     table=TableWithAlias() startJoins=JoinsList()
     <K_SET>
     (
@@ -1497,12 +1494,9 @@ Delete Delete( List<WithItem> with ):
 }
 {
     <K_DELETE> { delete.setOracleHint(getOracleHint()); }
-    [(tk = <K_LOW_PRIORITY>)
-    {if (tk!=null)
-        modifierPriority = DeleteModifierPriority.LOW_PRIORITY;
-    }]
-    [<K_QUICK>{ modifierQuick = true; }]
-    [<K_IGNORE>{ modifierIgnore = true; }]
+    [<K_LOW_PRIORITY> { modifierPriority = DeleteModifierPriority.LOW_PRIORITY; }]
+    [<K_QUICK> { modifierQuick = true; }]
+    [<K_IGNORE> { modifierIgnore = true; }]
     [LOOKAHEAD(4) (table=TableWithAlias() { tables.add(table); }
           ("," table=TableWithAlias() { tables.add(table); } )*
     <K_FROM> | <K_FROM>) { hasFrom = true; }]

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1133,7 +1133,7 @@ Update Update( List<WithItem> with ):
    <K_UPDATE> { update.setOracleHint(getOracleHint()); }
     [(tk = <K_LOW_PRIORITY>)
     {if (tk!=null)
-        modifierPriority = UpdateModifierPriority.valueOf(tk.image.toUpperCase());
+        modifierPriority = UpdateModifierPriority.LOW_PRIORITY;
     }]
     [<K_IGNORE>{ modifierIgnore = true; }]
     table=TableWithAlias() startJoins=JoinsList()
@@ -1499,7 +1499,7 @@ Delete Delete( List<WithItem> with ):
     <K_DELETE> { delete.setOracleHint(getOracleHint()); }
     [(tk = <K_LOW_PRIORITY>)
     {if (tk!=null)
-        modifierPriority = DeleteModifierPriority.valueOf(tk.image.toUpperCase());
+        modifierPriority = DeleteModifierPriority.LOW_PRIORITY;
     }]
     [<K_QUICK>{ modifierQuick = true; }]
     [<K_IGNORE>{ modifierIgnore = true; }]

--- a/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
@@ -12,6 +12,8 @@ package net.sf.jsqlparser.statement.delete;
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
 import static net.sf.jsqlparser.test.TestUtils.assertOracleHintExists;
 import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringReader;
 
@@ -136,5 +138,46 @@ public class DeleteTest {
     public void testUsing() throws JSQLParserException {
         String statement = "DELETE A USING B.C D WHERE D.Z = 1";
         assertSqlCanBeParsedAndDeparsed(statement);
+    }
+
+    @Test
+    public void testDeleteLowPriority() throws JSQLParserException {
+        String stmt = "DELETE LOW_PRIORITY FROM tablename";
+        Delete delete = (Delete)assertSqlCanBeParsedAndDeparsed(stmt);
+        assertEquals(delete.getModifierPriority(), DeleteModifierPriority.LOW_PRIORITY);
+    }
+
+    @Test
+    public void testDeleteQuickModifier() throws JSQLParserException {
+        String stmt = "DELETE QUICK FROM tablename";
+        Delete delete = (Delete)assertSqlCanBeParsedAndDeparsed(stmt);
+        assertTrue(delete.isModifierQuick());
+        String stmt2 = "DELETE FROM tablename";
+        Delete delete2 = (Delete)assertSqlCanBeParsedAndDeparsed(stmt2);
+        assertFalse(delete2.isModifierQuick());
+    }
+
+    @Test
+    public void testDeleteIgnoreModifier() throws JSQLParserException {
+        String stmt = "DELETE IGNORE FROM tablename";
+        Delete delete = (Delete)assertSqlCanBeParsedAndDeparsed(stmt);
+        assertTrue(delete.isModifierIgnore());
+        String stmt2 = "DELETE FROM tablename";
+        Delete delete2 = (Delete)assertSqlCanBeParsedAndDeparsed(stmt2);
+        assertFalse(delete2.isModifierIgnore());
+    }
+
+    @Test
+    public void testDeleteMultipleModifiers() throws JSQLParserException {
+        String stmt = "DELETE LOW_PRIORITY QUICK FROM tablename";
+        Delete delete = (Delete)assertSqlCanBeParsedAndDeparsed(stmt);
+        assertEquals(delete.getModifierPriority(), DeleteModifierPriority.LOW_PRIORITY);
+        assertTrue(delete.isModifierQuick());
+
+        String stmt2 = "DELETE LOW_PRIORITY QUICK IGNORE FROM tablename";
+        Delete delete2 = (Delete)assertSqlCanBeParsedAndDeparsed(stmt2);
+        assertEquals(delete2.getModifierPriority(), DeleteModifierPriority.LOW_PRIORITY);
+        assertTrue(delete2.isModifierIgnore());
+        assertTrue(delete2.isModifierQuick());
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
@@ -143,39 +143,39 @@ public class DeleteTest {
     @Test
     public void testDeleteLowPriority() throws JSQLParserException {
         String stmt = "DELETE LOW_PRIORITY FROM tablename";
-        Delete delete = (Delete)assertSqlCanBeParsedAndDeparsed(stmt);
+        Delete delete = (Delete) assertSqlCanBeParsedAndDeparsed(stmt);
         assertEquals(delete.getModifierPriority(), DeleteModifierPriority.LOW_PRIORITY);
     }
 
     @Test
     public void testDeleteQuickModifier() throws JSQLParserException {
         String stmt = "DELETE QUICK FROM tablename";
-        Delete delete = (Delete)assertSqlCanBeParsedAndDeparsed(stmt);
+        Delete delete = (Delete) assertSqlCanBeParsedAndDeparsed(stmt);
         assertTrue(delete.isModifierQuick());
         String stmt2 = "DELETE FROM tablename";
-        Delete delete2 = (Delete)assertSqlCanBeParsedAndDeparsed(stmt2);
+        Delete delete2 = (Delete) assertSqlCanBeParsedAndDeparsed(stmt2);
         assertFalse(delete2.isModifierQuick());
     }
 
     @Test
     public void testDeleteIgnoreModifier() throws JSQLParserException {
         String stmt = "DELETE IGNORE FROM tablename";
-        Delete delete = (Delete)assertSqlCanBeParsedAndDeparsed(stmt);
+        Delete delete = (Delete) assertSqlCanBeParsedAndDeparsed(stmt);
         assertTrue(delete.isModifierIgnore());
         String stmt2 = "DELETE FROM tablename";
-        Delete delete2 = (Delete)assertSqlCanBeParsedAndDeparsed(stmt2);
+        Delete delete2 = (Delete) assertSqlCanBeParsedAndDeparsed(stmt2);
         assertFalse(delete2.isModifierIgnore());
     }
 
     @Test
     public void testDeleteMultipleModifiers() throws JSQLParserException {
         String stmt = "DELETE LOW_PRIORITY QUICK FROM tablename";
-        Delete delete = (Delete)assertSqlCanBeParsedAndDeparsed(stmt);
+        Delete delete = (Delete) assertSqlCanBeParsedAndDeparsed(stmt);
         assertEquals(delete.getModifierPriority(), DeleteModifierPriority.LOW_PRIORITY);
         assertTrue(delete.isModifierQuick());
 
         String stmt2 = "DELETE LOW_PRIORITY QUICK IGNORE FROM tablename";
-        Delete delete2 = (Delete)assertSqlCanBeParsedAndDeparsed(stmt2);
+        Delete delete2 = (Delete) assertSqlCanBeParsedAndDeparsed(stmt2);
         assertEquals(delete2.getModifierPriority(), DeleteModifierPriority.LOW_PRIORITY);
         assertTrue(delete2.isModifierIgnore());
         assertTrue(delete2.isModifierQuick());

--- a/src/test/java/net/sf/jsqlparser/statement/update/UpdateTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/update/UpdateTest.java
@@ -18,8 +18,8 @@ import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.expression.operators.relational.GreaterThanEquals;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
 import static net.sf.jsqlparser.test.TestUtils.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
 
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import org.junit.Assert;
@@ -247,5 +247,30 @@ public class UpdateTest {
 
         Assert.assertEquals(1, update.getUpdateSets().get(2).getColumns().size());
         Assert.assertEquals(1, update.getUpdateSets().get(2).getExpressions().size());
+    }
+
+    @Test
+    public void testUpdateLowPriority() throws JSQLParserException {
+        String stmt = "UPDATE LOW_PRIORITY table1 A SET A.columna = 'XXX'";
+        Update update = (Update)assertSqlCanBeParsedAndDeparsed(stmt);
+        assertEquals(update.getModifierPriority(), UpdateModifierPriority.LOW_PRIORITY);
+    }
+
+    @Test
+    public void testUpdateIgnoreModifier() throws JSQLParserException {
+        String stmt = "UPDATE IGNORE table1 A SET A.columna = 'XXX'";
+        Update update = (Update)assertSqlCanBeParsedAndDeparsed(stmt);
+        assertTrue(update.isModifierIgnore());
+        String stmt2 = "UPDATE table1 A SET A.columna = 'XXX'";
+        Update update2 = (Update)assertSqlCanBeParsedAndDeparsed(stmt2);
+        assertFalse(update2.isModifierIgnore());
+    }
+
+    @Test
+    public void testUpdateMultipleModifiers() throws JSQLParserException {
+        String stmt = "UPDATE LOW_PRIORITY IGNORE table1 A SET A.columna = 'XXX'";
+        Update update = (Update)assertSqlCanBeParsedAndDeparsed(stmt);
+        assertEquals(update.getModifierPriority(), UpdateModifierPriority.LOW_PRIORITY);
+        assertTrue(update.isModifierIgnore());
     }
 }


### PR DESCRIPTION
- Fixes https://github.com/JSQLParser/JSqlParser/issues/1254
- Add IGNORE parser/deparse for DELETE and UPDATE.
- I find also two modifiers not available for MySQL so I also add LOW_PRIORITY modifier for DELETE and UPDATE, and QUICK modifier for DELETE.
- Documentation : https://dev.mysql.com/doc/refman/8.0/en/update.html https://dev.mysql.com/doc/refman/8.0/en/delete.html

- Example queries:

```sql
UPDATE IGNORE table1 A SET A.columna = 'XXX'
DELETE IGNORE FROM tablename

UPDATE LOW_PRIORITY table1 A SET A.columna = 'XXX'
DELETE LOW_PRIORITY FROM tablename
DELETE QUICK FROM tablename
```