### PR TITLE
fix Issues: #1524  support hive alter sql : ALTER TABLE name ADD COLUMNS (col type,col2 type.....)

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -65,8 +65,19 @@ public class AlterExpression {
 
   private boolean hasColumn = false;
 
+
+  private  boolean useBrackets=false;
+
   public boolean hasColumn() {
     return hasColumn;
+  }
+
+  public boolean useBrackets() {
+    return useBrackets;
+  }
+
+  public void useBrackets(boolean useBrackets) {
+    this.useBrackets = useBrackets;
   }
 
   public void hasColumn(boolean hasColumn) {
@@ -382,7 +393,7 @@ public class AlterExpression {
   public String toString() {
 
     StringBuilder b = new StringBuilder();
-    
+
     if (operation== AlterOperation.UNSPECIFIC) {
         b.append(optionalSpecifier);
     } else if (operation== AlterOperation.RENAME_TABLE) {
@@ -432,7 +443,13 @@ public class AlterExpression {
               b.append("COLUMN ");
             }
           }
+          if (useBrackets && colDataTypeList.size() == 1){
+            b.append(" ( ");
+          }
           b.append(PlainSelect.getStringList(colDataTypeList));
+          if (useBrackets && colDataTypeList.size() == 1 ){
+            b.append(" ) ");
+          }
           if (colDataTypeList.size() > 1) {
             b.append(")");
           }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -5864,6 +5864,20 @@ AlterExpression AlterExpression():
                             alterExp.addColDropNotNull( alterExpressionColumnDropNotNull);
                          }
                     |
+                    LOOKAHEAD(4) "("
+                                   (  alterExpressionColumnDataType = AlterExpressionColumnDataType() {
+                                        if (alterExp.getOperation()== AlterOperation.ADD ){
+                                           alterExp.addColDataType(alterExpressionColumnDataType);
+                                       } else if(alterExp.getOperation()== AlterOperation.ALTER){
+                                            error_skipto(K_ALTER);
+                                       }else if(alterExp.getOperation()== AlterOperation.MODIFY){
+                                            error_skipto(K_MODIFY);
+                                       }
+                                    }
+                                      (LOOKAHEAD(2) "," alterExpressionColumnDataType = AlterExpressionColumnDataType() { alterExp.addColDataType(alterExpressionColumnDataType); }) *
+                                    )
+                              ")" {alterExp.useBrackets(true);}
+                    |
                     alterExpressionColumnDropDefault = AlterExpressionColumnDropDefault() {
                             alterExp.addColDropDefault( alterExpressionColumnDropDefault);
                          }

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -65,6 +65,21 @@ public class AlterTest {
         assertEquals("varchar (255)", colDataTypes.get(0).getColDataType().toString());
     }
 
+
+    @Test
+    public  void  testAlterTableBackBrackets()throws JSQLParserException{
+        String sql="ALTER TABLE tablename add column (field  string comment 'aaaaa')";
+        Statement statement = CCJSqlParserUtil.parse(sql);
+        Alter alter=(Alter) statement;
+        System.out.println(alter.toString());
+
+        String sql2="ALTER TABLE tablename add column (field  string comment 'aaaaa', field2 string comment 'bbbbb');";
+        Statement statement2 = CCJSqlParserUtil.parse(sql2);
+        Alter alter2=(Alter) statement2;
+        System.out.println(alter2.toString());
+    }
+
+
     @Test
     public void testAlterTablePrimaryKey() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE animals ADD PRIMARY KEY (id)");


### PR DESCRIPTION
support hive alter sql : ALTER TABLE name ADD COLUMNS (col type,col2 type.....)
example :
``` sql
   ALTER TABLE tablename add column (col  string comment 'aaaaa');
   ALTER TABLE tablename add column (col  string comment 'aaaaa', col2 string comment 'bbbbb');
```