### PR TITLE
fix truncate parsing to capture multiple tables

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/truncate/Truncate.java
+++ b/src/main/java/net/sf/jsqlparser/statement/truncate/Truncate.java
@@ -68,8 +68,7 @@ public class Truncate implements Statement {
             sb.append(tables.stream()
                 .map(Table::toString)
                 .collect(joining(", ")));
-        }
-        else {
+        } else {
             sb.append(table);
         }
         if (cascade) {

--- a/src/main/java/net/sf/jsqlparser/statement/truncate/Truncate.java
+++ b/src/main/java/net/sf/jsqlparser/statement/truncate/Truncate.java
@@ -9,6 +9,9 @@
  */
 package net.sf.jsqlparser.statement.truncate;
 
+import static java.util.stream.Collectors.joining;
+
+import java.util.List;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
@@ -19,6 +22,7 @@ public class Truncate implements Statement {
     boolean tableToken; // to support TRUNCATE without TABLE
     boolean only; // to support TRUNCATE with ONLY
     private Table table;
+    private List<Table> tables;
 
     @Override
     public <T, S> T accept(StatementVisitor<T> statementVisitor, S context) {
@@ -29,8 +33,16 @@ public class Truncate implements Statement {
         return table;
     }
 
+    public List<Table> getTables() {
+        return tables;
+    }
+
     public void setTable(Table table) {
         this.table = table;
+    }
+
+    public void setTables(List<Table> tables) {
+        this.tables = tables;
     }
 
     public boolean getCascade() {
@@ -52,8 +64,14 @@ public class Truncate implements Statement {
             sb.append(" ONLY");
         }
         sb.append(" ");
-        sb.append(table);
-
+        if (tables != null && !tables.isEmpty()) {
+            sb.append(tables.stream()
+                .map(Table::toString)
+                .collect(joining(", ")));
+        }
+        else {
+            sb.append(table);
+        }
         if (cascade) {
             sb.append(" CASCADE");
         }
@@ -83,6 +101,11 @@ public class Truncate implements Statement {
 
     public Truncate withTable(Table table) {
         this.setTable(table);
+        return this;
+    }
+
+    public Truncate withTables(List<Table> tables) {
+        this.setTables(tables);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -9,9 +9,12 @@
  */
 package net.sf.jsqlparser.util.deparser;
 
+import static java.util.stream.Collectors.joining;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.stream.Collectors;
 
+import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Block;
 import net.sf.jsqlparser.statement.Commit;
 import net.sf.jsqlparser.statement.CreateFunctionalStatement;
@@ -180,8 +183,14 @@ public class StatementDeParser extends AbstractDeParser<Statement>
             buffer.append(" ONLY");
         }
         buffer.append(" ");
-        buffer.append(truncate.getTable());
-
+        if (truncate.getTables() != null && !truncate.getTables().isEmpty()) {
+            buffer.append(truncate.getTables().stream()
+                .map(Table::toString)
+                .collect(joining(", ")));
+        }
+        else {
+            buffer.append(truncate.getTable());
+        }
         if (truncate.getCascade()) {
             buffer.append(" CASCADE");
         }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -187,8 +187,7 @@ public class StatementDeParser extends AbstractDeParser<Statement>
             buffer.append(truncate.getTables().stream()
                 .map(Table::toString)
                 .collect(joining(", ")));
-        }
-        else {
+        } else {
             buffer.append(truncate.getTable());
         }
         if (truncate.getCascade()) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -6633,8 +6633,8 @@ Truncate Truncate():
     <K_TRUNCATE>
     [LOOKAHEAD(2) <K_TABLE>  {truncate.setTableToken(true);}]
     [<K_ONLY>  { only = true; }]
-	  table=Table() { tables.add(table); } (LOOKAHEAD(2) "," table=Table() { tables.add(table); } )*
-	  [<K_CASCADE> { cascade = true; }]
+    table=Table() { tables.add(table); } (LOOKAHEAD(2) "," table=Table() { tables.add(table); } )*
+    [<K_CASCADE> { cascade = true; }]
     {
        if (only && tables.size() > 1 ) {
           throw new ParseException("Cannot TRUNCATE ONLY with multiple tables");

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -6633,17 +6633,18 @@ Truncate Truncate():
     <K_TRUNCATE>
     [LOOKAHEAD(2) <K_TABLE>  {truncate.setTableToken(true);}]
     [<K_ONLY>  { only = true; }]
-    table=Table() { tables.add(table); } (LOOKAHEAD(3) "," table=Table() { tables.add(table); } )*
+    table=Table() { tables.add(table); } (LOOKAHEAD(2) "," table=Table() { tables.add(table); } )*
     [<K_CASCADE> { cascade = true; }]
     {
        if (only && tables.size() > 1 ) {
           throw new ParseException("Cannot TRUNCATE ONLY with multiple tables");
+       } else {
+          return truncate
+             .withTables(tables)
+             .withTable(table)
+             .withOnly(only)
+             .withCascade(cascade);
        }
-       return truncate
-          .withTables(tables)
-          .withTable(table)
-          .withOnly(only)
-          .withCascade(cascade);
     }
 }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -6633,7 +6633,7 @@ Truncate Truncate():
     <K_TRUNCATE>
     [LOOKAHEAD(2) <K_TABLE>  {truncate.setTableToken(true);}]
     [<K_ONLY>  { only = true; }]
-    table=Table() { tables.add(table); } (LOOKAHEAD(2) "," table=Table() { tables.add(table); } )*
+    table=Table() { tables.add(table); } (LOOKAHEAD(3) "," table=Table() { tables.add(table); } )*
     [<K_CASCADE> { cascade = true; }]
     {
        if (only && tables.size() > 1 ) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -6630,8 +6630,11 @@ Truncate Truncate():
 *      [ RESTART IDENTITY | CONTINUE IDENTITY ] [ CASCADE | RESTRICT ]
 *
 */
-    <K_TRUNCATE> [LOOKAHEAD(2) <K_TABLE>  {truncate.setTableToken(true);}] [<K_ONLY>  { only = true; }]
-	table=Table() { tables.add(table); } ("," table=Table() { tables.add(table); } )* [<K_CASCADE> { cascade = true; } ]
+    <K_TRUNCATE>
+    [LOOKAHEAD(2) <K_TABLE>  {truncate.setTableToken(true);}]
+    [<K_ONLY>  { only = true; }]
+	  table=Table() { tables.add(table); } (LOOKAHEAD(2) "," table=Table() { tables.add(table); } )*
+	  [<K_CASCADE> { cascade = true; }]
     {
        if (only && tables.size() > 1 ) {
           throw new ParseException("Cannot TRUNCATE ONLY with multiple tables");

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -6617,6 +6617,9 @@ Truncate Truncate():
 {
     Truncate truncate = new Truncate();
     Table table;
+    List<Table> tables = new ArrayList<Table>();
+    boolean only = false;
+    boolean cascade = false;
 }
 {
 /**
@@ -6627,13 +6630,19 @@ Truncate Truncate():
 *      [ RESTART IDENTITY | CONTINUE IDENTITY ] [ CASCADE | RESTRICT ]
 *
 */
-    <K_TRUNCATE> [LOOKAHEAD(2) <K_TABLE>  {truncate.setTableToken(true);}] [<K_ONLY>  {truncate.setOnly(true);}]
-	table=Table() { truncate.setTable(table); truncate.setCascade(false); } [ <K_CASCADE> {truncate.setCascade(true);} ]
+    <K_TRUNCATE> [LOOKAHEAD(2) <K_TABLE>  {truncate.setTableToken(true);}] [<K_ONLY>  { only = true; }]
+	table=Table() { tables.add(table); } ("," table=Table() { tables.add(table); } )* [<K_CASCADE> { cascade = true; } ]
     {
-        return truncate;
+       if (only && tables.size() > 1 ) {
+          throw new ParseException("Cannot TRUNCATE ONLY with multiple tables");
+       }
+       return truncate
+          .withTables(tables)
+          .withTable(table)
+          .withOnly(only)
+          .withCascade(cascade);
     }
 }
-
 
 AlterExpression.ColumnDataType AlterExpressionColumnDataType():
 {

--- a/src/test/java/net/sf/jsqlparser/statement/truncate/TruncateMultipleTablesTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/truncate/TruncateMultipleTablesTest.java
@@ -1,0 +1,110 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.truncate;
+
+import static net.sf.jsqlparser.test.TestUtils.assertDeparse;
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringReader;
+import java.util.List;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserManager;
+import net.sf.jsqlparser.schema.Table;
+import org.junit.jupiter.api.Test;
+
+public class TruncateMultipleTablesTest {
+
+    private CCJSqlParserManager parserManager = new CCJSqlParserManager();
+
+    @Test
+    public void testTruncate2Tables() throws Exception {
+        String statement = "TRUncATE TABLE myschema.mytab, myschema2.mytab2";
+        Truncate truncate = (Truncate) parserManager.parse(new StringReader(statement));
+        assertEquals("myschema2", truncate.getTable().getSchemaName());
+        assertEquals("myschema2.mytab2", truncate.getTable().getFullyQualifiedName());
+        assertEquals(statement.toUpperCase(), truncate.toString().toUpperCase());
+        assertEquals("myschema.mytab", truncate.getTables().get(0).getFullyQualifiedName());
+        assertEquals("myschema2.mytab2", truncate.getTables().get(1).getFullyQualifiedName());
+
+        statement = "TRUncATE   TABLE    mytab,     my2ndtab";
+        String toStringStatement = "TRUncATE TABLE mytab, my2ndtab";
+        truncate = (Truncate) parserManager.parse(new StringReader(statement));
+        assertEquals("my2ndtab", truncate.getTable().getName());
+        assertEquals(toStringStatement.toUpperCase(), truncate.toString().toUpperCase());
+        assertEquals("mytab", truncate.getTables().get(0).getFullyQualifiedName());
+        assertEquals("my2ndtab", truncate.getTables().get(1).getFullyQualifiedName());
+
+        statement = "TRUNCATE TABLE mytab, my2ndtab CASCADE";
+        truncate = (Truncate) parserManager.parse(new StringReader(statement));
+        assertNull(truncate.getTables().get(0).getSchemaName());
+        assertEquals("mytab", truncate.getTables().get(0).getFullyQualifiedName());
+        assertEquals("my2ndtab", truncate.getTables().get(1).getFullyQualifiedName());
+        assertTrue(truncate.getCascade());
+        assertEquals(statement, truncate.toString());
+    }
+
+    @Test
+    public void testTruncatePostgresqlWithoutTableNames() throws Exception {
+        String statement = "TRUncATE myschema.mytab, myschema2.mytab2";
+        Truncate truncate = (Truncate) parserManager.parse(new StringReader(statement));
+        assertEquals("myschema2", truncate.getTable().getSchemaName());
+        assertEquals("myschema2.mytab2", truncate.getTable().getFullyQualifiedName());
+        assertEquals(statement.toUpperCase(), truncate.toString().toUpperCase());
+        assertEquals("myschema.mytab", truncate.getTables().get(0).getFullyQualifiedName());
+        assertEquals("myschema2.mytab2", truncate.getTables().get(1).getFullyQualifiedName());
+
+        statement = "TRUncATE      mytab,     my2ndtab";
+        String toStringStatement = "TRUncATE mytab, my2ndtab";
+        truncate = (Truncate) parserManager.parse(new StringReader(statement));
+        assertEquals("my2ndtab", truncate.getTable().getName());
+        assertEquals(toStringStatement.toUpperCase(), truncate.toString().toUpperCase());
+        assertEquals("mytab", truncate.getTables().get(0).getFullyQualifiedName());
+        assertEquals("my2ndtab", truncate.getTables().get(1).getFullyQualifiedName());
+
+        statement = "TRUNCATE mytab, my2ndtab CASCADE";
+        truncate = (Truncate) parserManager.parse(new StringReader(statement));
+        assertNull(truncate.getTables().get(0).getSchemaName());
+        assertEquals("mytab", truncate.getTables().get(0).getFullyQualifiedName());
+        assertEquals("my2ndtab", truncate.getTables().get(1).getFullyQualifiedName());
+        assertTrue(truncate.getCascade());
+        assertEquals(statement, truncate.toString());
+    }
+
+    @Test
+    public void testTruncateDeparse() throws JSQLParserException {
+        String statement = "TRUNCATE TABLE foo, bar";
+        assertSqlCanBeParsedAndDeparsed(statement);
+        assertDeparse(new Truncate()
+            .withTables(List.of(new Table("foo"), new Table("bar")))
+            .withTableToken(true), statement);
+    }
+
+    @Test
+    public void testTruncateCascadeDeparse() throws JSQLParserException {
+        String statement = "TRUNCATE TABLE foo, bar CASCADE";
+        assertSqlCanBeParsedAndDeparsed(statement);
+        assertDeparse(new Truncate()
+            .withTables(List.of(new Table("foo"), new Table("bar")))
+            .withTableToken(true)
+            .withCascade(true), statement);
+    }
+
+    @Test
+    public void testTruncateDoesNotAllowOnlyWithMultipleTables() {
+        String statement = "TRUNCATE TABLE ONLY foo, bar";
+        assertThrows(JSQLParserException.class,
+            () -> parserManager.parse(new StringReader(statement)));
+    }
+
+}

--- a/src/test/java/net/sf/jsqlparser/statement/truncate/TruncateTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/truncate/TruncateTest.java
@@ -71,8 +71,8 @@ public class TruncateTest {
         String statement = "TRUNCATE TABLE foo";
         assertSqlCanBeParsedAndDeparsed(statement);
         assertDeparse(new Truncate()
-                .withTable(new Table("foo"))
-                .withTableToken(true), statement);
+            .withTable(new Table("foo"))
+            .withTableToken(true), statement);
     }
 
     @Test
@@ -80,19 +80,28 @@ public class TruncateTest {
         String statement = "TRUNCATE TABLE foo CASCADE";
         assertSqlCanBeParsedAndDeparsed(statement);
         assertDeparse(new Truncate()
-                .withTable(new Table("foo"))
-                .withTableToken(true)
-                .withCascade(true), statement);
+            .withTable(new Table("foo"))
+            .withTableToken(true)
+            .withCascade(true), statement);
     }
 
     @Test
     public void testTruncateOnlyDeparse() throws JSQLParserException {
-        String statement = "TRUNCATE TABLE ONLY foo CASCADE";
+        String statement = "TRUNCATE TABLE ONLY foo";
         assertSqlCanBeParsedAndDeparsed(statement);
         assertDeparse(new Truncate()
-                .withTable(new Table("foo"))
-                .withCascade(true)
-                .withTableToken(true)
-                .withOnly(true), statement);
+            .withTable(new Table("foo"))
+            .withTableToken(true)
+            .withOnly(true), statement);
+    }
+
+    @Test
+    public void testTruncateOnlyAndCascadeDeparse() throws JSQLParserException {
+        String statement = "TRUNCATE ONLY foo CASCADE";
+        assertSqlCanBeParsedAndDeparsed(statement);
+        assertDeparse(new Truncate()
+            .withTable(new Table("foo"))
+            .withCascade(true)
+            .withOnly(true), statement);
     }
 }


### PR DESCRIPTION
Looking to address this issue -> https://github.com/JSQLParser/JSqlParser/issues/2047

**Problem**

Truncate statements with multiple tables do not parse

**Solution**

- Add test scenarios
- Add `getTables`, `setTables` and `withTables` methods to the `Truncate` class
- Update `JSqlParserCC.jjt` + `StatementDeParser`