### PR TITLE
Postgres NATURAL LEFT/RIGHT joins

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Additionally, we have fixed many errors and improved the code quality and the te
 * Add support for `... ALTER COLUMN ... DROP DEFAULT`
 * `INSERT` supports `SetOperations` (e. g. `INSERT INTO ... SELECT ... FROM ... UNION SELECT ... FROM ...`), those `SetOperations` are used both for `SELECT` and `VALUES` clauses (API change) in order to simplify the Grammar
 * `(WITH ... SELECT ...)` statements within brackets are now supported
+* Postgres `NATURAL { INNER | LEFT | RIGHT } JOIN` support
 
 
 ## Building from the sources

--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -304,10 +304,12 @@ public class Join extends ASTNodeAccessImpl {
         } else if (isSimple()) {
             builder.append(rightItem);
         } else {
+            if (isNatural()) {
+                builder.append("NATURAL ");
+            }
+
             if (isRight()) {
                 builder.append("RIGHT ");
-            } else if (isNatural()) {
-                builder.append("NATURAL ");
             } else if (isFull()) {
                 builder.append("FULL ");
             } else if (isLeft()) {

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -401,10 +401,12 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
             buffer.append(", ");
         } else {
 
+            if (join.isNatural()) {
+                buffer.append(" NATURAL");
+            }
+
             if (join.isRight()) {
                 buffer.append(" RIGHT");
-            } else if (join.isNatural()) {
-                buffer.append(" NATURAL");
             } else if (join.isFull()) {
                 buffer.append(" FULL");
             } else if (join.isLeft()) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2579,24 +2579,37 @@ Join JoinerExpression() #JoinerExpression:
 
 }
 {
-
+    [ <K_NATURAL> { join.setNatural(true); } ]
 
     [
-          <K_LEFT> { join.setLeft(true); } [ <K_SEMI> { join.setSemi(true); } | <K_OUTER> { join.setOuter(true); } ]
-          |  ( <K_RIGHT> { join.setRight(true); }
-             | <K_FULL> { join.setFull(true); }
-           ) [ <K_OUTER> { join.setOuter(true); } ]
-        | <K_INNER> { join.setInner(true); }
-        | <K_NATURAL> { join.setNatural(true); }
-        | <K_CROSS> { join.setCross(true); }
-        | <K_OUTER> { join.setOuter(true); }
+        (
+            <K_LEFT> { join.setLeft(true); } [ <K_SEMI> { join.setSemi(true); } | <K_OUTER> { join.setOuter(true); } ]
+            |
+            (
+                <K_RIGHT> { join.setRight(true); }
+                |
+                <K_FULL> { join.setFull(true); }
+            ) [ <K_OUTER> { join.setOuter(true); } ]
+            |
+            <K_INNER> { join.setInner(true); }
+        )
+        |
+        <K_CROSS> { join.setCross(true); }
+        |
+        <K_OUTER> { join.setOuter(true); }
     ]
 
-          ( <K_JOIN> | "," { join.setSimple(true); } (<K_OUTER> { join.setOuter(true); } )?
-           | <K_STRAIGHT> { join.setStraight(true); } | <K_APPLY> {join.setApply(true); } )
+    (
+        <K_JOIN>
+        |
+        "," { join.setSimple(true); } (<K_OUTER> { join.setOuter(true); } )?
+        |
+        <K_STRAIGHT> { join.setStraight(true); }
+        |
+        <K_APPLY> {join.setApply(true); }
+    )
 
-        right=FromItem()
-
+    right=FromItem()
 
     [
         LOOKAHEAD(2) (

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -5213,4 +5213,17 @@ public class SelectTest {
     public void testMissingLimitIssue1505() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("(SELECT * FROM mytable) LIMIT 1");
     }
+
+    @Test
+    public void testPostgresNaturalJoinIssue1559() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "SELECT t1.ID,t1.name, t2.DID, t2.name\n" +
+                "FROM table1 as t1\n" +
+                "NATURAL RIGHT JOIN table2 as t2", true);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "SELECT t1.ID,t1.name, t2.DID, t2.name\n" +
+                        "FROM table1 as t1\n" +
+                        "NATURAL RIGHT JOIN table2 as t2", true);
+    }
 }

--- a/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/join21.sql
+++ b/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/join21.sql
@@ -11,3 +11,4 @@ select * from sys.dual natural join sys.dual
 
 
 --@SUCCESSFULLY_PARSED_AND_DEPARSED first on Aug 3, 2021, 7:20:08 AM
+--@FAILURE: Encountered unexpected token: "natural" "NATURAL" recorded first on 9 Jun 2022, 21:50:07

--- a/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/join21.sql
+++ b/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/join21.sql
@@ -11,4 +11,3 @@ select * from sys.dual natural join sys.dual
 
 
 --@SUCCESSFULLY_PARSED_AND_DEPARSED first on Aug 3, 2021, 7:20:08 AM
---@FAILURE: Encountered unexpected token: "natural" "NATURAL" recorded first on 9 Jun 2022, 21:50:07


### PR DESCRIPTION
Fixes #1559
Make NATURAL an optional Join Keyword, which can be combined with LEFT, RIGHT, INNER
Add tests