### PR TITLE
Fixing a problem with an OP_CONCAT in WhenExpression

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4796,7 +4796,7 @@ Expression CaseWhenExpression() #CaseWhenExpression:
     [
         <K_ELSE>
         (
-              LOOKAHEAD(3, {getAsBoolean(Feature.allowComplexParsing) && !interrupted}) elseExp=Expression()
+              LOOKAHEAD({getAsBoolean(Feature.allowComplexParsing) && !interrupted}) elseExp=Expression()
               | elseExp=SimpleExpression()
         )
     ]

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4796,7 +4796,8 @@ Expression CaseWhenExpression() #CaseWhenExpression:
     [
         <K_ELSE>
         (
-             LOOKAHEAD(3, {!interrupted}) "(" elseExp=CaseWhenExpression() ")" { elseExp = new Parenthesis( elseExp ); }
+            LOOKAHEAD(ConcatExpression()) elseExp = ConcatExpression() 
+              | LOOKAHEAD(3, {!interrupted}) "(" elseExp=CaseWhenExpression() ")" { elseExp = new Parenthesis( elseExp ); }
               | LOOKAHEAD(3, {!interrupted}) elseExp=CaseWhenExpression()
               | LOOKAHEAD(3, {getAsBoolean(Feature.allowComplexParsing) && !interrupted}) elseExp=Expression()
               | elseExp=SimpleExpression()

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4796,10 +4796,7 @@ Expression CaseWhenExpression() #CaseWhenExpression:
     [
         <K_ELSE>
         (
-            LOOKAHEAD(ConcatExpression()) elseExp = ConcatExpression() 
-              | LOOKAHEAD(3, {!interrupted}) "(" elseExp=CaseWhenExpression() ")" { elseExp = new Parenthesis( elseExp ); }
-              | LOOKAHEAD(3, {!interrupted}) elseExp=CaseWhenExpression()
-              | LOOKAHEAD(3, {getAsBoolean(Feature.allowComplexParsing) && !interrupted}) elseExp=Expression()
+              LOOKAHEAD(3, {getAsBoolean(Feature.allowComplexParsing) && !interrupted}) elseExp=Expression()
               | elseExp=SimpleExpression()
         )
     ]

--- a/src/test/java/net/sf/jsqlparser/expression/CaseExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/CaseExpressionTest.java
@@ -83,6 +83,33 @@ public class CaseExpressionTest {
     }
 
     @Test
+    public void testInnerCaseWithConcatInElsePart() throws JSQLParserException {
+        String query = "SELECT \n" +
+                "CASE \n" +
+                "   WHEN 1 = 1 \n" +
+                "   THEN \n" +
+                "       CASE \n" +
+                "           WHEN 2 = 2 \n" +
+                "           THEN '2a' \n" +
+                "           ELSE \n" +
+                "               CASE \n" +
+                "                   WHEN 1 = 1 \n" +
+                "                   THEN \n" +
+                "                       CASE \n" +
+                "                           WHEN 2 = 2 \n" +
+                "                           THEN '2a' \n" +
+                "                           ELSE '' \n" +
+                "                       END \n" +
+                "                   ELSE 'b' \n" +
+                "               END || 'z'\n" +
+                "       END \n" +
+                "   ELSE 'b' \n" +
+                "END AS tmp\n" +
+                "FROM test_table";
+        TestUtils.assertSqlCanBeParsedAndDeparsed(query, true);
+    }
+
+    @Test
     public void testCaseInsideBrackets() throws JSQLParserException {
         String sqlStr = "SELECT ( CASE\n"
                         + "            WHEN something\n"


### PR DESCRIPTION
Version: 4.7-SNAPSHOT

The problem was in an ELSE part of the WHEN expression. When we had a sub WHEN in ELSE and concatenate it with some another string:
`
CASE 
    WHEN 1 = 2 
    THEN 'string1'
    ELSE 
        CASE
        WHEN 2 = 3
        THEN 'string2'
        ELSE 'first part'
        END || 'second part'
END 
` 