### PR TITLE
Unit tests support multi-os and higher versions of jdk

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/ParserKeywordsUtils.java
+++ b/src/main/java/net/sf/jsqlparser/parser/ParserKeywordsUtils.java
@@ -214,7 +214,7 @@ public class ParserKeywordsUtils {
 
     public static TreeSet<String> getAllKeywordsUsingRegex(File file) throws IOException {
         Pattern tokenBlockPattern = Pattern.compile(
-                "TOKEN\\s*:\\s*(?:/\\*.*\\*/*)\\n\\{(?:[^\\}\\{]+|\\{(?:[^\\}\\{]+|\\{[^\\}\\{]*\\})*\\})*\\}",
+                "TOKEN\\s*:\\s*(?:/\\*.*\\*/*)(?:\\r?\\n|\\r)\\{(?:[^\\}\\{]+|\\{(?:[^\\}\\{]+|\\{[^\\}\\{]*\\})*\\})*\\}",
                 Pattern.MULTILINE);
         Pattern tokenStringValuePattern = Pattern.compile("\\\"(\\w{2,})\\\"", Pattern.MULTILINE);
 

--- a/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
@@ -9,7 +9,6 @@
  */
 package net.sf.jsqlparser.util;
 
-import jdk.nashorn.internal.ir.annotations.Ignore;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
@@ -23,6 +22,7 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.simpleparsing.CCJSqlParserManagerTest;
 import net.sf.jsqlparser.test.TestException;
 import net.sf.jsqlparser.test.TestUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
@@ -41,17 +41,17 @@ public class TablesNamesFinderTest {
 
     private static final CCJSqlParserManager PARSER_MANAGER = new CCJSqlParserManager();
 
-    @Ignore
+    @Disabled
     public void testRUBiSTableList() throws Exception {
         runTestOnResource("/RUBiS-select-requests.txt");
     }
 
-    @Ignore
+    @Disabled
     public void testMoreComplexExamples() throws Exception {
         runTestOnResource("complex-select-requests.txt");
     }
 
-    @Ignore
+    @Disabled
     public void testComplexMergeExamples() throws Exception {
         runTestOnResource("complex-merge-requests.txt");
     }


### PR DESCRIPTION
When I run unit tests, there are two failures:
1. ParserKeywordsUtilsTest#getAllKeywords failed to run. Because my os is windows and the regex in ParserKeywordsUtils#getAllKeywordsUsingRegex seems not support multi-os.
2. Compilation fails when using JDK 17. Nashorn has been deprecated after jdk11 and removed after jdk15.