### PR TITLE
Update Gradle JavaCC parser to latest version (3.0.0)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id 'maven-publish'
     id 'signing'
 
-    id "ca.coglinc2.javacc" version "latest.release"
+    id "org.javacc.javacc" version "latest.release"
     id 'jacoco'
     id 'com.github.kt3k.coveralls' version "latest.release"
     id "com.github.spotbugs" version "latest.release"


### PR DESCRIPTION
New version of the JavaCC plugin is out: [release notes](https://github.com/javacc/javaccPlugin/releases/tag/javacc-gradle-plugin-3.0.0). Because the plugin ID changed, it won't be found by usual dependency update mechanisms, so I'm making  PRs manually to update the major projects on GitHub that are using an older version of the plugin.

The new version should make compilation of the parser a bit faster and improve compatibility with future releases of Gradle.

I locally checked that `./gradlew test` is successful with this change, but have not done any other testing.

Personally I'd suggest to use specific versions of plugins in the Gradle file rather than `latest.release`, but I did not change it here.

The warnings before and after seem to be the same:
```
Warning:  "RR" cannot be matched as a string literal token at line 1749, column 2413. It will be matched as  <K_ISOLATION>.
Warning:  "UR" cannot be matched as a string literal token at line 1749, column 2982. It will be matched as  <K_ISOLATION>.
Warning:  "CS" cannot be matched as a string literal token at line 1749, column 638. It will be matched as  <K_ISOLATION>.
Warning:  "RS" cannot be matched as a string literal token at line 1749, column 2423. It will be matched as  <K_ISOLATION>.
Warning:  "RETURN" cannot be matched as a string literal token at line 1262, column 39. It will be matched as  <S_IDENTIFIER>.
Warning:  "UNQUIESCE" cannot be matched as a string literal token at line 6443, column 13. It will be matched as  <S_IDENTIFIER>.
Warning:  "INVALIDATE" cannot be matched as a string literal token at line 6146, column 23. It will be matched as  <S_IDENTIFIER>.
Warning:  "CONSTRAINTS" cannot be matched as a string literal token at line 6150, column 27. It will be matched as  <S_IDENTIFIER>.
Warning:  "TIMESTAMPTZ" cannot be matched as a string literal token at line 1749, column 2806. It will be matched as  <K_DATETIMELITERAL>
```