### PR TITLE
feat: Build with Automatic-Module-Name for compatibility with the Java module system.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,14 @@ javadoc {
     options.addBooleanOption("Xdoclint:none", true)
 }
 
+jar {
+    manifest {
+        attributes (
+            "Automatic-Module-Name": "net.sf.jsqlparser"
+        )
+    }
+}
+
 tasks.register('xmldoc', Javadoc) {
     def outFile =  reporting.file(
             version.endsWith("-SNAPSHOT")

--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,17 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>net.sf.jsqlparser</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.12.1</version>
                 <executions>


### PR DESCRIPTION
I use the Java module system with my project, but JSQLParser doesn't use modules. As a result, I need to use the --add-reads ALL-UNNAMED hack in order to depend on it.

Building a project with the Automatic-Module-Name feature allows it to work with the module system, but without actually depending on the module system itself. This change makes it easier to integrate JSQLParser with projects that are using the Java module system.

I ran both the Maven and Gradle builds and verified that `Automatic-Module-Name: net.sf.jsqlparser` appears in the jar's MANIFEST.MF file.