### PR TITLE
Support complex expressions in select clause

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2022,7 +2022,7 @@ SelectExpressionItem SelectExpressionItem():
     Alias alias = null;
 }
 {
-      expression=Condition() { selectExpressionItem = new SelectExpressionItem(); selectExpressionItem.setExpression(expression); }
+      expression=Expression() { selectExpressionItem = new SelectExpressionItem(); selectExpressionItem.setExpression(expression); }
              [alias=Alias() { selectExpressionItem.setAlias(alias); }] { return selectExpressionItem; }
 }
 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -1661,6 +1661,12 @@ public class SelectTest {
     }
 
     @Test
+    public void testComplexConditionInSelectClause() throws JSQLParserException {
+        String stmt = "SELECT (CASE WHEN col IS NULL THEN False ELSE True END) OR (CASE WHEN col2 IS NULL THEN False ELSE True END) FROM tbl";
+        assertSqlCanBeParsedAndDeparsed(stmt);
+    }
+
+    @Test
     public void testConcatProblem2_5() throws JSQLParserException {
         String stmt = "SELECT max((a || b) || c) FROM testtable";
         assertSqlCanBeParsedAndDeparsed(stmt);


### PR DESCRIPTION
The SELECT clause can contain complex expressions, for example "(condition) OR (condition)", which actually returns a boolean.

Sample query:
`SELECT (CASE WHEN col IS NULL THEN False ELSE True END) OR (CASE WHEN col2 IS NULL THEN False ELSE True END) FROM tbl`

Adding support for such complex conditions in the SELECT clause.