### PR TITLE
Support timestamptz dateliteral

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/DateTimeLiteralExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/DateTimeLiteralExpression.java
@@ -53,6 +53,6 @@ public class DateTimeLiteralExpression extends ASTNodeAccessImpl implements Expr
     }
 
     public enum DateTime {
-        DATE, TIME, TIMESTAMP;
+        DATE, TIME, TIMESTAMP, TIMESTAMPTZ;
     }
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -182,7 +182,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_CYCLE:"CYCLE">
 |   <K_DATABASE:"DATABASE">
 |   <K_DECLARE: "DECLARE">
-|   <K_DATETIMELITERAL : ("DATE" | "TIME" | "TIMESTAMP") >
+|   <K_DATETIMELITERAL : ("DATE" | "TIME" | "TIMESTAMP" | "TIMESTAMPTZ") >
 |   <K_DATE_LITERAL : ( "YEAR" | "MONTH" | "DAY" | "HOUR" | "MINUTE" | "SECOND" ) >
 |   <K_DBA_RECYCLEBIN: "DBA_RECYCLEBIN">
 |   <K_DEFAULT : "DEFAULT">

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -5242,4 +5242,9 @@ public class SelectTest {
     public void testNamedWindowDefinitionIssue1581_2() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT sum(salary) OVER w1, avg(salary) OVER w2 FROM empsalary WINDOW w1 AS (PARTITION BY depname ORDER BY salary DESC), w2 AS (PARTITION BY depname2 ORDER BY salary2)");
     }
+
+    @Test
+    public void testTimestampzzDateTimeLiteral() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT * FROM table WHERE x >= TIMESTAMPTZ '2021-07-05 00:00:00+00'");
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -5244,7 +5244,7 @@ public class SelectTest {
     }
 
     @Test
-    public void testTimestampzzDateTimeLiteral() throws JSQLParserException {
+    public void testTimestamptzDateTimeLiteral() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("SELECT * FROM table WHERE x >= TIMESTAMPTZ '2021-07-05 00:00:00+00'");
     }
 }


### PR DESCRIPTION
Closes https://github.com/JSQLParser/JSqlParser/issues/1619

This add support for the `timestamptz` date time literal found in postgres derivative SQL. It's a commonly used abbreviation for the equivalent standard sql of `TIMESTAMP WITH TIME ZONE`