### PR TITLE
Configurable Parser Timeout via Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Additionally, we have fixed many errors and improved the code quality and the te
 * support table option **character set** and **index** options
 * support Postgresql optional **TABLE** in **TRUNCATE**
 * support for `ANALYZE mytable`
+* Implement Parser Timeout Feature, e. g. `CCJSqlParserUtil.parse(sqlStr, parser -> parser.withTimeOut(60000));`
 
 
 ## Building from the sources

--- a/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
+++ b/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
@@ -32,9 +32,18 @@ public abstract class AbstractJSqlParser<P> {
     public P withUnsupportedStatements(boolean allowUnsupportedStatements) {
         return withFeature(Feature.allowUnsupportedStatements, allowUnsupportedStatements);
     }
+
+    public P withTimeOut(int timeOutMillSeconds) {
+        return withFeature(Feature.timeOut, timeOutMillSeconds);
+    }
     
     public P withFeature(Feature f, boolean enabled) {
         getConfiguration().setValue(f, enabled);
+        return me();
+    }
+
+    public P withFeature(Feature f, int value) {
+        getConfiguration().setValue(f, value);
         return me();
     }
 
@@ -44,6 +53,10 @@ public abstract class AbstractJSqlParser<P> {
 
     public boolean getAsBoolean(Feature f) {
         return getConfiguration().getAsBoolean(f);
+    }
+
+    public Integer getAsInteger(Feature f) {
+        return getConfiguration().getAsInteger(f);
     }
 
     public void setErrorRecovery(boolean errorRecovery) {

--- a/src/main/java/net/sf/jsqlparser/parser/CCJSqlParserUtil.java
+++ b/src/main/java/net/sf/jsqlparser/parser/CCJSqlParserUtil.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.Statements;
 
@@ -33,7 +34,6 @@ import net.sf.jsqlparser.statement.Statements;
 @SuppressWarnings("PMD.CyclomaticComplexity")
 public final class CCJSqlParserUtil {
     public final static int ALLOWED_NESTING_DEPTH = 10;
-    public static final int PARSER_TIMEOUT = 6000;
 
     private CCJSqlParserUtil() {
     }
@@ -255,7 +255,7 @@ public final class CCJSqlParserUtil {
             });
             executorService.shutdown();
 
-            statement = future.get(PARSER_TIMEOUT, TimeUnit.MILLISECONDS);
+            statement = future.get( parser.getConfiguration().getAsInteger(Feature.timeOut), TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {
             parser.interrupted = true;
             throw new JSQLParserException("Time out occurred.", ex);
@@ -319,7 +319,7 @@ public final class CCJSqlParserUtil {
             });
             executorService.shutdown();
 
-            statements = future.get(PARSER_TIMEOUT, TimeUnit.MILLISECONDS);
+            statements = future.get( parser.getConfiguration().getAsInteger(Feature.timeOut) , TimeUnit.MILLISECONDS);
         } catch (TimeoutException ex) {
             parser.interrupted = true;
             throw new JSQLParserException("Time out occurred.", ex);

--- a/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
+++ b/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
@@ -741,6 +741,8 @@ public enum Feature {
      * needs to be switched off, when VALIDATING statements or parsing blocks
      */
     allowUnsupportedStatements(false),
+
+    timeOut( 6000)
     ;
 
     private Object value;

--- a/src/main/java/net/sf/jsqlparser/parser/feature/FeatureConfiguration.java
+++ b/src/main/java/net/sf/jsqlparser/parser/feature/FeatureConfiguration.java
@@ -58,7 +58,11 @@ public class FeatureConfiguration {
     }
 
     public boolean getAsBoolean(Feature f) {
-        return Boolean.valueOf(String.valueOf(getValue(f)));
+        return Boolean.parseBoolean(String.valueOf(getValue(f)));
+    }
+
+    public Integer getAsInteger(Feature f) {
+        return Integer.valueOf(String.valueOf(getValue(f)));
     }
 
     public String getAsString(Feature f) {

--- a/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
@@ -29,7 +29,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;

--- a/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
@@ -14,6 +14,8 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeoutException;
+
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.LongValue;
@@ -27,8 +29,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class CCJSqlParserUtilTest {
 
@@ -269,5 +273,61 @@ public class CCJSqlParserUtilTest {
     public void testCondExpressionIssue1482_2() throws JSQLParserException {
         Expression expr = CCJSqlParserUtil.parseCondExpression("test_table_enum.f1_enum IN ('TEST2'::test.\"test_enum\")", false);
         assertEquals("test_table_enum.f1_enum IN ('TEST2'::test.\"test_enum\")", expr.toString());
+    }
+
+    @Test
+    public void testTimeOutIssue1582() throws InterruptedException {
+        // This statement is INVALID on purpose
+        // There are crafted INTO keywords in order to make it fail but only after a long time (40 seconds plus)
+
+        String sqlStr = "" +
+                "select\n" +
+                "              t0.operatienr\n" +
+                "            , case\n" +
+                "                when\n" +
+                "                    case when (t0.vc_begintijd_operatie is null or lpad((extract('hours' into t0.vc_begintijd_operatie::timestamp))::text,2,'0') ||':'|| lpad(extract('minutes' from t0.vc_begintijd_operatie::timestamp)::text,2,'0') = '00:00') then null\n" +
+                "                         else (greatest(((extract('hours' into (t0.vc_eindtijd_operatie::timestamp-t0.vc_begintijd_operatie::timestamp))*60 + extract('minutes' from (t0.vc_eindtijd_operatie::timestamp-t0.vc_begintijd_operatie::timestamp)))/60)::numeric(12,2),0))*60\n" +
+                "                end = 0 then null\n" +
+                "                    else '25. Meer dan 4 uur'\n" +
+                "                end                                                                                                                                                  \n" +
+                "              as snijtijd_interval";
+
+        // With DEFAULT TIMEOUT 6 Seconds, we expect the statement to timeout normally
+        // A TimeoutException wrapped into a Parser Exception should be thrown
+
+        Assertions.assertThrows(TimeoutException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                try {
+                    CCJSqlParserUtil.parse(sqlStr);
+                } catch (JSQLParserException ex) {
+                    Throwable cause = ((JSQLParserException) ex).getCause();
+                    if (cause!=null) {
+                        throw cause;
+                    } else {
+                        throw ex;
+                    }
+                }
+            }
+        });
+
+        // With custom TIMEOUT 60 Seconds, we expect the statement to not timeout but to fail instead
+        // No TimeoutException wrapped into a Parser Exception must be thrown
+        // Instead we expect a Parser Exception only
+        Assertions.assertThrows(JSQLParserException.class, new Executable() {
+            @Override
+            public void execute() throws Throwable {
+                try {
+                    CCJSqlParserUtil.parse(sqlStr, parser -> parser.withTimeOut(60000));
+                } catch (JSQLParserException ex) {
+                    Throwable cause = ((JSQLParserException) ex).getCause();
+                    if (cause instanceof TimeoutException) {
+                        throw cause;
+                    } else {
+                        throw ex;
+                    }
+                }
+            }
+        });
     }
 }

--- a/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
@@ -295,7 +295,7 @@ public class CCJSqlParserUtilTest {
         // With DEFAULT TIMEOUT 6 Seconds, we expect the statement to timeout normally
         // A TimeoutException wrapped into a Parser Exception should be thrown
 
-        Assertions.assertThrows(TimeoutException.class, new Executable() {
+        assertThrows(TimeoutException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 try {
@@ -314,7 +314,7 @@ public class CCJSqlParserUtilTest {
         // With custom TIMEOUT 60 Seconds, we expect the statement to not timeout but to fail instead
         // No TimeoutException wrapped into a Parser Exception must be thrown
         // Instead we expect a Parser Exception only
-        Assertions.assertThrows(JSQLParserException.class, new Executable() {
+        assertThrows(JSQLParserException.class, new Executable() {
             @Override
             public void execute() throws Throwable {
                 try {


### PR DESCRIPTION
Fixes #1582
Implement Parser Timeout Feature, e. g. `CCJSqlParserUtil.parse(sqlStr, parser -> parser.withTimeOut(60000));`
Add a special test failing after a long time only, to test TimeOut vs. Parser Exception