### PR TITLE
Guard Values against null/empty values

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/DoubleValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/DoubleValue.java
@@ -24,6 +24,9 @@ public class DoubleValue extends ASTNodeAccessImpl implements Expression {
     }
 
     public DoubleValue(final String value) {
+        if (value == null || value.length() == 0) {
+            throw new IllegalArgumentException("value can neither be null nor empty.");
+        }
         String val = value;
         if (val.charAt(0) == '+') {
             val = val.substring(1);

--- a/src/main/java/net/sf/jsqlparser/expression/LongValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/LongValue.java
@@ -26,6 +26,9 @@ public class LongValue extends ASTNodeAccessImpl implements Expression {
     }
 
     public LongValue(final String value) {
+        if (value == null || value.length() == 0) {
+            throw new IllegalArgumentException("value can neither be null nor empty.");
+        }
         String val = value;
         if (val.charAt(0) == '+') {
             val = val.substring(1);

--- a/src/main/java/net/sf/jsqlparser/expression/TimeValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/TimeValue.java
@@ -25,6 +25,9 @@ public class TimeValue extends ASTNodeAccessImpl implements Expression {
     }
 
     public TimeValue(String value) {
+        if (value == null || value.length() == 0) {
+            throw new IllegalArgumentException("value can neither be null nor empty.");
+        }
         this.value = Time.valueOf(value.substring(1, value.length() - 1));
     }
 

--- a/src/test/java/net/sf/jsqlparser/expression/DoubleValueTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/DoubleValueTest.java
@@ -1,0 +1,31 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class DoubleValueTest {
+
+    @Test
+    public void testNullValue() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new DoubleValue(null);
+        });
+    }
+
+    @Test
+    public void testEmptyValue() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new DoubleValue("");
+        });
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/expression/LongValueTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/LongValueTest.java
@@ -40,7 +40,7 @@ public class LongValueTest {
             value.getValue();
             fail("should not work");
         } catch (Exception e) {
-            //expected to fail
+            // expected to fail
         }
         assertEquals(new BigInteger(largeNumber), value.getBigIntegerValue());
     }

--- a/src/test/java/net/sf/jsqlparser/expression/LongValueTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/LongValueTest.java
@@ -11,6 +11,7 @@ package net.sf.jsqlparser.expression;
 
 import java.math.BigInteger;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
 
@@ -42,5 +43,19 @@ public class LongValueTest {
             //expected to fail
         }
         assertEquals(new BigInteger(largeNumber), value.getBigIntegerValue());
+    }
+
+    @Test
+    public void testNullStringValue() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new LongValue((String) null);
+        });
+    }
+
+    @Test
+    public void testEmptyStringValue() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new LongValue("");
+        });
     }
 }

--- a/src/test/java/net/sf/jsqlparser/expression/TimeValueTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/TimeValueTest.java
@@ -1,0 +1,31 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TimeValueTest {
+
+    @Test
+    public void testNullValue() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new TimeValue(null);
+        });
+    }
+
+    @Test
+    public void testEmptyValue() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new TimeValue("");
+        });
+    }
+}


### PR DESCRIPTION
This PR intends to implement suitable guards for the constructors of the classes `DoubleValue`, `LongValue`, and `TimeValue`.
Both `null` and empty strings provided to their constructors fail, but they provide very different error messages (NullPointerException and StringIndexOutOfBoundsException),
which is neither sensible nor helpful in debugging.
This PR adds a guard to throw `IllegalArgumentException` for both cases in order to improve coherency and usefulness of the error messages.