### PR TITLE
Add support for expressions (such as columns) in AT TIME ZONE expressions

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/TimezoneExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/TimezoneExpression.java
@@ -17,7 +17,7 @@ import java.util.List;
 public class TimezoneExpression extends ASTNodeAccessImpl implements Expression {
 
     private Expression leftExpression;
-    private ArrayList<String> timezoneExpressions = new ArrayList<>();
+    private ArrayList<Expression> timezoneExpressions = new ArrayList<>();
 
     public Expression getLeftExpression() {
         return leftExpression;
@@ -32,19 +32,19 @@ public class TimezoneExpression extends ASTNodeAccessImpl implements Expression 
         expressionVisitor.visit(this);
     }
 
-    public List<String> getTimezoneExpressions() {
+    public List<Expression> getTimezoneExpressions() {
         return timezoneExpressions;
     }
 
-    public void addTimezoneExpression(String timezoneExpr) {
+    public void addTimezoneExpression(Expression timezoneExpr) {
         this.timezoneExpressions.add(timezoneExpr);
     }
 
     @Override
     public String toString() {
         String returnValue = getLeftExpression().toString();
-        for (String expr : timezoneExpressions) {
-            returnValue += " AT TIME ZONE " + expr;
+        for (Expression expr : timezoneExpressions) {
+            returnValue += " AT TIME ZONE " + expr.toString();
         }
 
         return returnValue;

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -923,8 +923,9 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
     public void visit(TimezoneExpression var) {
         var.getLeftExpression().accept(this);
 
-        for (String expr : var.getTimezoneExpressions()) {
-            buffer.append(" AT TIME ZONE " + expr);
+        for (Expression expr : var.getTimezoneExpressions()) {
+            buffer.append(" AT TIME ZONE ");
+            expr.accept(this);
         }
     }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3614,6 +3614,7 @@ Expression PrimaryExpression() #PrimaryExpression:
     Expression retval = null;
     CastExpression castExpr = null;
     TimezoneExpression timezoneExpr = null;
+    Expression timezoneRightExpr = null;
     Token token = null;
     Token sign = null;
     String tmp = "";
@@ -3738,11 +3739,11 @@ Expression PrimaryExpression() #PrimaryExpression:
         retval=castExpr;
     } )*
 
-    ( <K_AT> <K_DATETIMELITERAL> <K_ZONE> token=<S_CHAR_LITERAL> {
+    ( <K_AT> <K_DATETIMELITERAL> <K_ZONE> timezoneRightExpr=PrimaryExpression() {
         if (timezoneExpr == null)
             timezoneExpr = new TimezoneExpression();
 
-        timezoneExpr.addTimezoneExpression(token.image);
+        timezoneExpr.addTimezoneExpression(timezoneRightExpr);
     } )*
 
     {

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -887,6 +887,12 @@ public class SelectTest {
     }
 
     @Test
+    public void testTimezoneExpressionWithColumnBasedTimezone() throws JSQLParserException {
+        String stmt = "SELECT 1 FROM tbl WHERE col AT TIME ZONE timezone_col < '2021-11-05 00:00:35'::date + INTERVAL '1 day' * 0";
+        assertSqlCanBeParsedAndDeparsed(stmt);
+    }
+
+    @Test
     public void testUnionWithOrderByAndLimitAndNoBrackets() throws JSQLParserException {
         String stmt = "SELECT id FROM table1 UNION SELECT id FROM table2 ORDER BY id ASC LIMIT 55";
         assertSqlCanBeParsedAndDeparsed(stmt);


### PR DESCRIPTION
This far only 'strings' were supported as part of an AT TIME ZONE expression.
Now supporting columns and more complex expressions, in case one wants to use them as a timezone name.

For example:
`SELECT 1 FROM tbl WHERE col AT TIME ZONE timezone_col < '2021-11-05 00:00:35'::date + INTERVAL '1 day' * 0`