### PR TITLE
feat: Allow OUTER keyword as function parameter name

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4619,15 +4619,16 @@ JdbcNamedParameter JdbcNamedParameter() : {
 }
 
 OracleNamedFunctionParameter OracleNamedFunctionParameter() : {
-    String name;
+    Token token = null;
+    String name = null;
     Expression expression;
 }
 {
-    name=RelObjectNameExt2()
+    ( name=RelObjectNameExt2() | token=<K_OUTER> )
     <K_ORACLE_NAMED_PARAMETER_ASSIGNMENT>
     expression=Expression()
     {
-        return new OracleNamedFunctionParameter(name, expression);
+        return new OracleNamedFunctionParameter(name != null ? name : token.image, expression);
     }
 }
 

--- a/src/test/java/net/sf/jsqlparser/statement/select/TableFunctionTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/TableFunctionTest.java
@@ -31,4 +31,20 @@ class TableFunctionTest {
         TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
     }
 
+    /**
+     * The SQL keyword "OUTER" is a valid parameter name for Snowflake's FLATTEN table function.
+     */
+    @Test
+    void testTableFunctionWithNamedParameterWhereNameIsOuterKeyword() throws JSQLParserException {
+        String sqlStr =
+                "INSERT INTO db.schema.target\n" +
+                "     (Name, FriendParent)\n" +
+                " SELECT\n" +
+                "     i.DATA_VALUE:Name AS Name,\n" +
+                "     f1.Value:Parent:Name AS FriendParent\n" +
+                " FROM\n" +
+                "     db.schema.source AS i,\n" +
+                "     lateral flatten(input => i.DATA_VALUE:Friends, outer => true) AS f1;";
+        TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/TableFunctionTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/TableFunctionTest.java
@@ -38,13 +38,13 @@ class TableFunctionTest {
     void testTableFunctionWithNamedParameterWhereNameIsOuterKeyword() throws JSQLParserException {
         String sqlStr =
                 "INSERT INTO db.schema.target\n" +
-                "     (Name, FriendParent)\n" +
-                " SELECT\n" +
-                "     i.DATA_VALUE:Name AS Name,\n" +
-                "     f1.Value:Parent:Name AS FriendParent\n" +
-                " FROM\n" +
-                "     db.schema.source AS i,\n" +
-                "     lateral flatten(input => i.DATA_VALUE:Friends, outer => true) AS f1;";
+                        "     (Name, FriendParent)\n" +
+                        " SELECT\n" +
+                        "     i.DATA_VALUE:Name AS Name,\n" +
+                        "     f1.Value:Parent:Name AS FriendParent\n" +
+                        " FROM\n" +
+                        "     db.schema.source AS i,\n" +
+                        "     lateral flatten(input => i.DATA_VALUE:Friends, outer => true) AS f1;";
         TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
     }
 }


### PR DESCRIPTION
# Context
SQL keywords are sometimes allowed as parameter names in table functions. For example, the following statement is valid on Snowflake:
```
INSERT INTO db.schema.target
    (Name, FriendParent)
SELECT
    i.DATA_VALUE:Name AS Name,
    f1.Value:Parent:Name AS FriendParent
FROM
    db.schema.source AS i,
    flatten(input => i.DATA_VALUE:Friends, outer => true) AS f1
```
Note that the second named parameter passed to the table function `flatten` is `outer`, which is a SQL keyword, and it is unquoted.

Currently, statements like this fail to parse, I think because SQL keywords are not allowed as parameter names. However, as this is a valid statement, I'd like to be able to parse it.

# Details
The production in the grammar which handles named parameters is `OracleNamedFunctionParameter`. Currently, this is using the `RelObjectNameExt2` production to match the parameter name. I think (although I don't understand how) this does not match keywords. Since parameter names are not objects, I thought we could use the `<S_IDENTIFIER>` token, which looks like it should match something like `outer`. However, this doesn't appear to match keywords, again I don't understand how - looking at the `<S_IDENTIFIER>` token, it looks like it will match any sequence of unicode characters 🤔 . As a simple (probably wrong) solution, I've manually added the `<K_OUTER>` token as a possible match in `OracleNamedFunctionParameter`:
```
( name=RelObjectNameExt2() | token=<K_OUTER> )
```
But this feels wrong. I don't think parameter names necessarily need to be valid object names, hence why I wanted to use `<S_IDENTIFIER>`, but I can't work out why `<S_IDENTIFIER>` won't match keywords. Happy to discuss this further, any help would be much appreciated!