### PR TITLE
feat:support clickhouse global keyword in IN Expression

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/InExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/InExpression.java
@@ -17,6 +17,7 @@ public class InExpression extends ASTNodeAccessImpl implements Expression, Suppo
 
     private Expression leftExpression;
     private ItemsList rightItemsList;
+    private boolean global = false;
     private boolean not = false;
     private Expression rightExpression;
     private int oldOracleJoinSyntax = NO_ORACLE_JOIN;
@@ -69,6 +70,13 @@ public class InExpression extends ASTNodeAccessImpl implements Expression, Suppo
         leftExpression = expression;
     }
 
+    public boolean isGlobal() {
+        return global;
+    }
+
+    public void setGlobal(boolean b) {
+        global = b;
+    }
     public boolean isNot() {
         return not;
     }
@@ -100,6 +108,9 @@ public class InExpression extends ASTNodeAccessImpl implements Expression, Suppo
         statementBuilder.append(getLeftExpressionString());
 
         statementBuilder.append(" ");
+        if (global) {
+            statementBuilder.append("GLOBAL ");
+        }
         if (not) {
             statementBuilder.append("NOT ");
         }
@@ -138,6 +149,11 @@ public class InExpression extends ASTNodeAccessImpl implements Expression, Suppo
     @Override
     public InExpression withOraclePriorPosition(int priorPosition) {
         this.setOraclePriorPosition(priorPosition);
+        return this;
+    }
+
+    public InExpression withGlobal(boolean global) {
+        this.setGlobal(global);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -252,6 +252,9 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
                 .getOldOracleJoinSyntax() == SupportsOldOracleJoinSyntax.ORACLE_JOIN_RIGHT) {
             buffer.append("(+)");
         }
+        if (inExpression.isGlobal()) {
+            buffer.append(" GLOBAL");
+        }
         if (inExpression.isNot()) {
             buffer.append(" NOT");
         }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3314,7 +3314,7 @@ Expression InExpression() #InExpression :
         leftExpression=SimpleExpression() { result.setLeftExpression(leftExpression); }
         [ "(" "+" ")" { result.setOldOracleJoinSyntax(EqualsTo.ORACLE_JOIN_RIGHT); } ]
 
-    [<K_NOT> { result.setNot(true); } ] <K_IN>
+    [<K_GLOBAL> { result.setGlobal(true); } ][<K_NOT> { result.setNot(true); } ] <K_IN>
     (
       LOOKAHEAD(2) token=<S_CHAR_LITERAL> {  result.setRightExpression(new StringValue(token.image)); }
       | LOOKAHEAD(3) rightExpression = Function() {  result.setRightExpression(rightExpression); }

--- a/src/test/java/net/sf/jsqlparser/statement/select/ClickHouseTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/ClickHouseTest.java
@@ -34,4 +34,11 @@ public class ClickHouseTest {
         sql = "SELECT schemaName.f1(arguments).f2(arguments).f3.f4 from dual";
         assertSqlCanBeParsedAndDeparsed(sql, true);
     }
+
+    @Test
+    public void testGlobalIn() throws JSQLParserException {
+        String sql =
+                "SELECT lo_linenumber,lo_orderkey from lo_linenumber where lo_linenumber global in (1,2,3)";
+        assertSqlCanBeParsedAndDeparsed(sql, true);
+    }
 }


### PR DESCRIPTION
- Add support for clickhouse global keyword in IN Expression

-  example:

SELECT lo_linenumber,lo_orderkey from lo_linenumber where lo_linenumber global in (1,2,3)