### PR TITLE
Ignoring unnecessarily generated by pmd plugin

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,4 +27,4 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package --file pom.xml -DdisableXmlReport=true
+      run: mvn -B package --file pom.xml -DdisableXmlReport=true -Dpmd.skip=true


### PR DESCRIPTION
In our analysis, we observe that there are a few directories and files (e.g., css, images, pmd.html) generated under target/site that are not used in CI. Because these are not accessed after its generation. Hence, we propose to disable the generation of these directories and files to save runtime. We found that the pmd plugin is generating this stuff. 

The generation of this directory can be disabled by simply adding -Dpmd.skip=true to the mvn command.