### PR TITLE
Add support for Hive dialect GROUPING SETS.

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/GroupByElement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/GroupByElement.java
@@ -95,7 +95,14 @@ public class GroupByElement {
             if (groupByExpressions.isUsingBrackets()) {
                 b.append(" )");
             }
-        } else if (groupingSets.size() > 0) {
+        } else if (groupByExpressions.isUsingBrackets()) {
+            b.append("()");
+        }
+
+        if (groupingSets.size() > 0) {
+            if (b.charAt(b.length() - 1) != ' ') {
+                b.append(' ');
+            }
             b.append("GROUPING SETS (");
             boolean first = true;
             for (Object o : groupingSets) {
@@ -112,10 +119,6 @@ public class GroupByElement {
                 }
             }
             b.append(")");
-        } else {
-            if (groupByExpressions.isUsingBrackets()) {
-                b.append("()");
-            }
         }
 
         return b.toString();

--- a/src/main/java/net/sf/jsqlparser/util/deparser/GroupByDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/GroupByDeParser.java
@@ -51,6 +51,9 @@ public class GroupByDeParser extends AbstractDeParser<GroupByElement> {
             buffer.append(" )");
         }
         if (!groupBy.getGroupingSets().isEmpty()) {
+            if (buffer.charAt(buffer.length() - 1) != ' ') {
+                buffer.append(' ');
+            }
             buffer.append("GROUPING SETS (");
             boolean first = true;
             for (Object o : groupBy.getGroupingSets()) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2734,6 +2734,19 @@ GroupByElement GroupByColumnReferences():
     <K_GROUP> <K_BY>
     (     LOOKAHEAD(2) (
               "(" ")" { groupBy.withUsingBrackets(true); }
+              (
+                LOOKAHEAD(2) (
+                  <K_GROUPING> <K_SETS> "("
+                      ( LOOKAHEAD(2) "(" ")" { groupBy.addGroupingSet(new ExpressionList()); }
+                          | LOOKAHEAD(3) "(" list = SimpleExpressionList(true) ")" { groupBy.addGroupingSet(list); }
+                          | expr = SimpleExpression() { groupBy.addGroupingSet(expr); } )
+
+                      ( "," ( LOOKAHEAD(2) "(" ")" { groupBy.addGroupingSet(new ExpressionList()); }
+                          | LOOKAHEAD(3) "(" list = SimpleExpressionList(true) ")" { groupBy.addGroupingSet(list); }
+                          | expr = SimpleExpression() { groupBy.addGroupingSet(expr); } ) )*
+                  ")"
+                )
+              )?
           )
           |
           LOOKAHEAD(2) ( 
@@ -2750,6 +2763,19 @@ GroupByElement GroupByColumnReferences():
           |
           LOOKAHEAD(2) (  
             list = ComplexExpressionList() { groupBy.setGroupByExpressionList(list.withUsingBrackets(false)); }
+            (
+              LOOKAHEAD(2) (
+                <K_GROUPING> <K_SETS> "("
+                    ( LOOKAHEAD(2) "(" ")" { groupBy.addGroupingSet(new ExpressionList()); }
+                        | LOOKAHEAD(3) "(" list = SimpleExpressionList(true) ")" { groupBy.addGroupingSet(list); }
+                        | expr = SimpleExpression() { groupBy.addGroupingSet(expr); } )
+
+                    ( "," ( LOOKAHEAD(2) "(" ")" { groupBy.addGroupingSet(new ExpressionList()); }
+                        | LOOKAHEAD(3) "(" list = SimpleExpressionList(true) ")" { groupBy.addGroupingSet(list); }
+                        | expr = SimpleExpression() { groupBy.addGroupingSet(expr); } ) )*
+                ")"
+              )
+            )?
           )
     )
     {

--- a/src/test/java/net/sf/jsqlparser/statement/select/HiveTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/HiveTest.java
@@ -46,4 +46,24 @@ public class HiveTest {
 
         assertSqlCanBeParsedAndDeparsed(sql, true);
     }
+
+    @Test
+    public void testGroupByGroupingSets() throws Exception {
+        String sql;
+        Statement statement;
+
+        sql = "SELECT\n"
+            + "    C1, C2, C3, MAX(Value)\n"
+            + "FROM\n"
+            + "    Sometable\n"
+            + "GROUP BY C1, C2, C3 GROUPING SETS ((C1, C2), (C1, C2, C3), ())";
+
+        statement = CCJSqlParserUtil.parse(sql);
+
+        System.out.println(statement.toString());
+
+        Select select = (Select) statement;
+        assertStatementCanBeDeparsedAs(select, sql, true);
+        assertSqlCanBeParsedAndDeparsed(sql, true);
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/HiveTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/HiveTest.java
@@ -49,21 +49,11 @@ public class HiveTest {
 
     @Test
     public void testGroupByGroupingSets() throws Exception {
-        String sql;
-        Statement statement;
-
-        sql = "SELECT\n"
+        String sql = "SELECT\n"
             + "    C1, C2, C3, MAX(Value)\n"
             + "FROM\n"
             + "    Sometable\n"
             + "GROUP BY C1, C2, C3 GROUPING SETS ((C1, C2), (C1, C2, C3), ())";
-
-        statement = CCJSqlParserUtil.parse(sql);
-
-        System.out.println(statement.toString());
-
-        Select select = (Select) statement;
-        assertStatementCanBeDeparsedAs(select, sql, true);
         assertSqlCanBeParsedAndDeparsed(sql, true);
     }
 }


### PR DESCRIPTION
[Hive dialect](https://cwiki.apache.org/confluence/display/Hive/Enhanced+Aggregation%2C+Cube%2C+Grouping+and+Rollup#EnhancedAggregation,Cube,GroupingandRollup-GROUPINGSETSclause) requires all columns appear in GROUPING SETS clause to be in GROUP BY clause.

```
SELECT a, b, SUM( c ) FROM tab1 GROUP BY a, b GROUPING SETS ( (a, b), a, b, ( ) )
```