### PR TITLE
Allow isolation keywords as column name and aliases

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1662,7 +1662,7 @@ String RelObjectNameWithoutValue() :
       | tk=<K_ARRAY_LITERAL>
       | tk=<K_STRING_FUNCTION_NAME>
       | tk=<K_USER>
-      | tk=<K_RECYCLEBIN> | tk=<K_DBA_RECYCLEBIN>
+      | tk=<K_RECYCLEBIN> | tk=<K_DBA_RECYCLEBIN> | tk=<K_ISOLATION>
 
       /* Keywords for ALTER SESSION */
       /* | tk=<K_NAME> */ | tk=<K_TIMEOUT> | tk=<K_PARALLEL>

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -2501,6 +2501,12 @@ public class SelectTest {
     }
 
     @Test
+    public void selectIsolationKeywordsAsAlias() throws JSQLParserException {
+        String stmt = "SELECT col FROM tbl cs";
+        assertSqlCanBeParsedAndDeparsed(stmt);
+    }
+
+    @Test
     public void testMultiValueInBinds() throws JSQLParserException {
         String stmt = "SELECT * FROM mytable WHERE (a, b) IN ((?, ?), (?, ?))";
         assertSqlCanBeParsedAndDeparsed(stmt);


### PR DESCRIPTION
This allows to parse statements such as:
`SELECT col FROM tbl cs`