### PR TITLE
add support for index hints in Update statement for MySQL

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1203,7 +1203,7 @@ Update Update( List<WithItem> with ):
    <K_UPDATE> { update.setOracleHint(getOracleHint()); }
     [ LOOKAHEAD(2) <K_LOW_PRIORITY> { modifierPriority = UpdateModifierPriority.LOW_PRIORITY; }]
     [ LOOKAHEAD(2) <K_IGNORE> { modifierIgnore = true; }]
-    table=TableWithAlias() startJoins=JoinsList()
+    table=TableWithAliasAndMysqlIndexHint() startJoins=JoinsList()
     <K_SET>
     (
         LOOKAHEAD(3) tableColumn=Column() "=" valueExpression=SimpleExpression() { update.addUpdateSet(tableColumn, valueExpression); }
@@ -1911,6 +1911,17 @@ Table TableWithAlias():
 }
 {
     table=Table() [ LOOKAHEAD(2) alias=Alias() { table.setAlias(alias); }]
+    { return table; }
+}
+
+Table TableWithAliasAndMysqlIndexHint():
+{
+    Table table = null;
+    Alias alias = null;
+    MySQLIndexHint indexHint = null;
+}
+{
+    table=Table() [alias=Alias() { table.setAlias(alias); }] [indexHint=MySQLIndexHint() {table.setHint(indexHint);}]
     { return table; }
 }
 

--- a/src/test/java/net/sf/jsqlparser/statement/update/UpdateTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/update/UpdateTest.java
@@ -178,6 +178,11 @@ public class UpdateTest {
     }
 
     @Test
+    public void testMysqlHint() throws JSQLParserException {
+        assertUpdateMysqlHintExists("UPDATE demo FORCE INDEX (idx_demo) SET col1 = NULL WHERE col2 = 1", true, "FORCE", "INDEX", "idx_demo");
+    }
+
+    @Test
     public void testWith() throws JSQLParserException {
         String statement
                 = ""

--- a/src/test/java/net/sf/jsqlparser/test/TestUtils.java
+++ b/src/test/java/net/sf/jsqlparser/test/TestUtils.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.MySQLIndexHint;
 import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.parser.CCJSqlParser;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
@@ -37,10 +38,10 @@ import net.sf.jsqlparser.util.deparser.StatementDeParser;
 import org.apache.commons.lang3.builder.MultilineRecursiveToStringStyle;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  *
@@ -341,5 +342,20 @@ public class TestUtils {
             assertNotNull(hint);
             assertEquals(hints[0], hint.getValue());
         }
+    }
+
+    public static void assertUpdateMysqlHintExists(String sql, boolean assertDeparser, String action, String qualifier, String... indexNames)
+            throws JSQLParserException {
+        if (assertDeparser) {
+            assertSqlCanBeParsedAndDeparsed(sql, true);
+        }
+        Statement statement = CCJSqlParserUtil.parse(sql);
+        assertInstanceOf(Update.class, statement);
+        Update updateStmt = (Update) statement;
+        final MySQLIndexHint indexHint = updateStmt.getTable().getIndexHint();
+        assertNotNull(indexHint);
+        assertEquals(indexHint.getAction(), action);
+        assertEquals(indexHint.getIndexQualifier(), qualifier);
+        assertArrayEquals(indexHint.getIndexNames().toArray(), indexNames);
     }
 }


### PR DESCRIPTION
- add support for index hints in update statment for mysql

- Documentation: 
https://dev.mysql.com/doc/refman/8.0/en/update.html
https://dev.mysql.com/doc/refman/8.0/en/select.html
https://dev.mysql.com/doc/refman/8.0/en/join.html

- Example sql:
```sql
UPDATE demo FORCE INDEX (idx_demo) SET col1 = NULL WHERE col2 = 1
```