### PR TITLE
fix: ExpressionVisitor.visit(AllTableColumns) method isn't being called.

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/AllTableColumns.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/AllTableColumns.java
@@ -9,6 +9,7 @@
  */
 package net.sf.jsqlparser.statement.select;
 
+import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
@@ -49,5 +50,10 @@ public class AllTableColumns extends AllColumns {
     @Override
     public StringBuilder appendTo(StringBuilder builder) {
         return super.appendTo(table.appendTo(builder).append("."));
+    }
+
+    @Override
+    public void accept(ExpressionVisitor expressionVisitor) {
+        expressionVisitor.visit(this);
     }
 }

--- a/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
@@ -15,6 +15,7 @@ import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
 import net.sf.jsqlparser.expression.operators.relational.InExpression;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.select.AllTableColumns;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
@@ -240,5 +241,22 @@ public class ExpressionVisitorAdapterTest {
         CCJSqlParserUtil.parseExpression(
                 "CAST(ROW(dataid, value, calcMark) AS ROW(datapointid CHAR, value CHAR, calcMark CHAR))")
                 .accept(adapter);
+    }
+
+    @Test
+    public void testAllTableColumns() throws JSQLParserException {
+        PlainSelect plainSelect = (PlainSelect) CCJSqlParserUtil.parse("select a.* from foo a");
+        final AllTableColumns[] holder = new AllTableColumns[1];
+        Expression from = plainSelect.getSelectItems().get(0).getExpression();
+        from.accept(new ExpressionVisitorAdapter() {
+
+            @Override
+            public void visit(AllTableColumns all) {
+                holder[0] = all;
+            }
+        });
+
+        assertNotNull(holder[0]);
+        assertEquals("a.*", holder[0].toString());
     }
 }


### PR DESCRIPTION
This fixes a regression introduced in change #4b4ae04f44ff18b669d0f30d637e5b7c64b085e4: feat: BigQuery Except(..) Replace(..) syntax

https://github.com/JSQLParser/JSqlParser/commit/4b4ae04f44ff18b669d0f30d637e5b7c64b085e4