### PR TITLE
fix fetch present in the end of union query

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/SetOperationList.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/SetOperationList.java
@@ -97,8 +97,8 @@ public class SetOperationList implements SelectBody {
         this.fetch = fetch;
     }
 
-    public Fetch getWithIsolation() {
-        return fetch;
+    public WithIsolation getWithIsolation() {
+        return this.withIsolation;
     }
 
     public void setWithIsolation(WithIsolation withIsolation) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1938,15 +1938,23 @@ SelectBody SetOperationList() #SetOperationList: {
                 ((PlainSelect)selects.get(0)).setUseBrackets(true);
             return selects.get(0);
         } else {
-            if (selects.size()>1 && selects.get(selects.size()-1) instanceof PlainSelect) {
+            if (selects.size()>1 && selects.get(selects.size()-1) instanceof PlainSelect && !brackets.get(brackets.size() - 1)) {
                 PlainSelect ps = (PlainSelect)selects.get(selects.size()-1);
-                if (ps.getOrderByElements() != null && !brackets.get(brackets.size() - 1)) {
+                if (ps.getOrderByElements() != null) {
                     list.setOrderByElements(ps.getOrderByElements());
                     list.setLimit(ps.getLimit());
                     list.setOffset(ps.getOffset());
                     ps.setOrderByElements(null);
                     ps.setLimit(null);
                     ps.setOffset(null);
+                }
+                if (ps.getFetch() != null) {
+                    list.setFetch(ps.getFetch());
+                    ps.setFetch(null);
+                }
+                if (ps.getWithIsolation() != null) {
+                    list.setWithIsolation(ps.getWithIsolation());
+                    ps.setWithIsolation(null);
                 }
             }
             list.setBracketsOpsAndSelects(brackets,selects,operations);

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -898,6 +898,25 @@ public class SelectTest {
                 + "SELECT * FROM mytable3 WHERE mytable3.col = ? UNION "
                 + "SELECT * FROM mytable2 LIMIT 3, 4";
         assertStatementCanBeDeparsedAs(select, statementToString);
+
+        //with fetch and with ur
+        String statement2 = "SELECT * FROM mytable WHERE mytable.col = 9 UNION "
+                + "SELECT * FROM mytable3 WHERE mytable3.col = ? UNION " + "SELECT * FROM mytable2 ORDER BY COL DESC FETCH FIRST 1 ROWS ONLY WITH UR";
+
+        Select select2 = (Select) parserManager.parse(new StringReader(statement2));
+        SetOperationList setList2 = (SetOperationList) select2.getSelectBody();
+        assertEquals(3, setList2.getSelects().size());
+        assertEquals("mytable", ((Table) ((PlainSelect) setList2.getSelects().get(0)).getFromItem()).
+                getName());
+        assertEquals("mytable3", ((Table) ((PlainSelect) setList2.getSelects().get(1)).getFromItem()).
+                getName());
+        assertEquals("mytable2", ((Table) ((PlainSelect) setList2.getSelects().get(2)).getFromItem()).
+                getName());
+        assertEquals(1, ((SetOperationList) setList2).getFetch().getRowCount());
+
+        assertEquals("UR", ((SetOperationList) setList2).getWithIsolation().getIsolation());
+
+        assertStatementCanBeDeparsedAs(select2, statement2);
     }
 
     @Test


### PR DESCRIPTION
Fixes #1455 

The `fetch` and `with ur` present in the end of a UNION query should be associated with the UNION query as a whole. 