### PR TITLE
add support for drop column if exists

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -412,6 +412,9 @@ public class AlterExpression {
           if (hasColumn) {
             b.append("COLUMN ");
           }
+          if (usingIfExists) {
+            b.append("IF EXISTS ");
+          }
           if (operation == AlterOperation.RENAME) {
             b.append(columnOldName).append(" TO ");
           }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -5861,6 +5861,7 @@ AlterExpression AlterExpression():
                 |
                 (
                     ( LOOKAHEAD(2) <K_COLUMN> { alterExp.hasColumn(true); } )?
+                    [<K_IF> <K_EXISTS> { alterExp.setUsingIfExists(true); } ]
                     (tk=<S_IDENTIFIER>    | tk=<S_QUOTED_IDENTIFIER>) { alterExp.setColumnName(tk.image); }
 
                     [ "INVALIDATE" { alterExp.addParameters("INVALIDATE"); } ]

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -789,4 +789,18 @@ public class AlterTest {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE a MODIFY (COLUMN b DROP DEFAULT, COLUMN b DROP NOT NULL)", true);
     }
 
+    @Test
+    public void testAlterTableDropColumnIfExists() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE test DROP COLUMN IF EXISTS name");
+    }
+
+    @Test
+    public void testAlterTableDropMultipleColumnsIfExists() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE test DROP COLUMN IF EXISTS name, DROP COLUMN IF EXISTS surname");
+    }
+
+    @Test
+    public void testAlterTableDropMultipleColumnsIfExistsWithParams() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE test DROP COLUMN IF EXISTS name CASCADE, DROP COLUMN IF EXISTS surname CASCADE");
+    }
 }


### PR DESCRIPTION
Adds support for "IF EXISTS" command in DROP COLUMN statement for PostgreSQL ([alter table docs](https://www.postgresql.org/docs/9.0/sql-altertable.html)).