### PR TITLE
support custom DeParser

### DIFF
--- a/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
@@ -90,10 +90,7 @@ public class DeleteDeParser extends AbstractDeParser<Delete> {
             }
         }
 
-        if (delete.getWhere() != null) {
-            buffer.append(" WHERE ");
-            delete.getWhere().accept(expressionVisitor);
-        }
+        deparseWhereClause(delete);
 
         if (delete.getOrderByElements() != null) {
             new OrderByDeParser(expressionVisitor, buffer).deParse(delete.getOrderByElements());
@@ -106,6 +103,13 @@ public class DeleteDeParser extends AbstractDeParser<Delete> {
             delete.getReturningClause().appendTo(buffer);
         }
 
+    }
+
+    protected void deparseWhereClause(Delete delete) {
+        if (delete.getWhere() != null) {
+            buffer.append(" WHERE ");
+            delete.getWhere().accept(expressionVisitor);
+        }
     }
 
     public ExpressionVisitor getExpressionVisitor() {

--- a/src/main/java/net/sf/jsqlparser/util/deparser/MergeDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/MergeDeParser.java
@@ -28,7 +28,7 @@ public class MergeDeParser extends AbstractDeParser<Merge> implements MergeOpera
     }
 
     @Override
-    void deParse(Merge merge) {
+    public void deParse(Merge merge) {
         List<WithItem> withItemsList = merge.getWithItemsList();
         if (withItemsList != null && !withItemsList.isEmpty()) {
             buffer.append("WITH ");
@@ -115,4 +115,11 @@ public class MergeDeParser extends AbstractDeParser<Merge> implements MergeOpera
         }
     }
 
+    public ExpressionDeParser getExpressionDeParser() {
+        return expressionDeParser;
+    }
+
+    public SelectDeParser getSelectDeParser() {
+        return selectDeParser;
+    }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -361,4 +361,12 @@ public class StatementDeParser extends AbstractDeParser<Statement> implements St
     public void visit(UnsupportedStatement unsupportedStatement) {
         unsupportedStatement.appendTo(buffer);
     }
+
+    public ExpressionDeParser getExpressionDeParser() {
+        return expressionDeParser;
+    }
+
+    public SelectDeParser getSelectDeParser() {
+        return selectDeParser;
+    }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/UpdateDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/UpdateDeParser.java
@@ -69,7 +69,7 @@ public class UpdateDeParser extends AbstractDeParser<Update> implements OrderByV
         }
         buffer.append(" SET ");
 
-        deparseUpdateSets(update.getUpdateSets(), buffer, expressionVisitor);
+        deparseUpdateSetsClause(update);
 
         if (update.getOutputClause() != null) {
             update.getOutputClause().appendTo(buffer);
@@ -88,10 +88,8 @@ public class UpdateDeParser extends AbstractDeParser<Update> implements OrderByV
             }
         }
 
-        if (update.getWhere() != null) {
-            buffer.append(" WHERE ");
-            update.getWhere().accept(expressionVisitor);
-        }
+        deparseWhereClause(update);
+
         if (update.getOrderByElements() != null) {
             new OrderByDeParser(expressionVisitor, buffer).deParse(update.getOrderByElements());
         }
@@ -103,6 +101,18 @@ public class UpdateDeParser extends AbstractDeParser<Update> implements OrderByV
             update.getReturningClause().appendTo(buffer);
         }
     }
+
+    protected void deparseWhereClause(Update update) {
+        if (update.getWhere() != null) {
+            buffer.append(" WHERE ");
+            update.getWhere().accept(expressionVisitor);
+        }
+    }
+
+    protected void deparseUpdateSetsClause(Update update) {
+        deparseUpdateSets(update.getUpdateSets(), buffer, expressionVisitor);
+    }
+
 
     public ExpressionVisitor getExpressionVisitor() {
         return expressionVisitor;


### PR DESCRIPTION
My requirement scenario is ：
sql template "SELECT * FROM user WHERE name = :param_name AND status = :param_status"
where param_name and param_status both is null, need generated sql: "SELECT * FROM user"
where param_name is not null, param_status is null, need generated sql: "SELECT * FROM user WHERE name = ? "
so deParse where expression maybe is empty

deparseDistinctClause、deparseSelectItemsClause、deparseOrderByElementsClause requires two parameters ,
Parameter plainSelect mainly used to determine the current selection. like：
```java
  @Override
  protected void deparseDistinctClause(PlainSelect plainSelect, Distinct distinct) {
    if (this.countSelect != plainSelect) {
        super.deparseDistinctClause(plainSelect, distinct);
    } else {
        super.deparseDistinctClause(plainSelect, this.countDistinct);
    }
}

protected void deparseSelectItemsClause(PlainSelect plainSelect, List<SelectItem<?>> selectItems) {
    if (this.countSelect != plainSelect) {
        super.deparseSelectItemsClause(plainSelect, selectItems);
    } else {
        super.deparseSelectItemsClause(plainSelect, this.countRootSelectItems);
    }
}

protected void deparseOrderByElementsClause(PlainSelect plainSelect, List<OrderByElement> orderByElements) {
    if (this.countSelect != plainSelect) {
        super.deparseOrderByElementsClause(plainSelect, orderByElements);
    } else {
        super.deparseOrderByElementsClause(plainSelect, null);
    }
}
```