### PR TITLE
Add support for IS DISTINCT FROM clause

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -186,4 +186,6 @@ public interface ExpressionVisitor {
     void visit(AllTableColumns allTableColumns);
 
     void visit(AllValue allValue);
+
+    void visit(IsDistinctExpression isDistinctExpression);
 }

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -505,6 +505,11 @@ public class ExpressionVisitorAdapter implements ExpressionVisitor, ItemsListVis
     }
 
     @Override
+    public void visit(IsDistinctExpression isDistinctExpression) {
+        visitBinaryExpression(isDistinctExpression);
+    }
+
+    @Override
     public void visit(SelectExpressionItem selectExpressionItem) {
         selectExpressionItem.getExpression().accept(this);
     }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsDistinctExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsDistinctExpression.java
@@ -1,0 +1,42 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression.operators.relational;
+
+import net.sf.jsqlparser.expression.BinaryExpression;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+
+public class IsDistinctExpression extends BinaryExpression {
+
+    private boolean not = false;
+
+    public boolean isNot() {
+        return not;
+    }
+
+    public void setNot(boolean b) {
+        not = b;
+    }
+
+    @Override
+    public void accept(ExpressionVisitor expressionVisitor) {
+        expressionVisitor.visit(this);
+    }
+
+    @Override
+    public String getStringExpression() {
+        return " IS " + (isNot() ? "NOT " : "") + "DISTINCT FROM ";
+    }
+
+    @Override
+    public String toString() {
+        String retval = getLeftExpression() + getStringExpression() + getRightExpression();
+        return retval;
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -577,6 +577,11 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
     }
 
     @Override
+    public void visit(IsDistinctExpression isDistinctExpression) {
+        visitBinaryExpression(isDistinctExpression);
+    }
+
+    @Override
     public void visit(SelectExpressionItem item) {
         item.getExpression().accept(this);
     }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -52,6 +52,7 @@ import net.sf.jsqlparser.expression.operators.relational.OldOracleJoinBinaryExpr
 import net.sf.jsqlparser.expression.operators.relational.RegExpMatchOperator;
 import net.sf.jsqlparser.expression.operators.relational.RegExpMySQLOperator;
 import net.sf.jsqlparser.expression.operators.relational.SimilarToExpression;
+import net.sf.jsqlparser.expression.operators.relational.IsDistinctExpression;
 import net.sf.jsqlparser.expression.operators.relational.SupportsOldOracleJoinSyntax;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
@@ -987,5 +988,12 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
     @Override
     public void visit(AllValue allValue) {
         buffer.append(allValue);
+    }
+
+    @Override
+    public void visit(IsDistinctExpression isDistinctExpression) {
+        buffer.append(isDistinctExpression.getLeftExpression() +
+                isDistinctExpression.getStringExpression() +
+                isDistinctExpression.getRightExpression());
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
@@ -45,6 +45,7 @@ import net.sf.jsqlparser.expression.operators.relational.OldOracleJoinBinaryExpr
 import net.sf.jsqlparser.expression.operators.relational.RegExpMatchOperator;
 import net.sf.jsqlparser.expression.operators.relational.RegExpMySQLOperator;
 import net.sf.jsqlparser.expression.operators.relational.SimilarToExpression;
+import net.sf.jsqlparser.expression.operators.relational.IsDistinctExpression;
 import net.sf.jsqlparser.expression.operators.relational.SupportsOldOracleJoinSyntax;
 import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.schema.Column;
@@ -577,6 +578,12 @@ public class ExpressionValidator extends AbstractValidator<Expression> implement
     @Override
     public void visit(AllValue allValue) {
 
+    }
+
+    @Override
+    public void visit(IsDistinctExpression isDistinctExpression) {
+        isDistinctExpression.getLeftExpression().accept(this);
+        isDistinctExpression.getRightExpression().accept(this);
     }
 
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3141,6 +3141,7 @@ Expression SQLCondition():
          | LOOKAHEAD(IsNullExpression()) result=IsNullExpression(left)
          | LOOKAHEAD(IsBooleanExpression()) result=IsBooleanExpression(left)
          | LOOKAHEAD(2) result=LikeExpression(left)
+         | LOOKAHEAD(IsDistinctExpression()) result=IsDistinctExpression(left)
          | result=SimilarToExpression(left)
         )) ]
     )
@@ -3250,6 +3251,22 @@ Expression SimilarToExpression(Expression leftExpression) #SimilarToExpression:
     <K_SIMILAR> <K_TO>
     rightExpression=SimpleExpression()
     [<K_ESCAPE> token=<S_CHAR_LITERAL> { result.setEscape((new StringValue(token.image)).getValue()); }]
+    {
+        result.setLeftExpression(leftExpression);
+        result.setRightExpression(rightExpression);
+        linkAST(result,jjtThis);
+        return result;
+    }
+}
+
+Expression IsDistinctExpression(Expression leftExpression) #IsDistinctExpression:
+{
+    IsDistinctExpression result = new IsDistinctExpression();
+    Expression rightExpression = null;
+}
+{
+    <K_IS> [<K_NOT> { result.setNot(true); } ] <K_DISTINCT> <K_FROM>
+    rightExpression=SimpleExpression()
     {
         result.setLeftExpression(leftExpression);
         result.setRightExpression(rightExpression);

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -943,6 +943,18 @@ public class SelectTest {
     }
 
     @Test
+    public void testIsDistinctFrom() throws JSQLParserException {
+        String stmt = "SELECT name FROM tbl WHERE name IS DISTINCT FROM foo";
+        assertSqlCanBeParsedAndDeparsed(stmt);
+    }
+
+    @Test
+    public void testIsNotDistinctFrom() throws JSQLParserException {
+        String stmt = "SELECT name FROM tbl WHERE name IS NOT DISTINCT FROM foo";
+        assertSqlCanBeParsedAndDeparsed(stmt);
+    }
+
+    @Test
     public void testDistinctTop() throws JSQLParserException {
         String statement = "SELECT DISTINCT TOP 5 myid, mycol FROM mytable WHERE mytable.col = 9";
         Select select = (Select) parserManager.parse(new StringReader(statement));


### PR DESCRIPTION
PostgreSQL supports IS DISTINCT FROM clauses as part of conditions.
https://wiki.postgresql.org/wiki/Is_distinct_from

Adding a new type of expression to hold these expressions.

Example:
`SELECT name FROM tbl WHERE name IS DISTINCT FROM foo`