### PR TITLE
Adjust Gradle to JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,12 @@ java.sourceCompatibility = JavaVersion.VERSION_1_8
 repositories {
 	gradlePluginPortal()
     mavenLocal()
+    mavenCentral()
     maven {
         url = uri('https://repo.maven.apache.org/maven2/')
+    }
+    maven {
+      url "https://plugins.gradle.org/m2/"
     }
 }
 
@@ -35,6 +39,12 @@ dependencies {
     // for JaCoCo Reports
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+    
+    // https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
+    testImplementation 'org.mockito:mockito-junit-jupiter:4.1.0'
+    
+    // enforce latest version of JavaCC
+    javacc 'net.java.dev.javacc:javacc:7.0.10'
     
 }
 
@@ -56,6 +66,18 @@ jacoco {
 }
 
 test {
+    useJUnitPlatform()
+
+    // set heap size for the test JVM(s)
+    minHeapSize = "128m"
+    maxHeapSize = "1G"
+
+    jvmArgs << [
+            '-Djunit.jupiter.execution.parallel.enabled=true',
+            '-Djunit.jupiter.execution.parallel.config.strategy=dynamic',
+            '-Djunit.jupiter.execution.parallel.mode.default=concurrent'
+    ]
+
     finalizedBy jacocoTestReport // report is always generated after tests run
     finalizedBy jacocoTestCoverageVerification
 }
@@ -93,7 +115,7 @@ jacocoTestCoverageVerification {
             limit {
                 counter = 'LINE'
                 value = 'MISSEDCOUNT'
-                maximum = 5458
+                maximum = 5500
                 }
             excludes = [
                     'net.sf.jsqlparser.util.validation.*',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,12 @@
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+org.gradle.jvmargs=-Xmx1G -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError
+
+org.gradle.caching=true
+
+# Modularise your project and enable parallel build
+org.gradle.parallel=true
+
+# Enable configure on demand.
+org.gradle.configureondemand=true
+

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -45,7 +45,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class SelectTest {
 
     private final CCJSqlParserManager parserManager = new CCJSqlParserManager();

--- a/src/test/java/net/sf/jsqlparser/statement/select/SpeedTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SpeedTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
+//@Execution(ExecutionMode.CONCURRENT)
 public class SpeedTest {
 
     private final static int NUM_REPS_500 = 500;

--- a/src/test/java/net/sf/jsqlparser/statement/select/SpeedTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SpeedTest.java
@@ -23,10 +23,7 @@ import net.sf.jsqlparser.statement.simpleparsing.CCJSqlParserManagerTest;
 import net.sf.jsqlparser.test.TestException;
 import net.sf.jsqlparser.util.TablesNamesFinder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-//@Execution(ExecutionMode.CONCURRENT)
 public class SpeedTest {
 
     private final static int NUM_REPS_500 = 500;

--- a/src/test/java/net/sf/jsqlparser/statement/select/SpeedTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SpeedTest.java
@@ -23,7 +23,10 @@ import net.sf.jsqlparser.statement.simpleparsing.CCJSqlParserManagerTest;
 import net.sf.jsqlparser.test.TestException;
 import net.sf.jsqlparser.util.TablesNamesFinder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class SpeedTest {
 
     private final static int NUM_REPS_500 = 500;


### PR DESCRIPTION
After JUnit 5 migration, tests were not found when building with Gradle. This PR fixes the issue and adds smaller Gradle goodies. 

Clean Gradle build takes on 4 seconds (when cached).
Clean Maven PACKAGE takes 50 seconds.

Parallel Test execution
Gradle Caching
Explicitly request for latest JavaCC 7.0.10
Fixes #1398