### PR TITLE
Support for SKIP LOCKED tokens on SELECT FOR UPDATE statements

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
+++ b/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
@@ -261,6 +261,10 @@ public enum Feature {
      * "FOR UPDATE NOWAIT"
      */
     selectForUpdateNoWait,
+    /**
+     * "FOR UPDATE SKIP LOCKED"
+     */
+    selectForUpdateSkipLocked,
 
 
     /**

--- a/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
@@ -48,6 +48,7 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
     private boolean oracleSiblings = false;
     private boolean forUpdate = false;
     private Table forUpdateTable = null;
+    private boolean skipLocked;
     private boolean useBrackets = false;
     private Wait wait;
     private boolean mySqlSqlCalcFoundRows = false;
@@ -349,6 +350,14 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
         this.windowDefinitions = windowDefinitions;
     }
 
+    public boolean isSkipLocked() {
+        return skipLocked;
+    }
+
+    public void setSkipLocked(boolean skipLocked) {
+        this.skipLocked = skipLocked;
+    }
+
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.ExcessiveMethodLength", "PMD.NPathComplexity"})
     public String toString() {
@@ -464,6 +473,8 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
 
                 if (isNoWait()) {
                     sql.append(" NOWAIT");
+                } else if (isSkipLocked()) {
+                    sql.append(" SKIP LOCKED");
                 }
             }
             if (optimizeFor != null) {
@@ -717,6 +728,11 @@ public class PlainSelect extends ASTNodeAccessImpl implements SelectBody {
 
     public PlainSelect withNoWait(boolean noWait) {
         this.setNoWait(noWait);
+        return this;
+    }
+
+    public PlainSelect withSkipLocked(boolean skipLocked) {
+        this.setSkipLocked(skipLocked);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -217,6 +217,8 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
             }
             if (plainSelect.isNoWait()) {
                 buffer.append(" NOWAIT");
+            } else if (plainSelect.isSkipLocked()) {
+                buffer.append(" SKIP LOCKED");
             }
         }
         if (plainSelect.getOptimizeFor() != null) {

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/MariaDbVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/MariaDbVersion.java
@@ -35,7 +35,10 @@ public enum MariaDbVersion implements Version {
                     Feature.selectHaving,
                     Feature.limit, Feature.limitOffset, Feature.offset, Feature.offsetParam,
                     Feature.orderBy,
-                    Feature.selectForUpdate, Feature.selectForUpdateWait, Feature.selectForUpdateNoWait,
+                    Feature.selectForUpdate,
+                    Feature.selectForUpdateWait,
+                    Feature.selectForUpdateNoWait,
+                    Feature.selectForUpdateSkipLocked,
 
                     // https://mariadb.com/kb/en/join-syntax/
                     Feature.join, Feature.joinSimple, Feature.joinRight, Feature.joinNatural, Feature.joinLeft,

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/MySqlVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/MySqlVersion.java
@@ -33,7 +33,10 @@ public enum MySqlVersion implements Version {
                     Feature.select,
                     Feature.selectGroupBy, Feature.selectHaving,
                     Feature.limit, Feature.limitOffset, Feature.offset, Feature.offsetParam, Feature.orderBy,
-                    Feature.selectForUpdate, Feature.selectForUpdateOfTable, Feature.selectForUpdateNoWait,
+                    Feature.selectForUpdate,
+                    Feature.selectForUpdateOfTable,
+                    Feature.selectForUpdateNoWait,
+                    Feature.selectForUpdateSkipLocked,
                     Feature.distinct,
 
                     Feature.setOperation,

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/OracleVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/OracleVersion.java
@@ -83,7 +83,9 @@ public enum OracleVersion implements Version {
                     // https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/SELECT.html
                     // see "for_update_clause"
                     Feature.selectForUpdate,
-                    Feature.selectForUpdateWait, Feature.selectForUpdateNoWait,
+                    Feature.selectForUpdateWait,
+                    Feature.selectForUpdateNoWait,
+                    Feature.selectForUpdateSkipLocked,
 
                     // https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/INSERT.html
                     Feature.insert,

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/PostgresqlVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/PostgresqlVersion.java
@@ -76,6 +76,7 @@ public enum PostgresqlVersion implements Version {
                     Feature.selectForUpdate,
                     Feature.selectForUpdateOfTable,
                     Feature.selectForUpdateNoWait,
+                    Feature.selectForUpdateSkipLocked,
 
                     // https://www.postgresql.org/docs/current/queries-union.html
                     Feature.setOperation,

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/SelectValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/SelectValidator.java
@@ -86,6 +86,7 @@ public class SelectValidator extends AbstractValidator<SelectItem>
                 validateOptionalFeature(c, plainSelect.getForUpdateTable(), Feature.selectForUpdateOfTable);
                 validateOptionalFeature(c, plainSelect.getWait(), Feature.selectForUpdateWait);
                 validateFeature(c, plainSelect.isNoWait(), Feature.selectForUpdateNoWait);
+                validateFeature(c, plainSelect.isSkipLocked(), Feature.selectForUpdateSkipLocked);
             }
 
             validateOptionalFeature(c, plainSelect.getForXmlPath(), Feature.selectForXmlPath);

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -274,6 +274,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_LIKE:"LIKE">
 |   <K_LIMIT:"LIMIT">
 |   <K_LOCAL:"LOCAL">
+|   <K_LOCKED:"LOCKED">
 |   <K_LINK:"LINK">
 |   <K_LOG:"LOG">
 |   <K_LOW_PRIORITY : "LOW_PRIORITY">
@@ -2076,7 +2077,8 @@ PlainSelect PlainSelect() #PlainSelect:
     [LOOKAHEAD(2) <K_FOR> <K_UPDATE> { plainSelect.setForUpdate(true); }
         [ <K_OF> updateTable = Table() { plainSelect.setForUpdateTable(updateTable); } ]
         [ LOOKAHEAD(<K_WAIT>) wait = Wait() { plainSelect.setWait(wait); } ]
-        [ <K_NOWAIT> { plainSelect.setNoWait(true); } ] ]
+        [ <K_NOWAIT> { plainSelect.setNoWait(true); }
+           | <K_SKIP> <K_LOCKED> { plainSelect.setSkipLocked(true); } ] ]
 
     [LOOKAHEAD(<K_OPTIMIZE>) optimize = OptimizeFor() { plainSelect.setOptimizeFor(optimize); } ]
 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -5265,4 +5265,37 @@ public class SelectTest {
         assertEquals("tablename", table.getName());
         assertEquals("dblink", table.getDBLinkName());
     }
+
+    @Test
+    public void testSelectStatementWithForUpdateAndSkipLockedTokens() throws JSQLParserException {
+        String sql = "SELECT * FROM test FOR UPDATE SKIP LOCKED";
+        assertSqlCanBeParsedAndDeparsed(sql);
+
+        Select select = (Select) CCJSqlParserUtil.parse(sql);
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertTrue(plainSelect.isForUpdate());
+        assertTrue(plainSelect.isSkipLocked());
+    }
+
+    @Test
+    public void testSelectStatementWithForUpdateButWithoutSkipLockedTokens() throws JSQLParserException {
+        String sql = "SELECT * FROM test FOR UPDATE";
+        assertSqlCanBeParsedAndDeparsed(sql);
+
+        Select select = (Select) CCJSqlParserUtil.parse(sql);
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertTrue(plainSelect.isForUpdate());
+        assertFalse(plainSelect.isSkipLocked());
+    }
+
+    @Test
+    public void testSelectStatementWithoutForUpdateAndSkipLockedTokens() throws JSQLParserException {
+        String sql = "SELECT * FROM test";
+        assertSqlCanBeParsedAndDeparsed(sql);
+
+        Select select = (Select) CCJSqlParserUtil.parse(sql);
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertFalse(plainSelect.isForUpdate());
+        assertFalse(plainSelect.isSkipLocked());
+    }
 }

--- a/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/for_update06.sql
+++ b/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/for_update06.sql
@@ -12,3 +12,4 @@ select employee_id from (select employee_id+1 as employee_id from employees)
 
 
 --@FAILURE: Encountered unexpected token: "skip" "SKIP" recorded first on Aug 3, 2021, 7:20:08 AM
+--@SUCCESSFULLY_PARSED_AND_DEPARSED first on Oct 19, 2022, 6:34:12 PM


### PR DESCRIPTION
This PR solves #1610 by adding the support to parse SKIP LOCKED tokens on SELECT FOR UPDATE statements