### PR TITLE
add support for postgres drop function statement

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/drop/Drop.java
+++ b/src/main/java/net/sf/jsqlparser/statement/drop/Drop.java
@@ -12,7 +12,9 @@ package net.sf.jsqlparser.statement.drop;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
@@ -24,6 +26,7 @@ public class Drop implements Statement {
     private String type;
     private Table name;
     private List<String> parameters;
+    private Map<String, List<String>> typeToParameters = new HashMap<>();
     private boolean ifExists = false;
 
     @Override
@@ -63,16 +66,39 @@ public class Drop implements Statement {
         this.ifExists = ifExists;
     }
 
+    public Map<String, List<String>> getTypeToParameters() {
+        return typeToParameters;
+    }
+
+    public void setTypeToParameters(Map<String, List<String>> typeToParameters) {
+        this.typeToParameters = typeToParameters;
+    }
+
     @Override
     public String toString() {
         String sql = "DROP " + type + " "
                 + (ifExists ? "IF EXISTS " : "") + name.toString();
+
+        if (type.equals("FUNCTION")) {
+            sql += formatFuncParams(getParamsByType("FUNCTION"));
+        }
 
         if (parameters != null && !parameters.isEmpty()) {
             sql += " " + PlainSelect.getStringList(parameters);
         }
 
         return sql;
+    }
+
+    public static String formatFuncParams(List<String> params) {
+        if (params == null) {
+            return "";
+        }
+        return params.isEmpty() ? "()" : PlainSelect.getStringList(params, true, true);
+    }
+
+    public List<String> getParamsByType(String type) {
+        return typeToParameters.get(type);
     }
 
     public Drop withIfExists(boolean ifExists) {

--- a/src/main/java/net/sf/jsqlparser/util/deparser/DropDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/DropDeParser.java
@@ -28,6 +28,10 @@ public class DropDeParser extends AbstractDeParser<Drop> {
 
         buffer.append(" ").append(drop.getName());
 
+        if (drop.getType().equals("FUNCTION")) {
+            buffer.append(Drop.formatFuncParams(drop.getParamsByType("FUNCTION")));
+        }
+
         if (drop.getParameters() != null && !drop.getParameters().isEmpty()) {
             buffer.append(" ").append(PlainSelect.getStringList(drop.getParameters()));
         }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -5396,12 +5396,55 @@ List<String> ColumnsNamesList():
     }
 }
 
+String FuncArgsListItem():
+{
+	Token tk = null;
+    String argName = null;
+    String argType = null;
+}
+{
+    (
+        LOOKAHEAD(2) (
+            argName = RelObjectName()
+            argType = RelObjectName()
+            [ "(" tk = <S_LONG>  ")" { argType = argType + "(" + tk.image + ")"; } ]
+        )
+        |
+        (
+            argType = RelObjectName()
+            [ "(" tk = <S_LONG>  ")" { argType = argType + "(" + tk.image + ")"; } ]
+        )
+    )
+	{
+	    return argName != null ? String.format("%s %s", argName, argType) : argType;
+	}
+}
+
+List<String> FuncArgsList():
+{
+    List<String> retval = null;
+    String img = null;
+}
+{
+    "("
+         { retval = new ArrayList<String>(); }
+         [
+            img=FuncArgsListItem() { retval.add(img); }
+            ( "," img=FuncArgsListItem() { retval.add(img); } )*
+         ]
+    ")"
+    {
+        return retval;
+    }
+}
+
 Drop Drop():
 {
     Drop drop = new Drop();
     Token tk = null;
     Table name;
     List<String> dropArgs = new ArrayList<String>();
+    List<String> funcArgs = null;
 }
 {
     <K_DROP>
@@ -5417,17 +5460,25 @@ Drop Drop():
         tk=<K_SCHEMA>
         |
         tk=<K_SEQUENCE>
+        |
+        tk=<K_FUNCTION>
     )
     { drop.setType(tk.image); }
 
     [ LOOKAHEAD(2) <K_IF> <K_EXISTS> {drop.setIfExists(true);} ]
 
     name = Table() { drop.setName(name); }
+    [ funcArgs = FuncArgsList() ]
     ((tk=<S_IDENTIFIER> | tk=<K_CASCADE> | tk=<K_RESTRICT> ) { dropArgs.add(tk.image); })*
 
     {
-        if (dropArgs.size() > 0)
+        if (dropArgs.size() > 0) {
             drop.setParameters(dropArgs);
+        }
+        if (drop.getType().equals("FUNCTION")) {
+            drop.getTypeToParameters().put("FUNCTION", funcArgs);
+        }
+
         return drop;
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/drop/DropTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/drop/DropTest.java
@@ -97,4 +97,29 @@ public class DropTest {
         //assertSqlCanBeParsedAndDeparsed("ALTER TABLE foo DROP (bar, baz)");
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE foo DROP (bar, baz) CASCADE");
     }
+
+    @Test
+    public void testUniqueFunctionDrop() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("DROP FUNCTION myFunc");
+    }
+
+    @Test
+    public void testZeroArgDropFunction() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("DROP FUNCTION myFunc()");
+    }
+
+    @Test
+    public void testDropFunctionWithSimpleType() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("DROP FUNCTION myFunc(integer, varchar)");
+    }
+
+    @Test
+    public void testDropFunctionWithNameAndType() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("DROP FUNCTION myFunc(amount integer, name varchar)");
+    }
+
+    @Test
+    public void testDropFunctionWithNameAndParameterizedType() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("DROP FUNCTION myFunc(amount integer, name varchar(255))");
+    }
 }


### PR DESCRIPTION
Adds a support for PostgreSQL DROP FUNCTION statement: [PostgreSQL DROP FUNCTION documentation](https://www.postgresql.org/docs/current/sql-dropfunction.html)

Also added a new map to Drop class to store parameters by type. Not sure about other drop types, but drop function actually has a more richer syntax with additional parameters which we could support in the future. Storing them in a map could possibly hold off bloating the class.