### PR TITLE
INSERT with SetOperations

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ To help JSqlParser's development you are encouraged to provide
 
 **Please write in English, since it's the language most of the dev team knows.**
 
-Also I would like to know about needed examples or documentation stuff.
+Any requests for examples or any particular documentation will be most welcome.
 
 ## Extensions in the latest SNAPSHOT version 4.5
+
+- `INSERT` supports `SetOperations` (e. g. `INSERT INTO ... SELECT ... FROM ... UNION SELECT ... FROM ...`), those `SetOperations` are used both for `SELECT` and `VALUES` clauses (API change) in order to simplify the Grammar
+- `(WITH ... SELECT ...)` statements within brackets are now supported
 
 Additionally, we have fixed many errors and improved the code quality and the test coverage.
 
@@ -76,7 +79,7 @@ gradle build
     
 The project requires the following to build:
 - Maven (or Gradle)
-- JDK 8 or later. The jar will target JDK 8, but the version of the maven-compiler-plugin that JsqlParser uses requires JDK 8+
+- JDK 8 or later. The JAR will target JDK 8, but the version of the maven-compiler-plugin that JSqlParser uses requires JDK 8+
 
 This will produce the jsqlparser-VERSION.jar file in the `target/` directory (`build/libs/jsqlparser-VERSION.jar` in case of Gradle).
 
@@ -106,7 +109,7 @@ This is a valid piece of source code:
 
 ## Maven Repository
 
-JSQLParser is deployed at sonatypes open source maven repository. 
+JSQLParser is deployed at Sonatype open source maven repository. 
 Starting from now I will deploy there. The first snapshot version there will be 0.8.5-SNAPSHOT.
 To use it this is the repository configuration:
 
@@ -121,14 +124,14 @@ To use it this is the repository configuration:
      </repository>
 </repositories>
 ```
-This repositories releases will be synched to maven central. Snapshots remain at sonatype.
+These repository releases will be synchronised to Maven Central. Snapshots remain at Sonatype.
 
 And this is the dependency declaration in your pom:
 ```xml
 <dependency>
 	<groupId>com.github.jsqlparser</groupId>
 	<artifactId>jsqlparser</artifactId>
-	<version>4.2</version>
+	<version>4.4</version>
 </dependency>
 ```
 

--- a/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
@@ -29,7 +29,6 @@ import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.select.SelectBody;
-import net.sf.jsqlparser.statement.select.SelectExpressionItem;
 import net.sf.jsqlparser.statement.select.SetOperationList;
 import net.sf.jsqlparser.statement.select.WithItem;
 import net.sf.jsqlparser.statement.values.ValuesStatement;

--- a/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
@@ -123,12 +123,7 @@ public class Insert implements Statement {
 
     @Deprecated
     public boolean isUseValues() {
-        SelectBody selectBody = select.getSelectBody();
-        if (selectBody instanceof ValuesStatement) {
-            return true;
-        } else {
-            return false;
-        }
+        return (select!=null && select.getSelectBody() instanceof ValuesStatement);
     }
 
     public boolean isReturningAllColumns() {

--- a/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
@@ -123,7 +123,7 @@ public class Insert implements Statement {
 
     @Deprecated
     public boolean isUseValues() {
-        return (select!=null && select.getSelectBody() instanceof ValuesStatement);
+        return select!=null && select.getSelectBody() instanceof ValuesStatement;
     }
 
     public boolean isReturningAllColumns() {

--- a/src/main/java/net/sf/jsqlparser/statement/select/Select.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Select.java
@@ -23,6 +23,8 @@ public class Select implements Statement {
     private SelectBody selectBody;
     private List<WithItem> withItemsList;
 
+    private boolean useWithBrackets = false;
+
     @Override
     public void accept(StatementVisitor statementVisitor) {
         statementVisitor.visit(this);
@@ -41,11 +43,27 @@ public class Select implements Statement {
         selectBody = body;
     }
 
+    public void setUsingWithBrackets(boolean useWithBrackets) {
+        this.useWithBrackets = useWithBrackets;
+    }
+
+    public Select withUsingWithBrackets(boolean useWithBrackets) {
+        this.useWithBrackets = useWithBrackets;
+        return this;
+    }
+
+    public boolean isUsingWithBrackets() {
+        return this.useWithBrackets;
+    }
+
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     public String toString() {
         StringBuilder retval = new StringBuilder();
         if (withItemsList != null && !withItemsList.isEmpty()) {
+            if (useWithBrackets) {
+                retval.append("( ");
+            }
             retval.append("WITH ");
             for (Iterator<WithItem> iter = withItemsList.iterator(); iter.hasNext();) {
                 WithItem withItem = iter.next();
@@ -57,6 +75,9 @@ public class Select implements Statement {
             }
         }
         retval.append(selectBody);
+        if (withItemsList != null && !withItemsList.isEmpty() && useWithBrackets) {
+            retval.append(" )");
+        }
         return retval.toString();
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/InsertDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/InsertDeParser.java
@@ -77,13 +77,9 @@ public class InsertDeParser extends AbstractDeParser<Insert> implements ItemsLis
             buffer.append(")");
         }
 
-        if (insert.getItemsList() != null) {
-            insert.getItemsList().accept(this);
-        }
-
         if (insert.getSelect() != null) {
             buffer.append(" ");
-            if (insert.isUseSelectBrackets()) {
+            if (insert.getSelect().isUsingWithBrackets()) {
                 buffer.append("(");
             }
             if (insert.getSelect().getWithItemsList() != null) {
@@ -94,7 +90,7 @@ public class InsertDeParser extends AbstractDeParser<Insert> implements ItemsLis
                 buffer.append(" ");
             }
             insert.getSelect().getSelectBody().accept(selectVisitor);
-            if (insert.isUseSelectBrackets()) {
+            if (insert.getSelect().isUsingWithBrackets()) {
                 buffer.append(")");
             }
         }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -142,6 +142,9 @@ public class StatementDeParser extends AbstractDeParser<Statement> implements St
         expressionDeParser.setBuffer(buffer);
         selectDeParser.setExpressionVisitor(expressionDeParser);
         if (select.getWithItemsList() != null && !select.getWithItemsList().isEmpty()) {
+            if (select.isUsingWithBrackets()) {
+                buffer.append("( ");
+            }
             buffer.append("WITH ");
             for (Iterator<WithItem> iter = select.getWithItemsList().iterator(); iter.hasNext();) {
                 WithItem withItem = iter.next();
@@ -153,6 +156,9 @@ public class StatementDeParser extends AbstractDeParser<Statement> implements St
             }
         }
         select.getSelectBody().accept(selectDeParser);
+        if (select.isUsingWithBrackets()) {
+            buffer.append(" )");
+        }
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/H2Version.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/H2Version.java
@@ -100,6 +100,7 @@ public enum H2Version implements Version {
                     // http://h2database.com/html/commands.html#insert
                     Feature.insert,
                     Feature.insertValues,
+                    Feature.values,
                     Feature.insertFromSelect,
                     // http://h2database.com/html/commands.html#update
                     Feature.update,
@@ -136,7 +137,8 @@ public enum H2Version implements Version {
                     // http://www.h2database.com/html/commands.html#grant_role
                     Feature.grant,
                     // http://h2database.com/html/commands.html#commit
-                    Feature.commit));
+                    Feature.commit
+            ));
 
     private Set<Feature> features;
     private String versionString;

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/MariaDbVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/MariaDbVersion.java
@@ -60,7 +60,7 @@ public enum MariaDbVersion implements Version {
                     Feature.withItem, Feature.withItemRecursive,
 
                     // https://mariadb.com/kb/en/insert/
-                    Feature.insert, Feature.insertValues,
+                    Feature.insert, Feature.insertValues, Feature.values,
                     Feature.insertFromSelect, Feature.insertModifierPriority, Feature.insertModifierIgnore,
                     Feature.insertUseSet, Feature.insertUseDuplicateKeyUpdate, Feature.insertReturningExpressionList,
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/MySqlVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/MySqlVersion.java
@@ -54,6 +54,7 @@ public enum MySqlVersion implements Version {
                     // https://dev.mysql.com/doc/refman/8.0/en/insert.html
                     Feature.insert,
                     Feature.insertValues,
+                    Feature.values,
                     Feature.insertFromSelect, Feature.insertUseSet, Feature.insertModifierPriority,
                     Feature.insertModifierIgnore, Feature.insertUseDuplicateKeyUpdate,
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/OracleVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/OracleVersion.java
@@ -88,6 +88,7 @@ public enum OracleVersion implements Version {
                     // https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/INSERT.html
                     Feature.insert,
                     Feature.insertValues,
+                    Feature.values,
                     // https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/INSERT.html
                     // see "single_table_insert"
                     Feature.insertFromSelect,

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/PostgresqlVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/PostgresqlVersion.java
@@ -109,6 +109,7 @@ public enum PostgresqlVersion implements Version {
                     // https://www.postgresql.org/docs/current/sql-insert.html
                     Feature.insert,
                     Feature.insertValues,
+                    Feature.values,
                     Feature.insertFromSelect,
                     Feature.insertReturningAll, Feature.insertReturningExpressionList,
                     // https://www.postgresql.org/docs/current/sql-update.html

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/SQLVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/SQLVersion.java
@@ -29,10 +29,13 @@ public enum SQLVersion implements Version {
             Feature.jdbcParameter,
             Feature.jdbcNamedParameter,
             // common features
+            Feature.setOperation,
             Feature.select,
             Feature.selectGroupBy, Feature.function,
             Feature.insert,
+            Feature.insertFromSelect,
             Feature.insertValues,
+            Feature.values,
             Feature.update,
             Feature.delete,
             Feature.truncate,

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -541,8 +541,29 @@ Statement SingleStatement() :
 {
     try {
         (
+            LOOKAHEAD(2) (
+                "(" with=WithList()
+                (
+                    stm = Select( with ) { ( (Select) stm).setUsingWithBrackets(true); }
+
+                    /* @todo: unsure, if we need to implement those
+                              since DMLs in brackets do not really make any sense
+                    |
+                    stm = Insert( with ) { ( (Insert) stm).setUsingWithBrackets(true); }
+                    |
+                    stm = Update( with ) { ( (Update) stm).setUsingWithBrackets(true); }
+                    |
+                    stm = Delete( with ) { ( (Delete) stm).setUsingWithBrackets(true); }
+                    |
+                    stm = Merge( with ) { ( (Merge) stm).setUsingWithBrackets(true); }
+
+                     */
+                )
+                ")"
+            )
+            |
             (
-                [ with=WithList() {  } ]
+                [ with=WithList() ]
                 (
                     stm = Select( with )
                     |
@@ -555,86 +576,86 @@ Statement SingleStatement() :
                     stm = Merge( with)
                 )
             )
-        |
-        stm = Upsert()
-        |
-        LOOKAHEAD(3)
-        stm = Replace()
-        |
-        LOOKAHEAD(2)
-        stm = AlterTable()
-        |
-        LOOKAHEAD(2)
-        stm = AlterSession()
-        |
-        LOOKAHEAD(CreateFunctionStatement())
-        stm = CreateFunctionStatement()
-        |
-        LOOKAHEAD(CreateIndex())
-        stm = CreateIndex()
-        |
-        LOOKAHEAD(CreateSchema())
-        stm = CreateSchema()
-        |
-        LOOKAHEAD(CreateSequence())
-        stm = CreateSequence()
-        |
-        LOOKAHEAD(CreateSynonym())
-        stm = CreateSynonym()
-        |
-        LOOKAHEAD(CreateTable())
-        stm = CreateTable()
-        |
-        LOOKAHEAD(CreateView())
-        stm = CreateView()
-        |
-        LOOKAHEAD(AlterView())
-        stm = AlterView()
-        |
-        LOOKAHEAD(AlterSequence())
-        stm = AlterSequence()
-        |
-        stm = Drop()
-        |
-        stm = Truncate()
-        |
-        stm = Execute()
-        |
-        stm = Set()
-        |
-        stm = RenameTableStatement()
-        |
-        stm = Reset()
-        |
-        LOOKAHEAD(ShowColumns())
-        stm = ShowColumns()
-        |
-        LOOKAHEAD(ShowTables())
-        stm = ShowTables()
-        |
-        stm = Show()
-        |
-        stm = Use()
-        |
-        stm = SavepointStatement()
-        |
-        stm = RollbackStatement()
-        |
-        stm = Commit()
-        |
-        stm = Comment()
-        |
-        stm = Describe()
-        |
-        stm = Explain()
-        |
-        stm = Declare()
-        |
-        stm = Grant()
-        |
-        stm = PurgeStatement()
-        |
-        stm = AlterSystemStatement()
+            |
+            stm = Upsert()
+            |
+            LOOKAHEAD(3)
+            stm = Replace()
+            |
+            LOOKAHEAD(2)
+            stm = AlterTable()
+            |
+            LOOKAHEAD(2)
+            stm = AlterSession()
+            |
+            LOOKAHEAD(CreateFunctionStatement())
+            stm = CreateFunctionStatement()
+            |
+            LOOKAHEAD(CreateIndex())
+            stm = CreateIndex()
+            |
+            LOOKAHEAD(CreateSchema())
+            stm = CreateSchema()
+            |
+            LOOKAHEAD(CreateSequence())
+            stm = CreateSequence()
+            |
+            LOOKAHEAD(CreateSynonym())
+            stm = CreateSynonym()
+            |
+            LOOKAHEAD(CreateTable())
+            stm = CreateTable()
+            |
+            LOOKAHEAD(CreateView())
+            stm = CreateView()
+            |
+            LOOKAHEAD(AlterView())
+            stm = AlterView()
+            |
+            LOOKAHEAD(AlterSequence())
+            stm = AlterSequence()
+            |
+            stm = Drop()
+            |
+            stm = Truncate()
+            |
+            stm = Execute()
+            |
+            stm = Set()
+            |
+            stm = RenameTableStatement()
+            |
+            stm = Reset()
+            |
+            LOOKAHEAD(ShowColumns())
+            stm = ShowColumns()
+            |
+            LOOKAHEAD(ShowTables())
+            stm = ShowTables()
+            |
+            stm = Show()
+            |
+            stm = Use()
+            |
+            stm = SavepointStatement()
+            |
+            stm = RollbackStatement()
+            |
+            stm = Commit()
+            |
+            stm = Comment()
+            |
+            stm = Describe()
+            |
+            stm = Explain()
+            |
+            stm = Declare()
+            |
+            stm = Grant()
+            |
+            stm = PurgeStatement()
+            |
+            stm = AlterSystemStatement()
         )
         { return stm; }
     } catch (ParseException e) {
@@ -1107,7 +1128,7 @@ ShowStatement Show(): {
 ValuesStatement Values(): {
     ItemsList itemsList;
 } {
-    <K_VALUES>
+    ( <K_VALUES> | <K_VALUE> )
 
     itemsList = SimpleExpressionList(false)
 
@@ -1288,14 +1309,9 @@ Insert Insert( List<WithItem> with ):
     Table table = null;
     Column tableColumn = null;
     List<Column> columns = new ArrayList<Column>();
-    List<Expression> primaryExpList = new ArrayList<Expression>();
-    ItemsList itemsList = null;
     Expression exp = null;
-    MultiExpressionList multiExpr = null;
     List<SelectExpressionItem> returning = null;
     Select select = null;
-    boolean useValues = true;
-    boolean useSelectBrackets = false;
     boolean useDuplicate = false;
     List<Column> duplicateUpdateColumns = null;
     List<Expression> duplicateUpdateExpressionList = null;
@@ -1321,38 +1337,8 @@ Insert Insert( List<WithItem> with ):
 
      [LOOKAHEAD(2) "(" tableColumn=Column() { columns.add(tableColumn); } ("," tableColumn=Column() { columns.add(tableColumn); } )* ")"  ]
     (
-        LOOKAHEAD(2) [<K_VALUES> | <K_VALUE>]  "(" exp=SimpleExpression() { primaryExpList.add(exp); }
-                ("," exp=SimpleExpression()  { primaryExpList.add(exp); } )* ")" { itemsList = new ExpressionList(primaryExpList); }
-            ("," "(" exp=SimpleExpression() {
-                    if (multiExpr==null) {
-                        multiExpr=new MultiExpressionList();
-                        multiExpr.addExpressionList((ExpressionList)itemsList);
-                        itemsList = multiExpr;
-                    }
-                    primaryExpList = new ArrayList<Expression>();
-                    primaryExpList.add(exp); }
-                ("," exp=SimpleExpression() { primaryExpList.add(exp); } )* ")" { multiExpr.addExpressionList(primaryExpList); } )*
-
-        |
-
         (
-            LOOKAHEAD(2) "(" { useSelectBrackets = true; }
-                { insert.setUseValues(false); }
-                select = SelectWithWithItems( )
-            ")"
-            |
-            { insert.setUseValues(false); }
-            select = SelectWithWithItems( )
-        )
-
-        |
-
-        <K_SET>
-        (
-            {
-                useSet = true;
-                insert.setUseValues(false);
-            }
+            <K_SET> { useSet = true; }
             tableColumn=Column() "=" exp=SimpleExpression()
             {
                 setColumns = new ArrayList<Column>();
@@ -1364,6 +1350,8 @@ Insert Insert( List<WithItem> with ):
                 { setColumns.add(tableColumn);
                 setExpressionList.add(exp); } )*
         )
+        |
+        select = SelectWithWithItems( )
     )
 
     [ <K_ON> <K_DUPLICATE> <K_KEY> <K_UPDATE>
@@ -1391,8 +1379,6 @@ Insert Insert( List<WithItem> with ):
             insert.setColumns(columns);
         }
         return insert.withWithItemsList(with)
-              .withItemsList(itemsList)
-              .withUseSelectBrackets(useSelectBrackets)
               .withSelect(select)
               .withTable(table)
               .withUseDuplicate(useDuplicate)
@@ -1688,7 +1674,7 @@ String RelObjectName() :
 {    Token tk = null; String result = null; }
 {
     (result = RelObjectNameWithoutValue()
-		| tk=<K_GROUP> | tk=<K_INTERVAL> | tk=<K_ON> | tk=<K_ORDER> | tk=<K_START> | tk=<K_TOP> | tk=<K_VALUE> 
+		| tk=<K_GROUP> | tk=<K_INTERVAL> | tk=<K_ON> | tk=<K_ORDER> | tk=<K_START> | tk=<K_TOP> | tk=<K_VALUE>
         | tk=<K_VALUES> | tk=<K_CREATE> | tk=<K_TABLES> )
 
     {
@@ -1773,7 +1759,14 @@ Select SelectWithWithItems( ):
     List<WithItem> with = null;
 }
 {
-    [ with=WithList() {  } ] select = Select( with )
+    LOOKAHEAD(2) (
+        "(" with=WithList()  select = Select( with ) ")" { return select.withUsingWithBrackets(true); }
+    )
+    |
+    (
+         [ with=WithList() ] select = Select( with )
+    )
+
     {
         return select;
     }

--- a/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
@@ -73,7 +73,7 @@ public class InsertTest {
                 .withColumns(Arrays.asList(new Column("col1"), new Column("col2"), new Column("col3")))
                 .withSelect(select);
 
-        assertDeparse(insert, statement);
+        assertDeparse(insert2, statement);
 
         statement = "INSERT INTO myschema.mytable VALUES (?, ?, 2.3)";
         insert = (Insert) parserManager.parse(new StringReader(statement));

--- a/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
@@ -408,23 +408,21 @@ public class InsertTest {
 
     @Test
     public void testInsertUnionSelectIssue1491() throws JSQLParserException {
-        //@todo: Make this work
-//        assertSqlCanBeParsedAndDeparsed(
-//                "insert into table1 (tf1,tf2,tf2)\n" +
-//                        "select sf1,sf2,sf3 from s1" +
-//                        "union " +
-//                        "select rf1,rf2,rf2 from r1"
-//                , true
-//        );
+        assertSqlCanBeParsedAndDeparsed(
+                "insert into table1 (tf1,tf2,tf2)\n" +
+                        "select sf1,sf2,sf3 from s1\n" +
+                        "union\n" +
+                        "select rf1,rf2,rf2 from r1\n"
+                , true
+        );
 
-        //@todo: Make this work
-//        assertSqlCanBeParsedAndDeparsed(
-//                "insert into table1 (tf1,tf2,tf2)\n" +
-//                        "( select sf1,sf2,sf3 from s1" +
-//                        "union " +
-//                        "select rf1,rf2,rf2 from r1 )"
-//                , true
-//        );
+        assertSqlCanBeParsedAndDeparsed(
+                "insert into table1 (tf1,tf2,tf2)\n" +
+                        "( select sf1,sf2,sf3 from s1\n" +
+                        "union\n" +
+                        "select rf1,rf2,rf2 from r1\n)"
+                , true
+        );
 
         assertSqlCanBeParsedAndDeparsed(
                 "insert into table1 (tf1,tf2,tf2)\n" +

--- a/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
@@ -9,8 +9,6 @@
  */
 package net.sf.jsqlparser.statement.insert;
 
-import java.io.StringReader;
-import java.util.Arrays;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.DoubleValue;
 import net.sf.jsqlparser.expression.JdbcParameter;
@@ -24,6 +22,13 @@ import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.select.AllColumns;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.values.ValuesStatement;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.util.Arrays;
+
 import static net.sf.jsqlparser.test.TestUtils.assertDeparse;
 import static net.sf.jsqlparser.test.TestUtils.assertOracleHintExists;
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
@@ -33,8 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 
 public class InsertTest {
 
@@ -56,13 +59,21 @@ public class InsertTest {
                         getValue());
         assertEquals(234, ((LongValue) ((ExpressionList) insert.getItemsList()).getExpressions().
                 get(2)).getValue());
-        assertEquals(statement, "" + insert);
+        assertEquals(statement, insert.toString());
 
-        assertDeparse(new Insert().withTable(new Table("mytable"))
-                .addColumns(Arrays.asList(new Column("col1"), new Column("col2"), new Column("col3")))
-                .withItemsList(new ExpressionList(new JdbcParameter(), new StringValue("sadfsd"),
-                        new LongValue().withValue(234))),
-                statement);
+        ExpressionList expressionList =new ExpressionList(
+                new JdbcParameter()
+                , new StringValue("sadfsd")
+                , new LongValue().withValue(234)
+        );
+
+        Select select = new Select().withSelectBody(new ValuesStatement().withExpressions(expressionList));
+
+        Insert insert2 = new Insert().withTable(new Table("mytable"))
+                .withColumns(Arrays.asList(new Column("col1"), new Column("col2"), new Column("col3")))
+                .withSelect(select);
+
+        assertDeparse(insert, statement);
 
         statement = "INSERT INTO myschema.mytable VALUES (?, ?, 2.3)";
         insert = (Insert) parserManager.parse(new StringReader(statement));
@@ -82,9 +93,9 @@ public class InsertTest {
         assertEquals("mytable", insert.getTable().getName());
         assertEquals(1, insert.getColumns().size());
         assertEquals("col1", insert.getColumns().get(0).getColumnName());
-        assertEquals("val1",
-                ((StringValue) ((ExpressionList) insert.getItemsList()).getExpressions().get(0)).
-                        getValue());
+        assertEquals("('val1')",
+                (((ExpressionList) insert.getItemsList()).getExpressions().get(0)).
+                        toString());
         assertEquals("INSERT INTO mytable (col1) VALUES ('val1')", insert.toString());
 
     }
@@ -103,11 +114,11 @@ public class InsertTest {
         assertEquals("mytable2",
                 ((Table) ((PlainSelect) insert.getSelect().getSelectBody()).getFromItem()).getName());
 
-        // toString uses brakets
+        // toString uses brackets
         String statementToString = "INSERT INTO mytable (col1, col2, col3) SELECT * FROM mytable2";
         assertEquals(statementToString, "" + insert);
 
-        assertDeparse(new Insert().withUseValues(false).withUseSelectBrackets(false).withTable(new Table("mytable"))
+        assertDeparse(new Insert().withTable(new Table("mytable"))
                 .addColumns(new Column("col1"), new Column("col2"), new Column("col3"))
                 .withSelect(new Select().withSelectBody(
                         new PlainSelect().addSelectItems(new AllColumns()).withFromItem(new Table("mytable2")))),
@@ -135,7 +146,6 @@ public class InsertTest {
         Insert insert = (Insert) parserManager.parse(new StringReader(statement));
         assertEquals("TEST", insert.getTable().getName());
         assertEquals(2, insert.getColumns().size());
-        assertTrue(insert.isUseValues());
         assertEquals("ID", insert.getColumns().get(0).getColumnName());
         assertEquals("COUNTER", insert.getColumns().get(1).getColumnName());
         assertEquals(2, ((ExpressionList) insert.getItemsList()).getExpressions().size());
@@ -175,15 +185,24 @@ public class InsertTest {
     public void testInsertMultiRowValue() throws JSQLParserException {
         String statement = "INSERT INTO mytable (col1, col2) VALUES (a, b), (d, e)";
         assertSqlCanBeParsedAndDeparsed(statement);
-        assertDeparse(new Insert().withTable(new Table("mytable"))
+
+        MultiExpressionList multiExpressionList = new MultiExpressionList()
+                .addExpressionLists( new ExpressionList().addExpressions(new Column("a")).addExpressions(new Column("b")))
+                .addExpressionLists( new ExpressionList().addExpressions(new Column("d")).addExpressions(new Column("e")));
+
+        Select select = new Select().withSelectBody(new ValuesStatement().withExpressions(multiExpressionList));
+
+        Insert insert = new Insert().withTable(new Table("mytable"))
                 .withColumns(Arrays.asList(new Column("col1"), new Column("col2")))
-                .withItemsList(new MultiExpressionList().addExpressionLists(
-                        new ExpressionList().addExpressions(Arrays.asList(new Column("a"), new Column("b"))),
-                        new ExpressionList(new Column("d"), new Column("e")))),
-                statement);
+                .withSelect(select);
+
+        assertDeparse(insert, statement);
     }
 
     @Test
+    @Disabled
+    //@todo: Clarify, if and why this test is supposed to fail and if it is the Parser's job to decide
+    //What if col1 and col2 are Array Columns?
     public void testInsertMultiRowValueDifferent() throws JSQLParserException {
         try {
             assertSqlCanBeParsedAndDeparsed("INSERT INTO mytable (col1, col2) VALUES (a, b), (d, e, c)");
@@ -234,8 +253,8 @@ public class InsertTest {
 
     @Test
     public void testInsertWithSelect() throws JSQLParserException {
-        assertSqlCanBeParsedAndDeparsed("INSERT INTO mytable (mycolumn) WITH a AS (SELECT mycolumn FROM mytable) SELECT mycolumn FROM a");
-        assertSqlCanBeParsedAndDeparsed("INSERT INTO mytable (mycolumn) (WITH a AS (SELECT mycolumn FROM mytable) SELECT mycolumn FROM a)");
+        assertSqlCanBeParsedAndDeparsed("INSERT INTO mytable (mycolumn) WITH a AS (SELECT mycolumn FROM mytable) SELECT mycolumn FROM a", true);
+        assertSqlCanBeParsedAndDeparsed("INSERT INTO mytable (mycolumn) (WITH a AS (SELECT mycolumn FROM mytable) SELECT mycolumn FROM a)", true);
     }
 
     @Test
@@ -385,5 +404,47 @@ public class InsertTest {
     @Test
     public void testKeywordDefaultIssue1470() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("INSERT INTO mytable (col1, col2, col3) VALUES (?, 'sadfsd', default)");
+    }
+
+    @Test
+    public void testInsertUnionSelectIssue1491() throws JSQLParserException {
+        //@todo: Make this work
+//        assertSqlCanBeParsedAndDeparsed(
+//                "insert into table1 (tf1,tf2,tf2)\n" +
+//                        "select sf1,sf2,sf3 from s1" +
+//                        "union " +
+//                        "select rf1,rf2,rf2 from r1"
+//                , true
+//        );
+
+        //@todo: Make this work
+//        assertSqlCanBeParsedAndDeparsed(
+//                "insert into table1 (tf1,tf2,tf2)\n" +
+//                        "( select sf1,sf2,sf3 from s1" +
+//                        "union " +
+//                        "select rf1,rf2,rf2 from r1 )"
+//                , true
+//        );
+
+        assertSqlCanBeParsedAndDeparsed(
+                "insert into table1 (tf1,tf2,tf2)\n" +
+                        "(select sf1,sf2,sf3 from s1)" +
+                        "union " +
+                        "(select rf1,rf2,rf2 from r1)"
+                , true
+        );
+
+        assertSqlCanBeParsedAndDeparsed(
+                "insert into table1 (tf1,tf2,tf2)\n" +
+                        "((select sf1,sf2,sf3 from s1)" +
+                        "union " +
+                        "(select rf1,rf2,rf2 from r1))"
+                , true
+        );
+
+        assertSqlCanBeParsedAndDeparsed(
+                "(with a as (select * from dual) select * from a)"
+                , true
+        );
     }
 }

--- a/src/test/java/net/sf/jsqlparser/util/validation/validator/InsertValidatorTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/validation/validator/InsertValidatorTest.java
@@ -28,8 +28,13 @@ public class InsertValidatorTest extends ValidationTestAsserts {
     @Test
     public void testValidationInsertNotAllowed() throws JSQLParserException {
         String sql = "INSERT INTO tab1 (a, b, c) VALUES (5, 'val', ?)";
-        validateNotAllowed(sql, 1, 1, FeaturesAllowed.SELECT.copy().add(FeaturesAllowed.JDBC), Feature.insert,
-                Feature.insertValues);
+        validateNotAllowed(sql, 1, 1, FeaturesAllowed.SELECT.copy().add(FeaturesAllowed.JDBC)
+                , Feature.insertValues
+                , Feature.setOperation
+                , Feature.insertFromSelect
+                , Feature.values
+                , Feature.insert
+        );
     }
 
     @Test


### PR DESCRIPTION
Simplify the INSERT production
Use SetOperations for Select and Values
Better Bracket handling for WITH ... SELECT ...
Fixes #1491

Following statements will work now:
```sql
(
    with a as (select * from dual) 
    select * from a
);

insert into table1 (tf1,tf2,tf2) (   
    (select sf1,sf2,sf3 from s1)
    union (select rf1,rf2,rf2 from r1)
);
```