### PR TITLE
#1516 rename without column keyword

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -5632,13 +5632,9 @@ AlterExpression AlterExpression():
           )
       )
       |
-      (<K_CHANGE>
-        {
-          alterExp.setOperation(AlterOperation.CHANGE);
-        }
-        (
-          <K_COLUMN> { alterExp.hasColumn(true); alterExp.setOptionalSpecifier("COLUMN"); } | {}
-        )
+      (
+        <K_CHANGE> { alterExp.setOperation(AlterOperation.CHANGE); }
+        [ <K_COLUMN> { alterExp.hasColumn(true); alterExp.setOptionalSpecifier("COLUMN"); } ]
         (
           (tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER>)
           alterExpressionColumnDataType = AlterExpressionColumnDataType() {  alterExp.withColumnOldName(tk.image).addColDataType(alterExpressionColumnDataType); }
@@ -5714,7 +5710,7 @@ AlterExpression AlterExpression():
          sk3 = RelObjectName() {alterExp.addParameters(sk3); }
       )
       |
-      LOOKAHEAD(2)  <K_RENAME> <K_COLUMN> { alterExp.setOperation(AlterOperation.RENAME); alterExp.hasColumn(true);}
+      LOOKAHEAD(2)   <K_RENAME> { alterExp.setOperation(AlterOperation.RENAME); } [ <K_COLUMN> {  alterExp.hasColumn(true);} ]
                     ( tk=<S_IDENTIFIER>    | tk=<S_QUOTED_IDENTIFIER> ) { alterExp.setColOldName(tk.image); }
                     <K_TO>
                     (tk2=<S_IDENTIFIER>    | tk2=<S_QUOTED_IDENTIFIER>) { alterExp.setColumnName(tk2.image); }

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -471,6 +471,7 @@ public class AlterTest {
 
     @Test
     public void testAlterTableRenameColumn() throws JSQLParserException {
+        // With Column Keyword
         String sql = "ALTER TABLE \"test_table\" RENAME COLUMN \"test_column\" TO \"test_c\"";
         assertSqlCanBeParsedAndDeparsed(sql);
 
@@ -479,6 +480,10 @@ public class AlterTest {
         assertEquals(expression.getOperation(), AlterOperation.RENAME);
         assertEquals(expression.getColOldName(), "\"test_column\"");
         assertEquals(expression.getColumnName(), "\"test_c\"");
+
+        // Without Column Keyword
+        sql = "ALTER TABLE \"test_table\" RENAME \"test_column\" TO \"test_c\"";
+        assertSqlCanBeParsedAndDeparsed(sql);
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/statement/select/SpeedTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SpeedTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
-@Execution(ExecutionMode.CONCURRENT)
+//@Execution(ExecutionMode.CONCURRENT)
 public class SpeedTest {
 
     private final static int NUM_REPS_500 = 500;

--- a/src/test/java/net/sf/jsqlparser/statement/select/SpeedTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SpeedTest.java
@@ -23,10 +23,7 @@ import net.sf.jsqlparser.statement.simpleparsing.CCJSqlParserManagerTest;
 import net.sf.jsqlparser.test.TestException;
 import net.sf.jsqlparser.util.TablesNamesFinder;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
-//@Execution(ExecutionMode.CONCURRENT)
 public class SpeedTest {
 
     private final static int NUM_REPS_500 = 500;

--- a/src/test/java/net/sf/jsqlparser/statement/select/SpeedTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SpeedTest.java
@@ -23,7 +23,10 @@ import net.sf.jsqlparser.statement.simpleparsing.CCJSqlParserManagerTest;
 import net.sf.jsqlparser.test.TestException;
 import net.sf.jsqlparser.util.TablesNamesFinder;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class SpeedTest {
 
     private final static int NUM_REPS_500 = 500;


### PR DESCRIPTION
`RENAME ... TO ...` without `COLUMN` keyword, e. g.
``` sql
ALTER TABLE tableName RENAME col1 TO col2;
```

Fixes #1516