### PR TITLE
fix: Fixes parsing failing for ALTER MODIFY queries not containing datatype

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -773,7 +773,8 @@ public class AlterExpression implements Serializable {
 
         @Override
         public String toString() {
-            return getColumnName() + (withType ? " TYPE " : " ") + toStringDataTypeAndSpec();
+            return getColumnName() + (withType ? " TYPE " : getColDataType() == null ? "" : " ")
+                + toStringDataTypeAndSpec();
         }
 
         @Override

--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -774,7 +774,7 @@ public class AlterExpression implements Serializable {
         @Override
         public String toString() {
             return getColumnName() + (withType ? " TYPE " : getColDataType() == null ? "" : " ")
-                + toStringDataTypeAndSpec();
+                    + toStringDataTypeAndSpec();
         }
 
         @Override

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/ColumnDefinition.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/ColumnDefinition.java
@@ -69,9 +69,10 @@ public class ColumnDefinition implements Serializable {
     }
 
     public String toStringDataTypeAndSpec() {
-        return (colDataType == null ? "" : colDataType) + (columnSpecs != null && !columnSpecs.isEmpty()
-                ? " " + PlainSelect.getStringList(columnSpecs, false, false)
-                : "");
+        return (colDataType == null ? "" : colDataType)
+                + (columnSpecs != null && !columnSpecs.isEmpty()
+                        ? " " + PlainSelect.getStringList(columnSpecs, false, false)
+                        : "");
     }
 
     public ColumnDefinition withColumnName(String columnName) {

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/ColumnDefinition.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/ColumnDefinition.java
@@ -69,7 +69,7 @@ public class ColumnDefinition implements Serializable {
     }
 
     public String toStringDataTypeAndSpec() {
-        return colDataType + (columnSpecs != null && !columnSpecs.isEmpty()
+        return (colDataType == null ? "" : colDataType) + (columnSpecs != null && !columnSpecs.isEmpty()
                 ? " " + PlainSelect.getStringList(columnSpecs, false, false)
                 : "");
     }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -6273,8 +6273,7 @@ AlterExpression AlterExpression():
             )
 
             (
-                LOOKAHEAD(2)
-                (<K_PRIMARY> <K_KEY> columnNames=ColumnsNamesList() { alterExp.setPkColumns(columnNames); })
+                LOOKAHEAD(2) (<K_PRIMARY> <K_KEY> columnNames=ColumnsNamesList() { alterExp.setPkColumns(columnNames); })
 
                 constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
                 [<K_USING> sk4=RelObjectName() { alterExp.addParameters("USING", sk4); }]

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -6144,9 +6144,9 @@ AlterExpression.ColumnDataType AlterExpressionColumnDataType():
     List<String> parameter = null;
 }
 {
-    columnName = RelObjectName()
+    columnName = RelObjectName() { columnSpecs = new ArrayList<String>(); }
     ( LOOKAHEAD(2) <K_TYPE> { withType = true; } )?
-    dataType = ColDataType() { columnSpecs = new ArrayList<String>(); }
+    ( LOOKAHEAD(2) dataType = ColDataType() )?
     ( parameter = CreateParameter() { columnSpecs.addAll(parameter); } )*
     {
         return new AlterExpression.ColumnDataType(columnName, withType, dataType, columnSpecs);
@@ -6273,7 +6273,8 @@ AlterExpression AlterExpression():
             )
 
             (
-                LOOKAHEAD(2) (<K_PRIMARY> <K_KEY> columnNames=ColumnsNamesList() { alterExp.setPkColumns(columnNames); })
+                LOOKAHEAD(2)
+                (<K_PRIMARY> <K_KEY> columnNames=ColumnsNamesList() { alterExp.setPkColumns(columnNames); })
 
                 constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
                 [<K_USING> sk4=RelObjectName() { alterExp.addParameters("USING", sk4); }]
@@ -6289,6 +6290,10 @@ AlterExpression AlterExpression():
                   constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
                   [<K_USING> sk4=RelObjectName() { alterExp.addParameters("USING", sk4); }]
                   [ index = IndexWithComment(index) { alterExp.setIndex(index); } ]
+                )
+                |
+                LOOKAHEAD(2) (
+                  sk3=RelObjectName() <K_COMMENT> tk=<S_CHAR_LITERAL> { alterExp.withColumnName(sk3).withCommentText(tk.image); }
                 )
                 |
                 LOOKAHEAD(3) (
@@ -6433,8 +6438,6 @@ AlterExpression AlterExpression():
                     )
                    )
                 )
-                |
-                ( sk3=RelObjectName() <K_COMMENT> tk=<S_CHAR_LITERAL> { alterExp.withColumnName(sk3).withCommentText(tk.image); } )
               )
       )
       |

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -363,7 +363,7 @@ public class AlterTest {
     @Test
     public void testAlterTableModifyColumn3() throws JSQLParserException {
         Alter alter =
-            (Alter) CCJSqlParserUtil.parse("ALTER TABLE mytable modify col1 NULL");
+                (Alter) CCJSqlParserUtil.parse("ALTER TABLE mytable modify col1 NULL");
         AlterExpression alterExpression = alter.getAlterExpressions().get(0);
 
         // COLUMN keyword DOES NOT appear in deparsed statement, modify becomes all caps
@@ -377,7 +377,7 @@ public class AlterTest {
     @Test
     public void testAlterTableModifyColumn4() throws JSQLParserException {
         Alter alter =
-            (Alter) CCJSqlParserUtil.parse("ALTER TABLE mytable modify col1 DEFAULT 0");
+                (Alter) CCJSqlParserUtil.parse("ALTER TABLE mytable modify col1 DEFAULT 0");
         AlterExpression alterExpression = alter.getAlterExpressions().get(0);
 
         // COLUMN keyword DOES NOT appear in deparsed statement, modify becomes all caps

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -361,6 +361,34 @@ public class AlterTest {
     }
 
     @Test
+    public void testAlterTableModifyColumn3() throws JSQLParserException {
+        Alter alter =
+            (Alter) CCJSqlParserUtil.parse("ALTER TABLE mytable modify col1 NULL");
+        AlterExpression alterExpression = alter.getAlterExpressions().get(0);
+
+        // COLUMN keyword DOES NOT appear in deparsed statement, modify becomes all caps
+        assertStatementCanBeDeparsedAs(alter, "ALTER TABLE mytable MODIFY col1 NULL");
+
+        assertEquals(AlterOperation.MODIFY, alterExpression.getOperation());
+
+        assertFalse(alterExpression.hasColumn());
+    }
+
+    @Test
+    public void testAlterTableModifyColumn4() throws JSQLParserException {
+        Alter alter =
+            (Alter) CCJSqlParserUtil.parse("ALTER TABLE mytable modify col1 DEFAULT 0");
+        AlterExpression alterExpression = alter.getAlterExpressions().get(0);
+
+        // COLUMN keyword DOES NOT appear in deparsed statement, modify becomes all caps
+        assertStatementCanBeDeparsedAs(alter, "ALTER TABLE mytable MODIFY col1 DEFAULT 0");
+
+        assertEquals(AlterOperation.MODIFY, alterExpression.getOperation());
+
+        assertFalse(alterExpression.hasColumn());
+    }
+
+    @Test
     public void testAlterTableAlterColumn() throws JSQLParserException {
         // http://www.postgresqltutorial.com/postgresql-change-column-type/
         String sql =


### PR DESCRIPTION
Hi, I took a pass at fixing #1727 
This PR makes colDataType an optional value, so we can parse queries like
`ALTER TABLE table MODIFY col1 NULL`