### PR TITLE
Add support for quoted cast expressions

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4996,7 +4996,7 @@ ColDataType ColDataType():
     (
 		(tk=<K_CHARACTER> | tk=<K_BIT>) [tk2=<K_VARYING>] { colDataType.setDataType(tk.image + (tk2!=null?" " + tk2.image:"")); }
 		| tk=<K_DOUBLE> [LOOKAHEAD(2) tk2=<K_PRECISION>] { colDataType.setDataType(tk.image + (tk2!=null?" " + tk2.image:"")); }
-		| ( tk=<S_IDENTIFIER> | tk=<K_DATETIMELITERAL> | tk=<K_DATE_LITERAL> | tk=<K_XML> | tk=<K_INTERVAL>
+		| ( tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER> | tk=<K_DATETIMELITERAL> | tk=<K_DATE_LITERAL> | tk=<K_XML> | tk=<K_INTERVAL>
 			| tk=<DT_ZONE> | tk=<K_CHAR> | tk=<K_SET> | tk=<K_BINARY> | tk=<K_JSON> )
                         [ "." tk2=<S_IDENTIFIER> ]
 		    { if (tk2!=null) colDataType.setDataType(tk.image + "." + tk2.image); else colDataType.setDataType(tk.image); }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -1169,6 +1169,11 @@ public class SelectTest {
     }
 
     @Test
+    public void testQuotedCastExpression() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT col FROM test WHERE status = CASE WHEN anothercol = 5 THEN 'pending'::\"enum_test\" END");
+    }
+
+    @Test
     public void testWhere() throws JSQLParserException {
 
         final String statement = "SELECT * FROM tab1 WHERE";


### PR DESCRIPTION
PostgreSQL allows double quoting type names in "::" casting operations.

Note how "enum_test" is double quoted in this sample query, and it's valid to do it with built in types like "text" as well:
`SELECT col FROM test WHERE status = CASE WHEN anothercol = 5 THEN 'pending'::"enum_test" END`

Adding support for double quotes around the cast type.