### PR TITLE
added USE SCHEMA <schema> and CREATE OR REPLACE <table> support

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/UseStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/UseStatement.java
@@ -12,6 +12,7 @@ package net.sf.jsqlparser.statement;
 public class UseStatement implements Statement {
 
     private String name;
+    private boolean schemaKeyword;
 
     public UseStatement() {
         // empty constructor
@@ -19,6 +20,11 @@ public class UseStatement implements Statement {
 
     public UseStatement(String name) {
         this.name = name;
+    }
+
+    public UseStatement(String name, boolean hasSchemaKeyword) {
+        this.name = name;
+        this.schemaKeyword = hasSchemaKeyword;
     }
 
     public String getName() {
@@ -29,9 +35,17 @@ public class UseStatement implements Statement {
         this.name = name;
     }
 
+    public boolean hasSchemaKeyword() {
+        return schemaKeyword;
+    }
+
+    public void setSchemaKeyword(boolean schemaKeyword) {
+        this.schemaKeyword = schemaKeyword;
+    }
+
     @Override
     public String toString() {
-        return "USE " + name;
+        return "USE " + (schemaKeyword ? "SCHEMA " : "") + name;
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/CreateTable.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/CreateTable.java
@@ -34,6 +34,8 @@ public class CreateTable implements Statement {
     private Table likeTable;
     private boolean selectParenthesis;
     private boolean ifNotExists = false;
+    private boolean orReplace = false;
+
     private RowMovement rowMovement;
 
     @Override
@@ -134,6 +136,14 @@ public class CreateTable implements Statement {
         this.ifNotExists = ifNotExists;
     }
 
+    public boolean isOrReplace() {
+        return orReplace;
+    }
+
+    public void setOrReplace(boolean orReplace) {
+        this.orReplace = orReplace;
+    }
+
     public boolean isSelectParenthesis() {
         return selectParenthesis;
     }
@@ -158,6 +168,7 @@ public class CreateTable implements Statement {
 
         sql = "CREATE " + (unlogged ? "UNLOGGED " : "")
                 + (!"".equals(createOps) ? createOps + " " : "")
+                + (orReplace ? "OR REPLACE " : "")
                 + "TABLE " + (ifNotExists ? "IF NOT EXISTS " : "") + table;
 
         if (columns != null && !columns.isEmpty()) {

--- a/src/main/java/net/sf/jsqlparser/util/deparser/CreateTableDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/CreateTableDeParser.java
@@ -35,6 +35,9 @@ public class CreateTableDeParser extends AbstractDeParser<CreateTable> {
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     public void deParse(CreateTable createTable) {
         buffer.append("CREATE ");
+        if (createTable.isOrReplace()) {
+            buffer.append("OR REPLACE ");
+        }
         if (createTable.isUnlogged()) {
             buffer.append("UNLOGGED ");
         }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/UseStatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/UseStatementDeParser.java
@@ -19,6 +19,10 @@ public class UseStatementDeParser extends AbstractDeParser<UseStatement> {
 
     @Override
     public void deParse(UseStatement set) {
-        buffer.append("USE ").append(set.getName());
+        buffer.append("USE ");
+        if (set.hasSchemaKeyword()) {
+            buffer.append("SCHEMA ");
+        }
+        buffer.append(set.getName());
     }
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1033,11 +1033,12 @@ List<ExplainStatement.Option> ExplainStatementOptions():
 
 UseStatement Use(): {
     String name;
+    boolean hasSchemaKeyword = false;
 }
 {
-    <K_USE> name = RelObjectNameExt()
+    <K_USE> [ LOOKAHEAD(2) <K_SCHEMA> { hasSchemaKeyword = true; } ] name = RelObjectNameExt()
     {
-        return new UseStatement(name);
+        return new UseStatement(name, hasSchemaKeyword);
     }
 }
 
@@ -4811,6 +4812,7 @@ CreateTable CreateTable():
 }
 {
     <K_CREATE>
+    [ <K_OR> <K_REPLACE> { createTable.setOrReplace(true);} ]
     [ <K_UNLOGGED> { createTable.setUnlogged(true); } ]
 
     // table options, not required but 1 or none

--- a/src/test/java/net/sf/jsqlparser/expression/LimitExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/LimitExpressionTest.java
@@ -1,3 +1,12 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2021 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
 package net.sf.jsqlparser.expression;
 
 import net.sf.jsqlparser.JSQLParserException;

--- a/src/test/java/net/sf/jsqlparser/statement/UseStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/UseStatementTest.java
@@ -19,7 +19,11 @@ import org.junit.Test;
  */
 public class UseStatementTest {
 
-
+    @Test
+    public void testUseSchema() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("USE SCHEMA myschema");
+    }
+    
     @Test
     public void testSimpleUse() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("USE mydatabase");

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
@@ -45,6 +45,12 @@ public class CreateTableTest {
   private final CCJSqlParserManager parserManager = new CCJSqlParserManager();
 
   @Test
+  public void testCreateTableOrReplace() throws JSQLParserException {
+    String statement = "CREATE OR REPLACE TABLE testtab (\"test\" varchar (255))";
+    assertSqlCanBeParsedAndDeparsed(statement);
+  }
+
+  @Test
   public void testCreateTable2() throws JSQLParserException {
     String statement = "CREATE TABLE testtab (\"test\" varchar (255))";
     assertSqlCanBeParsedAndDeparsed(statement);


### PR DESCRIPTION
To parse out Snowflake DDL that we use I needed to extend the allowed syntax for USE SCHEMA <schema> and CREATE OR REPLACE <table>