### PR TITLE
feat: support any number/order of merge operations

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class Merge implements Statement {
 
@@ -34,9 +35,45 @@ public class Merge implements Statement {
     private OracleHint oracleHint = null;
     private FromItem fromItem;
     private Expression onCondition;
+    private MergeInsert mergeInsert;
+    private MergeUpdate mergeUpdate;
+    private boolean insertFirst = false;
     private List<MergeOperation> operations;
 
     private OutputClause outputClause;
+
+    private void deriveOperationsFromStandardClauses() {
+        List<MergeOperation> operations = new ArrayList<>();
+        if (insertFirst) {
+            Optional.ofNullable(mergeInsert).ifPresent(operations::add);
+            Optional.ofNullable(mergeUpdate).ifPresent(operations::add);
+        } else {
+            Optional.ofNullable(mergeUpdate).ifPresent(operations::add);
+            Optional.ofNullable(mergeInsert).ifPresent(operations::add);
+        }
+        this.operations = operations;
+    }
+
+    private void deriveStandardClausesFromOperations() {
+        List<MergeOperation> applicableOperations =
+                Optional.ofNullable(operations).orElse(Collections.emptyList()).stream()
+                        .filter(o -> o instanceof MergeUpdate || o instanceof MergeInsert)
+                        .collect(Collectors.toList());
+        mergeUpdate = applicableOperations.stream()
+                .filter(o -> o instanceof MergeUpdate)
+                .map(MergeUpdate.class::cast)
+                .findFirst()
+                .orElse(null);
+        mergeInsert = applicableOperations.stream()
+                .filter(o -> o instanceof MergeInsert)
+                .map(MergeInsert.class::cast)
+                .findFirst()
+                .orElse(null);
+        insertFirst = applicableOperations.stream()
+                .findFirst()
+                .map(o -> o instanceof MergeInsert)
+                .orElse(false);
+    }
 
     public List<WithItem> getWithItemsList() {
         return withItemsList;
@@ -133,30 +170,25 @@ public class Merge implements Statement {
 
     public void setOperations(List<MergeOperation> operations) {
         this.operations = operations;
+        deriveStandardClausesFromOperations();
     }
 
-    /**
-     * @deprecated use {@link #getOperations()} or consider a {@link MergeOperationVisitor} instead
-     */
-    @Deprecated
     public MergeInsert getMergeInsert() {
-        return operations.stream()
-                .filter(MergeInsert.class::isInstance)
-                .findFirst()
-                .map(MergeInsert.class::cast)
-                .orElse(null);
+        return mergeInsert;
     }
 
-    /**
-     * @deprecated use {@link #getOperations()} or consider a {@link MergeOperationVisitor} instead
-     */
-    @Deprecated
+    public void setMergeInsert(MergeInsert mergeInsert) {
+        this.mergeInsert = mergeInsert;
+        deriveOperationsFromStandardClauses();
+    }
+
     public MergeUpdate getMergeUpdate() {
-        return operations.stream()
-                .filter(MergeUpdate.class::isInstance)
-                .findFirst()
-                .map(MergeUpdate.class::cast)
-                .orElse(null);
+        return mergeUpdate;
+    }
+
+    public void setMergeUpdate(MergeUpdate mergeUpdate) {
+        this.mergeUpdate = mergeUpdate;
+        deriveOperationsFromStandardClauses();
     }
 
     @Override
@@ -164,15 +196,13 @@ public class Merge implements Statement {
         statementVisitor.visit(this);
     }
 
-    /**
-     * @deprecated use {@link #getOperations()} or consider a {@link MergeOperationVisitor} instead
-     */
-    @Deprecated
     public boolean isInsertFirst() {
-        if (operations == null || operations.isEmpty()) {
-            return false;
-        }
-        return operations.get(0) instanceof MergeInsert;
+        return insertFirst;
+    }
+
+    public void setInsertFirst(boolean insertFirst) {
+        this.insertFirst = insertFirst;
+        deriveOperationsFromStandardClauses();
     }
 
     public OutputClause getOutputClause() {
@@ -244,8 +274,23 @@ public class Merge implements Statement {
         return this;
     }
 
+    public Merge withMergeUpdate(MergeUpdate mergeUpdate) {
+        this.setMergeUpdate(mergeUpdate);
+        return this;
+    }
+
+    public Merge withInsertFirst(boolean insertFirst) {
+        this.setInsertFirst(insertFirst);
+        return this;
+    }
+
     public Merge withTable(Table table) {
         this.setTable(table);
+        return this;
+    }
+
+    public Merge withMergeInsert(MergeInsert mergeInsert) {
+        this.setMergeInsert(mergeInsert);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/merge/MergeDelete.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/MergeDelete.java
@@ -1,0 +1,47 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2024 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.merge;
+
+import net.sf.jsqlparser.expression.Expression;
+
+import java.io.Serializable;
+
+public class MergeDelete implements Serializable, MergeOperation {
+    private Expression andPredicate;
+
+    public Expression getAndPredicate() {
+        return andPredicate;
+    }
+
+    public void setAndPredicate(Expression andPredicate) {
+        this.andPredicate = andPredicate;
+    }
+
+    public MergeDelete withAndPredicate(Expression andPredicate) {
+        this.setAndPredicate(andPredicate);
+        return this;
+    }
+
+    @Override
+    public void accept(MergeOperationVisitor mergeOperationVisitor) {
+        mergeOperationVisitor.visit(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder b = new StringBuilder();
+        b.append(" WHEN MATCHED");
+        if (andPredicate != null) {
+            b.append(" AND ").append(andPredicate.toString());
+        }
+        b.append(" THEN DELETE");
+        return b.toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/merge/MergeInsert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/MergeInsert.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 
-public class MergeInsert implements Serializable {
+public class MergeInsert implements Serializable, MergeOperation {
 
     private Expression andPredicate;
     private ExpressionList<Column> columns;
@@ -55,6 +55,11 @@ public class MergeInsert implements Serializable {
 
     public void setWhereCondition(Expression whereCondition) {
         this.whereCondition = whereCondition;
+    }
+
+    @Override
+    public void accept(MergeOperationVisitor mergeOperationVisitor) {
+        mergeOperationVisitor.visit(this);
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/statement/merge/MergeOperation.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/MergeOperation.java
@@ -1,0 +1,17 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2024 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.merge;
+
+/**
+ * Marker interface to cover {@link MergeDelete}, {@link MergeUpdate} and {@link MergeInsert}
+ */
+public interface MergeOperation {
+    void accept(MergeOperationVisitor mergeOperationVisitor);
+}

--- a/src/main/java/net/sf/jsqlparser/statement/merge/MergeOperationVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/MergeOperationVisitor.java
@@ -1,0 +1,19 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2024 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.merge;
+
+public interface MergeOperationVisitor {
+
+    void visit(MergeDelete mergeDelete);
+
+    void visit(MergeUpdate mergeUpdate);
+
+    void visit(MergeInsert mergeInsert);
+}

--- a/src/main/java/net/sf/jsqlparser/statement/merge/MergeOperationVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/MergeOperationVisitorAdapter.java
@@ -1,0 +1,28 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2024 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.merge;
+
+@SuppressWarnings({"PMD.UncommentedEmptyMethodBody"})
+public class MergeOperationVisitorAdapter implements MergeOperationVisitor {
+    @Override
+    public void visit(MergeDelete mergeDelete) {
+
+    }
+
+    @Override
+    public void visit(MergeUpdate mergeUpdate) {
+
+    }
+
+    @Override
+    public void visit(MergeInsert mergeInsert) {
+
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/merge/MergeUpdate.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/MergeUpdate.java
@@ -15,7 +15,7 @@ import net.sf.jsqlparser.statement.update.UpdateSet;
 import java.io.Serializable;
 import java.util.List;
 
-public class MergeUpdate implements Serializable {
+public class MergeUpdate implements Serializable, MergeOperation {
 
     private List<UpdateSet> updateSets;
     private Expression andPredicate;
@@ -59,6 +59,11 @@ public class MergeUpdate implements Serializable {
 
     public void setDeleteWhereCondition(Expression deleteWhereCondition) {
         this.deleteWhereCondition = deleteWhereCondition;
+    }
+
+    @Override
+    public void accept(MergeOperationVisitor mergeOperationVisitor) {
+        mergeOperationVisitor.visit(this);
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/deparser/MergeDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/MergeDeParser.java
@@ -1,0 +1,118 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2024 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.util.deparser;
+
+import net.sf.jsqlparser.statement.merge.*;
+import net.sf.jsqlparser.statement.select.WithItem;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class MergeDeParser extends AbstractDeParser<Merge> implements MergeOperationVisitor {
+    private final ExpressionDeParser expressionDeParser;
+
+    private final SelectDeParser selectDeParser;
+
+    public MergeDeParser(ExpressionDeParser expressionDeParser, SelectDeParser selectDeParser,
+            StringBuilder buffer) {
+        super(buffer);
+        this.expressionDeParser = expressionDeParser;
+        this.selectDeParser = selectDeParser;
+    }
+
+    @Override
+    void deParse(Merge merge) {
+        List<WithItem> withItemsList = merge.getWithItemsList();
+        if (withItemsList != null && !withItemsList.isEmpty()) {
+            buffer.append("WITH ");
+            for (Iterator<WithItem> iter = withItemsList.iterator(); iter.hasNext();) {
+                iter.next().accept(expressionDeParser);
+                if (iter.hasNext()) {
+                    buffer.append(",");
+                }
+                buffer.append(" ");
+            }
+        }
+
+        buffer.append("MERGE ");
+        if (merge.getOracleHint() != null) {
+            buffer.append(merge.getOracleHint()).append(" ");
+        }
+        buffer.append("INTO ");
+        merge.getTable().accept(selectDeParser);
+
+        buffer.append(" USING ");
+        merge.getFromItem().accept(selectDeParser);
+
+        buffer.append(" ON ");
+        merge.getOnCondition().accept(expressionDeParser);
+
+        List<MergeOperation> operations = merge.getOperations();
+        if (operations != null && !operations.isEmpty()) {
+            operations.forEach(operation -> operation.accept(this));
+        }
+
+        if (merge.getOutputClause() != null) {
+            merge.getOutputClause().appendTo(buffer);
+        }
+    }
+
+    @Override
+    public void visit(MergeDelete mergeDelete) {
+        buffer.append(" WHEN MATCHED");
+        if (mergeDelete.getAndPredicate() != null) {
+            buffer.append(" AND ");
+            mergeDelete.getAndPredicate().accept(expressionDeParser);
+        }
+        buffer.append(" THEN DELETE");
+    }
+
+    @Override
+    public void visit(MergeUpdate mergeUpdate) {
+        buffer.append(" WHEN MATCHED");
+        if (mergeUpdate.getAndPredicate() != null) {
+            buffer.append(" AND ");
+            mergeUpdate.getAndPredicate().accept(expressionDeParser);
+        }
+        buffer.append(" THEN UPDATE SET ");
+        deparseUpdateSets(mergeUpdate.getUpdateSets(), buffer, expressionDeParser);
+
+        if (mergeUpdate.getWhereCondition() != null) {
+            buffer.append(" WHERE ");
+            mergeUpdate.getWhereCondition().accept(expressionDeParser);
+        }
+
+        if (mergeUpdate.getDeleteWhereCondition() != null) {
+            buffer.append(" DELETE WHERE ");
+            mergeUpdate.getDeleteWhereCondition().accept(expressionDeParser);
+        }
+    }
+
+    @Override
+    public void visit(MergeInsert mergeInsert) {
+        buffer.append(" WHEN NOT MATCHED");
+        if (mergeInsert.getAndPredicate() != null) {
+            buffer.append(" AND ");
+            mergeInsert.getAndPredicate().accept(expressionDeParser);
+        }
+        buffer.append(" THEN INSERT ");
+        if (mergeInsert.getColumns() != null) {
+            mergeInsert.getColumns().accept(expressionDeParser);
+        }
+        buffer.append(" VALUES ");
+        mergeInsert.getValues().accept(expressionDeParser);
+
+        if (mergeInsert.getWhereCondition() != null) {
+            buffer.append(" WHERE ");
+            mergeInsert.getWhereCondition().accept(expressionDeParser);
+        }
+    }
+
+}

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/MergeValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/MergeValidator.java
@@ -10,14 +10,14 @@
 package net.sf.jsqlparser.util.validation.validator;
 
 import net.sf.jsqlparser.parser.feature.Feature;
-import net.sf.jsqlparser.statement.merge.Merge;
+import net.sf.jsqlparser.statement.merge.*;
 import net.sf.jsqlparser.statement.update.UpdateSet;
 import net.sf.jsqlparser.util.validation.ValidationCapability;
 
 /**
  * @author gitmotte
  */
-public class MergeValidator extends AbstractValidator<Merge> {
+public class MergeValidator extends AbstractValidator<Merge> implements MergeOperationVisitor {
 
 
     @Override
@@ -26,20 +26,32 @@ public class MergeValidator extends AbstractValidator<Merge> {
             validateFeature(c, Feature.merge);
         }
         validateOptionalExpression(merge.getOnCondition());
-        // validateOptionalExpression(merge.getFromItem());
-        if (merge.getMergeInsert() != null) {
-            validateOptionalExpressions(merge.getMergeInsert().getColumns());
-            validateOptionalExpressions(merge.getMergeInsert().getValues());
-        }
-        if (merge.getMergeUpdate() != null) {
-            for (UpdateSet updateSet : merge.getMergeUpdate().getUpdateSets()) {
-                validateOptionalExpressions(updateSet.getColumns());
-                validateOptionalExpressions(updateSet.getValues());
-            }
-            validateOptionalExpression(merge.getMergeUpdate().getDeleteWhereCondition());
-            validateOptionalExpression(merge.getMergeUpdate().getWhereCondition());
+        if (merge.getOperations() != null) {
+            merge.getOperations().forEach(operation -> operation.accept(this));
         }
         validateOptionalFromItems(merge.getFromItem());
     }
 
+    @Override
+    public void visit(MergeDelete mergeDelete) {
+        validateOptionalExpression(mergeDelete.getAndPredicate());
+    }
+
+    @Override
+    public void visit(MergeUpdate mergeUpdate) {
+        validateOptionalExpression(mergeUpdate.getAndPredicate());
+        for (UpdateSet updateSet : mergeUpdate.getUpdateSets()) {
+            validateOptionalExpressions(updateSet.getColumns());
+            validateOptionalExpressions(updateSet.getValues());
+        }
+        validateOptionalExpression(mergeUpdate.getDeleteWhereCondition());
+        validateOptionalExpression(mergeUpdate.getWhereCondition());
+    }
+
+    @Override
+    public void visit(MergeInsert mergeInsert) {
+        validateOptionalExpression(mergeInsert.getAndPredicate());
+        validateOptionalExpressions(mergeInsert.getColumns());
+        validateOptionalExpressions(mergeInsert.getValues());
+    }
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1701,8 +1701,7 @@ Statement Merge( List<WithItem> with ) : {
     Table table;
     FromItem fromItem;
     Expression condition;
-    MergeUpdate update;
-    MergeInsert insert;
+    List<MergeOperation> operations;
     OutputClause outputClause;
 }
 {
@@ -1710,39 +1709,60 @@ Statement Merge( List<WithItem> with ) : {
     <K_USING> fromItem = FromItem() { merge.setFromItem(fromItem); }
     <K_ON> condition = Expression() { merge.setOnCondition(condition); }
 
-    [
-        ( LOOKAHEAD(2) update = MergeUpdateClause() { merge.setMergeUpdate(update); }
-          [ insert = MergeInsertClause() { merge.setMergeInsert(insert); } ]
-        | insert = MergeInsertClause() { merge.withMergeInsert(insert).withInsertFirst(true); }
-          [ update = MergeUpdateClause() { merge.setMergeUpdate(update); } ]
-        )
-    ]
+    operations = MergeOperations() { merge.setOperations(operations); }
 
     [ outputClause = OutputClause() { merge.setOutputClause(outputClause); } ]
 
     { return merge.withWithItemsList(with); }
 }
 
-MergeUpdate MergeUpdateClause() : {
-    MergeUpdate mu = new MergeUpdate();
-    List<UpdateSet> updateSets;
-    Expression predicate;
-    Expression condition;
+List<MergeOperation> MergeOperations() : {
+    List<MergeOperation> operationsList = new ArrayList<MergeOperation>();
+    MergeOperation operation;
+}
+{
+    (
+        LOOKAHEAD(2) operation = MergeWhenMatched() { operationsList.add(operation); }
+        |
+        operation = MergeWhenNotMatched() { operationsList.add(operation); }
+    )*
+    { return operationsList; }
+}
+
+MergeOperation MergeWhenMatched() : {
+    Expression predicate = null;
+    MergeOperation operation;
 }
 {
     <K_WHEN> <K_MATCHED>
-    [ <K_AND> predicate = Expression() { mu.setAndPredicate(predicate); } ]
-    <K_THEN> <K_UPDATE>
-    <K_SET>
-    updateSets = UpdateSets() { mu.setUpdateSets(updateSets); }
+    [ <K_AND> predicate = Expression() ]
+    <K_THEN>
+    (
+        operation = MergeDeleteClause(predicate) | operation = MergeUpdateClause(predicate)
+    )
+    { return operation; }
+}
 
+MergeOperation MergeDeleteClause(Expression predicate) : {
+    MergeDelete md = new MergeDelete().withAndPredicate(predicate);
+}
+{
+    <K_DELETE> { return md; }
+}
+
+MergeOperation MergeUpdateClause(Expression predicate) : {
+    MergeUpdate mu = new MergeUpdate().withAndPredicate(predicate);
+    List<UpdateSet> updateSets;
+    Expression condition;
+}
+{
+    <K_UPDATE> <K_SET> updateSets = UpdateSets() { mu.setUpdateSets(updateSets); }
     [ <K_WHERE> condition = Expression() { mu.setWhereCondition(condition); }]
     [ <K_DELETE> <K_WHERE> condition = Expression() { mu.setDeleteWhereCondition(condition); } ]
-
     { return mu; }
 }
 
-MergeInsert MergeInsertClause() : {
+MergeOperation MergeWhenNotMatched() : {
     MergeInsert mi = new MergeInsert();
     Expression predicate;
     ExpressionList<Column> columns;

--- a/src/test/java/net/sf/jsqlparser/statement/merge/MergeTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/merge/MergeTest.java
@@ -12,11 +12,20 @@ package net.sf.jsqlparser.statement.merge;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
 
 import static net.sf.jsqlparser.test.TestUtils.assertOracleHintExists;
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  *
@@ -153,10 +162,10 @@ public class MergeTest {
 
         Merge merge = (Merge) statement;
         MergeInsert mergeInsert = merge.getMergeInsert();
-        Assertions.assertThat(mergeInsert.getWhereCondition());
+        assertThat(mergeInsert.getWhereCondition());
 
         MergeUpdate mergeUpdate = merge.getMergeUpdate();
-        Assertions.assertThat(mergeUpdate.getWhereCondition());
+        assertThat(mergeUpdate.getWhereCondition());
     }
 
     @Test
@@ -265,5 +274,60 @@ public class MergeTest {
                         "    WHEN NOT MATCHED THEN INSERT (val, status) VALUES (t2.newVal, t2.newStatus)";
 
         assertSqlCanBeParsedAndDeparsed(sql, true);
+    }
+
+    @ParameterizedTest
+    @MethodSource("deriveOperationsFromStandardClausesCases")
+    void testDeriveOperationsFromStandardClauses(List<MergeOperation> expectedOperations,
+            MergeUpdate update, MergeInsert insert, boolean insertFirst) {
+        Merge merge = new Merge();
+        merge.setMergeUpdate(update);
+        merge.setMergeInsert(insert);
+        merge.setInsertFirst(insertFirst);
+
+        assertThat(merge.getOperations()).isEqualTo(expectedOperations);
+    }
+
+    private static Stream<Arguments> deriveOperationsFromStandardClausesCases() {
+        MergeUpdate update = mock(MergeUpdate.class);
+        MergeInsert insert = mock(MergeInsert.class);
+
+        return Stream.of(
+                Arguments.of(Arrays.asList(update, insert), update, insert, false),
+                Arguments.of(Arrays.asList(insert, update), update, insert, true));
+    }
+
+    @ParameterizedTest
+    @MethodSource("deriveStandardClausesFromOperationsCases")
+    void testDeriveStandardClausesFromOperations(List<MergeOperation> operations,
+            MergeUpdate expectedUpdate, MergeInsert expectedInsert, boolean expectedInsertFirst) {
+        Merge merge = new Merge();
+        merge.setOperations(operations);
+
+        assertThat(merge.getMergeUpdate()).isEqualTo(expectedUpdate);
+        assertThat(merge.getMergeInsert()).isEqualTo(expectedInsert);
+        assertThat(merge.isInsertFirst()).isEqualTo(expectedInsertFirst);
+    }
+
+    private static Stream<Arguments> deriveStandardClausesFromOperationsCases() {
+        MergeDelete delete1 = mock(MergeDelete.class);
+        MergeUpdate update1 = mock(MergeUpdate.class);
+        MergeUpdate update2 = mock(MergeUpdate.class);
+        MergeInsert insert1 = mock(MergeInsert.class);
+        MergeInsert insert2 = mock(MergeInsert.class);
+
+        return Stream.of(
+                // just the two standard clauses present
+                Arguments.of(Arrays.asList(update1, insert1), update1, insert1, false),
+                Arguments.of(Arrays.asList(insert1, update1), update1, insert1, true),
+                // some clause(s) missing
+                Arguments.of(Collections.singletonList(update1), update1, null, false),
+                Arguments.of(Collections.singletonList(insert1), null, insert1, true),
+                Arguments.of(Collections.emptyList(), null, null, false),
+                // many clauses (non-standard)
+                Arguments.of(Arrays.asList(update1, update2, delete1, insert1, insert2), update1,
+                        insert1, false),
+                Arguments.of(Arrays.asList(insert1, insert2, update1, update2, delete1), update1,
+                        insert1, true));
     }
 }


### PR DESCRIPTION
This PR changes the parser to account for any number of `WHEN MATCHED` and/or `WHEN NOT MATCHED` clauses in a `MERGE` statement. This is most directly applicable to Snowflake. From their docs:

> A single MERGE statement can include multiple matching and not-matching clauses (i.e. WHEN MATCHED ... and WHEN NOT MATCHED ...).

```sql
MERGE INTO t1 USING t2 ON t1.t1Key = t2.t2Key
    WHEN MATCHED AND t2.marked = 1 THEN DELETE
    WHEN MATCHED AND t2.isNewStatus = 1 THEN UPDATE SET val = t2.newVal, status = t2.newStatus
    WHEN MATCHED THEN UPDATE SET val = t2.newVal
    WHEN NOT MATCHED THEN INSERT (val, status) VALUES (t2.newVal, t2.newStatus);
```

To achieve this, the parser now collects a list of `MergeOperation`s which can be a `WHEN MATCHED THEN DELETE` (newly added also), `WHEN MATCHED THEN UPDATE` or `WHEN NOT MATCHED THEN INSERT`.

The pre-existing getters that presume 0 or 1 of `MergeUpdate` and `MergeInsert` are preserved, but deprecated and suggest using the newly added `MergeOperationVisitor` instead, which is itself used for the deparser and validation logic internally.