### PR TITLE
Fix: mysql and mariadb can use `index type` before `ON`

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
@@ -9,18 +9,27 @@
  */
 package net.sf.jsqlparser.statement.create.index;
 
+import static java.util.stream.Collectors.joining;
+
+import java.util.*;
 import net.sf.jsqlparser.schema.*;
 import net.sf.jsqlparser.statement.*;
 import net.sf.jsqlparser.statement.create.table.*;
-
-import java.util.*;
-import static java.util.stream.Collectors.joining;
 
 public class CreateIndex implements Statement {
 
     private Table table;
     private Index index;
     private List<String> tailParameters;
+    private boolean indexTypeBeforeOn = false;
+
+    public boolean isIndexTypeBeforeOn() {
+        return indexTypeBeforeOn;
+    }
+
+    public void setIndexTypeBeforeOn(boolean indexTypeBeforeOn) {
+        this.indexTypeBeforeOn = indexTypeBeforeOn;
+    }
 
     public boolean isUsingIfNotExists() {
         return usingIfNotExists;
@@ -78,10 +87,16 @@ public class CreateIndex implements Statement {
             buffer.append("IF NOT EXISTS ");
         }
         buffer.append(index.getName());
+
+        if (index.getUsing() != null && isIndexTypeBeforeOn()) {
+            buffer.append(" USING ");
+            buffer.append(index.getUsing());
+        }
+
         buffer.append(" ON ");
         buffer.append(table.getFullyQualifiedName());
 
-        if (index.getUsing() != null) {
+        if (index.getUsing() != null && !isIndexTypeBeforeOn()) {
             buffer.append(" USING ");
             buffer.append(index.getUsing());
         }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/CreateIndexDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/CreateIndexDeParser.java
@@ -9,10 +9,10 @@
  */
 package net.sf.jsqlparser.util.deparser;
 
+import static java.util.stream.Collectors.joining;
+
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.table.Index;
-
-import static java.util.stream.Collectors.joining;
 
 public class CreateIndexDeParser extends AbstractDeParser<CreateIndex> {
 
@@ -36,11 +36,17 @@ public class CreateIndexDeParser extends AbstractDeParser<CreateIndex> {
             buffer.append("IF NOT EXISTS ");
         }
         buffer.append(index.getName());
+
+        String using = index.getUsing();
+        if (using != null && createIndex.isIndexTypeBeforeOn()) {
+            buffer.append(" USING ");
+            buffer.append(using);
+        }
+
         buffer.append(" ON ");
         buffer.append(createIndex.getTable().getFullyQualifiedName());
 
-        String using = index.getUsing();
-        if (using != null) {
+        if (using != null && !createIndex.isIndexTypeBeforeOn()) {
             buffer.append(" USING ");
             buffer.append(using);
         }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -5302,9 +5302,21 @@ CreateIndex CreateIndex():
     <K_INDEX>
     [ LOOKAHEAD(2) <K_IF> <K_NOT> <K_EXISTS> { createIndex.setUsingIfNotExists(true);} ]
     index = Index() { index.setType(parameter.isEmpty() ? null : parameter.get(0)); }
-
-    <K_ON> table=Table()
-    [ <K_USING> using=<S_IDENTIFIER> {index.setUsing(using.image);} ]
+    (
+        LOOKAHEAD(3)(
+            <K_ON> table=Table()
+            [ <K_USING> using=<S_IDENTIFIER> { index.setUsing(using.image); } ]
+        )
+        |
+        (
+            [ <K_USING> using=<S_IDENTIFIER> { 
+                    index.setUsing(using.image);
+                    createIndex.setIndexTypeBeforeOn(true);
+                } 
+            ]
+            <K_ON> table=Table()
+        )
+    )
     colNames = ColumnNamesWithParamsList()
     ( parameter=CreateParameter() { tailParameters.addAll(parameter); } )*
     {

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
@@ -9,17 +9,16 @@
  */
 package net.sf.jsqlparser.statement.create;
 
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.StringReader;
+import java.util.List;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import org.junit.jupiter.api.Test;
-
-import java.io.StringReader;
-import java.util.List;
-
-import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class CreateIndexTest {
 
@@ -140,6 +139,13 @@ public class CreateIndexTest {
     void testIfNotExistsIssue1861() throws JSQLParserException {
         String sqlStr =
                 "CREATE INDEX IF NOT EXISTS test_test_idx ON test.test USING btree (\"time\")";
+        assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+    }
+
+    @Test
+    void testCreateIndexIssue1814() throws JSQLParserException {
+        String sqlStr =
+                "CREATE INDEX idx_operationlog_operatetime_regioncode USING BTREE ON operation_log (operate_time,region_biz_code)";
         assertSqlCanBeParsedAndDeparsed(sqlStr, true);
     }
 }


### PR DESCRIPTION
Closed #1814