### PR TITLE
Fix: DESC and EXPLAIN

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
+++ b/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
@@ -593,6 +593,14 @@ public enum Feature {
      * @see DescribeStatement
      */
     describe,
+
+    /**
+     * SQL "DESC" statement is allowed
+     *
+     * @see DescribeStatement
+     */
+    desc,
+
     /**
      * SQL "EXPLAIN" statement is allowed
      *

--- a/src/main/java/net/sf/jsqlparser/statement/DescribeStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/DescribeStatement.java
@@ -14,6 +14,7 @@ import net.sf.jsqlparser.schema.Table;
 public class DescribeStatement implements Statement {
 
     private Table table;
+    private String describeType;
 
     public DescribeStatement() {
         // empty constructor
@@ -33,7 +34,7 @@ public class DescribeStatement implements Statement {
 
     @Override
     public String toString() {
-        return "DESCRIBE " + table.getFullyQualifiedName();
+        return this.describeType + " " + table.getFullyQualifiedName();
     }
 
     @Override
@@ -43,6 +44,15 @@ public class DescribeStatement implements Statement {
 
     public DescribeStatement withTable(Table table) {
         this.setTable(table);
+        return this;
+    }
+
+    public String getDescribeType() {
+        return describeType;
+    }
+
+    public DescribeStatement setDescribeType(String describeType) {
+        this.describeType = describeType;
         return this;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/ExplainStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/ExplainStatement.java
@@ -9,11 +9,11 @@
  */
 package net.sf.jsqlparser.statement;
 
-import net.sf.jsqlparser.statement.select.Select;
-
 import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.stream.Collectors;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.select.Select;
 
 /**
  * An {@code EXPLAIN} statement
@@ -22,9 +22,19 @@ public class ExplainStatement implements Statement {
 
     private Select select;
     private LinkedHashMap<OptionType, Option> options;
+    private Table table;
 
     public ExplainStatement() {
         // empty constructor
+    }
+
+    public Table getTable() {
+        return table;
+    }
+
+    public ExplainStatement setTable(Table table) {
+        this.table = table;
+        return this;
     }
 
     public ExplainStatement(Select select) {
@@ -68,14 +78,19 @@ public class ExplainStatement implements Statement {
     @Override
     public String toString() {
         StringBuilder statementBuilder = new StringBuilder("EXPLAIN");
-        if (options != null) {
+        if (table != null) {
+            statementBuilder.append(" ").append(table);
+        } else {
+            if (options != null) {
+                statementBuilder.append(" ");
+                statementBuilder.append(options.values().stream().map(Option::formatOption)
+                        .collect(Collectors.joining(" ")));
+            }
+
             statementBuilder.append(" ");
-            statementBuilder.append(options.values().stream().map(Option::formatOption)
-                    .collect(Collectors.joining(" ")));
+            statementBuilder.append(select.toString());
         }
 
-        statementBuilder.append(" ");
-        statementBuilder.append(select.toString());
         return statementBuilder.toString();
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/ExplainStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/ExplainStatement.java
@@ -88,7 +88,9 @@ public class ExplainStatement implements Statement {
             }
 
             statementBuilder.append(" ");
-            statementBuilder.append(select.toString());
+            if (select != null) {
+                statementBuilder.append(select.toString());
+            }
         }
 
         return statementBuilder.toString();

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -1067,7 +1067,9 @@ public class TablesNamesFinder implements SelectVisitor, FromItemVisitor, Expres
 
     @Override
     public void visit(ExplainStatement explain) {
-        explain.getStatement().accept((StatementVisitor) this);
+        if (explain.getStatement() != null) {
+            explain.getStatement().accept((StatementVisitor) this);
+        }
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -9,6 +9,9 @@
  */
 package net.sf.jsqlparser.util.deparser;
 
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
 import net.sf.jsqlparser.statement.Block;
 import net.sf.jsqlparser.statement.Commit;
 import net.sf.jsqlparser.statement.CreateFunctionalStatement;
@@ -58,10 +61,6 @@ import net.sf.jsqlparser.statement.show.ShowTablesStatement;
 import net.sf.jsqlparser.statement.truncate.Truncate;
 import net.sf.jsqlparser.statement.update.Update;
 import net.sf.jsqlparser.statement.upsert.Upsert;
-
-import java.util.Iterator;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class StatementDeParser extends AbstractDeParser<Statement> implements StatementVisitor {
 
@@ -347,19 +346,25 @@ public class StatementDeParser extends AbstractDeParser<Statement> implements St
 
     @Override
     public void visit(DescribeStatement describe) {
-        buffer.append("DESCRIBE ");
+        buffer.append(describe.getDescribeType());
+        buffer.append(" ");
         buffer.append(describe.getTable());
     }
 
     @Override
     public void visit(ExplainStatement explain) {
         buffer.append("EXPLAIN ");
-        if (explain.getOptions() != null) {
+        if (explain.getTable() != null) {
+            buffer.append(explain.getTable());
+        } else if (explain.getOptions() != null) {
             buffer.append(explain.getOptions().values().stream()
                     .map(ExplainStatement.Option::formatOption).collect(Collectors.joining(" ")));
             buffer.append(" ");
         }
-        explain.getStatement().accept(this);
+        if (explain.getStatement() != null) {
+            explain.getStatement().accept(this);
+
+        }
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/MySqlVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/MySqlVersion.java
@@ -115,6 +115,7 @@ public enum MySqlVersion implements Version {
 
                     // https://dev.mysql.com/doc/refman/8.0/en/describe.html
                     Feature.describe,
+                    Feature.desc,
                     // https://dev.mysql.com/doc/refman/8.0/en/explain.html
                     Feature.explain,
                     // https://dev.mysql.com/doc/refman/8.0/en/show.html

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/StatementValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/StatementValidator.java
@@ -209,6 +209,7 @@ public class StatementValidator extends AbstractValidator<Statement> implements 
     @Override
     public void visit(DescribeStatement describe) {
         validateFeature(Feature.describe);
+        validateFeature(Feature.desc);
         validateOptionalFromItem(describe.getTable());
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/StatementValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/StatementValidator.java
@@ -216,7 +216,9 @@ public class StatementValidator extends AbstractValidator<Statement> implements 
     @Override
     public void visit(ExplainStatement explain) {
         validateFeature(Feature.explain);
-        explain.getStatement().accept(this);
+        if (explain.getStatement() != null) {
+            explain.getStatement().accept(this);
+        }
     }
 
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1056,29 +1056,43 @@ PurgeStatement PurgeStatement(): {
 
 DescribeStatement Describe(): {
     Table table;
+    DescribeStatement stmt = new DescribeStatement();
+    Token tk = null;
 } {
-    <K_DESCRIBE> table = Table()
+    (tk=<K_DESCRIBE> | tk=<K_DESC>) 
+    table = Table() { stmt.setDescribeType(tk.image).setTable(table); }
     {
-        return new DescribeStatement(table);
+        return stmt;
     }
 }
 
 ExplainStatement Explain(): {
     Select select;
+    Table table = null;
     List<ExplainStatement.Option> options = null;
+    ExplainStatement es = new ExplainStatement();
 } {
     <K_EXPLAIN>
-    options=ExplainStatementOptions()
-    select = Select( )
-    {
-       ExplainStatement es = new ExplainStatement(select);
-       if(options != null && !options.isEmpty()) {
-         for(ExplainStatement.Option o : options) {
-           es.addOption(o);
-         }
-       }
-       return es;
-    }
+    (
+        LOOKAHEAD(3)(
+            options=ExplainStatementOptions()
+            select = Select( )
+            {
+               es.setStatement(select);
+               if (options != null && !options.isEmpty()) {
+                 for(ExplainStatement.Option o : options) {
+                   es.addOption(o);
+                 }
+               }
+            }
+        )
+        |
+        (
+           table=Table( ) { es.setTable(table); }
+        )
+        
+    )
+    { return es; }
 }
 
 /**

--- a/src/test/java/net/sf/jsqlparser/statement/DescribeTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/DescribeTest.java
@@ -9,8 +9,9 @@
  */
 package net.sf.jsqlparser.statement;
 
-import net.sf.jsqlparser.JSQLParserException;
 import static net.sf.jsqlparser.test.TestUtils.*;
+
+import net.sf.jsqlparser.JSQLParserException;
 import org.junit.jupiter.api.Test;
 
 public class DescribeTest {
@@ -18,6 +19,12 @@ public class DescribeTest {
     @Test
     public void testDescribe() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("DESCRIBE foo.products");
+    }
+
+    @Test
+    public void testDescribeIssue1931() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("DESC table_name");
+        assertSqlCanBeParsedAndDeparsed("EXPLAIN table_name");
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/util/validation/validator/StatementValidatorTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/validation/validator/StatementValidatorTest.java
@@ -29,8 +29,16 @@ public class StatementValidatorTest extends ValidationTestAsserts {
 
     @Test
     public void testValidateCreateSchemaNotAllowed() throws JSQLParserException {
-        for (String sql : Arrays.asList("CREATE SCHEMA my_schema", "CREATE SCHEMA myschema AUTHORIZATION myauth")) {
+        for (String sql : Arrays.asList("CREATE SCHEMA my_schema",
+                "CREATE SCHEMA myschema AUTHORIZATION myauth")) {
             validateNotAllowed(sql, 1, 1, FeaturesAllowed.DML, Feature.createSchema);
+        }
+    }
+
+    @Test
+    public void testValidateDescNoErrors() throws JSQLParserException {
+        for (String sql : Arrays.asList("DESC table_name", "EXPLAIN table_name")) {
+            validateNoErrors(sql, 1, DatabaseType.MYSQL);
         }
     }
 
@@ -53,7 +61,8 @@ public class StatementValidatorTest extends ValidationTestAsserts {
     @Test
     public void testValidateComment() throws JSQLParserException {
         for (String sql : Arrays.asList("COMMENT ON VIEW myschema.myView IS 'myComment'",
-                "COMMENT ON COLUMN myTable.myColumn is 'Some comment'", "COMMENT ON TABLE table1 IS 'comment1'")) {
+                "COMMENT ON COLUMN myTable.myColumn is 'Some comment'",
+                "COMMENT ON TABLE table1 IS 'comment1'")) {
             validateNoErrors(sql, 1, DatabaseType.H2, DatabaseType.ORACLE, DatabaseType.POSTGRESQL);
         }
     }

--- a/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/explain01.sql
+++ b/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/explain01.sql
@@ -17,3 +17,4 @@ explain plan
                where location_id = 1700)
 
 --@FAILURE: Encountered unexpected token: "plan" <S_IDENTIFIER> recorded first on Aug 3, 2021, 7:20:08 AM
+--@FAILURE: Encountered unexpected token: "set" "SET" recorded first on 2023年12月23日 下午1:38:33


### PR DESCRIPTION
close #1931, to support MySQL `{EXPLAIN | DESCRIBE | DESC}  tbl_name` 
it is necessary to use LOOKAHEAD(3), It made `explain01.sql` change. It seems to be expected?