### PR TITLE
Handle select in ExpressionVisitorAdapter

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -283,14 +283,7 @@ public class ExpressionVisitorAdapter
 
     @Override
     public void visit(ParenthesedSelect selectBody) {
-        if (selectVisitor != null) {
-            if (selectBody.getWithItemsList() != null) {
-                for (WithItem item : selectBody.getWithItemsList()) {
-                    item.accept(selectVisitor);
-                }
-            }
-            selectBody.accept(selectVisitor);
-        }
+        visit((Select) selectBody);
         if (selectBody.getPivot() != null) {
             selectBody.getPivot().accept(this);
         }
@@ -663,7 +656,14 @@ public class ExpressionVisitorAdapter
 
     @Override
     public void visit(Select selectBody) {
-
+        if (selectVisitor != null) {
+            if (selectBody.getWithItemsList() != null) {
+                for (WithItem item : selectBody.getWithItemsList()) {
+                    item.accept(selectVisitor);
+                }
+            }
+            selectBody.accept(selectVisitor);
+        }
     }
 
     @Override


### PR DESCRIPTION
The ExpressionVisitorAdapter could handle Select to simplify the implementation of its children.

I've suggested an implementation that extracts portions from the ParenthesedSelect handling. Do take a look and let me know if this is fine.