### PR TITLE
chore adding extra details to unit test scenarios

### DIFF
--- a/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
@@ -10,6 +10,8 @@
 package net.sf.jsqlparser.statement.delete;
 
 import java.io.StringReader;
+import java.util.List;
+
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.LongValue;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
@@ -22,6 +24,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.sf.jsqlparser.statement.select.SelectItem;
+import net.sf.jsqlparser.statement.select.WithItem;
 import org.junit.jupiter.api.Test;
 
 public class DeleteTest {
@@ -118,8 +123,19 @@ public class DeleteTest {
                 + "DELETE FROM cfe.instrument_ref\n"
                 + "WHERE  id_instrument_ref = (SELECT id_instrument_ref\n"
                 + "                            FROM   a)";
-
         assertSqlCanBeParsedAndDeparsed(statement, true);
+        Delete delete = (Delete) parserManager.parse(new StringReader(statement));
+        List<WithItem> withItems = delete.getWithItemsList();
+        assertEquals("cfe.instrument_ref", delete.getTable().getFullyQualifiedName());
+        assertEquals(2, withItems.size());
+        SelectItem selectItem1 = withItems.get(0).getSelect().getPlainSelect().getSelectItems().get(0);
+        assertEquals("1", selectItem1.getExpression().toString());
+        assertEquals(" id_instrument_ref", selectItem1.getAlias().toString());
+        assertEquals(" a", withItems.get(0).getAlias().toString());
+        SelectItem selectItem2 = withItems.get(1).getSelect().getPlainSelect().getSelectItems().get(0);
+        assertEquals("1", selectItem2.getExpression().toString());
+        assertEquals(" id_instrument_ref", selectItem2.getAlias().toString());
+        assertEquals(" b", withItems.get(1).getAlias().toString());
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/delete/DeleteTest.java
@@ -123,8 +123,7 @@ public class DeleteTest {
                 + "DELETE FROM cfe.instrument_ref\n"
                 + "WHERE  id_instrument_ref = (SELECT id_instrument_ref\n"
                 + "                            FROM   a)";
-        assertSqlCanBeParsedAndDeparsed(statement, true);
-        Delete delete = (Delete) parserManager.parse(new StringReader(statement));
+        Delete delete = (Delete) assertSqlCanBeParsedAndDeparsed(statement, true);
         List<WithItem> withItems = delete.getWithItemsList();
         assertEquals("cfe.instrument_ref", delete.getTable().getFullyQualifiedName());
         assertEquals(2, withItems.size());

--- a/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
@@ -16,23 +16,23 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.JdbcParameter;
 import net.sf.jsqlparser.expression.LongValue;
 import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.expression.operators.relational.ExistsExpression;
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
 import net.sf.jsqlparser.expression.operators.relational.ParenthesedExpressionList;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
-import net.sf.jsqlparser.statement.select.AllColumns;
-import net.sf.jsqlparser.statement.select.PlainSelect;
-import net.sf.jsqlparser.statement.select.Select;
-import net.sf.jsqlparser.statement.select.Values;
+import net.sf.jsqlparser.statement.select.*;
 import net.sf.jsqlparser.statement.update.UpdateSet;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
 import java.io.StringReader;
+import java.util.List;
 
+import static junit.framework.Assert.assertNull;
 import static net.sf.jsqlparser.test.TestUtils.assertDeparse;
 import static net.sf.jsqlparser.test.TestUtils.assertOracleHintExists;
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
@@ -277,12 +277,27 @@ public class InsertTest {
 
     @Test
     public void testInsertWithSelect() throws JSQLParserException {
-        assertSqlCanBeParsedAndDeparsed(
-                "INSERT INTO mytable (mycolumn) WITH a AS (SELECT mycolumn FROM mytable) SELECT mycolumn FROM a",
-                true);
-        assertSqlCanBeParsedAndDeparsed(
-                "INSERT INTO mytable (mycolumn) (WITH a AS (SELECT mycolumn FROM mytable) SELECT mycolumn FROM a)",
-                true);
+        String sqlStr1 = "INSERT INTO mytable (mycolumn) WITH a AS (SELECT mycolumn FROM mytable) SELECT mycolumn FROM a";
+        assertSqlCanBeParsedAndDeparsed(sqlStr1, true);
+        Insert insert1 = (Insert) CCJSqlParserUtil.parse(sqlStr1);
+        List<WithItem> insertWithItems1 = insert1.getWithItemsList();
+        List<WithItem> selectWithItems1 = insert1.getSelect().getWithItemsList();
+        assertEquals("mytable", insert1.getTable().getFullyQualifiedName());
+        assertNull(insertWithItems1);
+        assertEquals(1, selectWithItems1.size());
+        assertEquals("SELECT mycolumn FROM mytable", selectWithItems1.get(0).getSelect().getPlainSelect().toString());
+        assertEquals(" a", selectWithItems1.get(0).getAlias().toString());
+
+        String sqlStr2 = "INSERT INTO mytable (mycolumn) (WITH a AS (SELECT mycolumn FROM mytable) SELECT mycolumn FROM a)";
+        assertSqlCanBeParsedAndDeparsed(sqlStr2, true);
+        Insert insert2 = (Insert) CCJSqlParserUtil.parse(sqlStr1);
+        List<WithItem> insertWithItems2 = insert2.getWithItemsList();
+        List<WithItem> selectWithItems2 = insert2.getSelect().getWithItemsList();
+        assertEquals("mytable", insert2.getTable().getFullyQualifiedName());
+        assertNull(insertWithItems2);
+        assertEquals(1, selectWithItems2.size());
+        assertEquals("SELECT mycolumn FROM mytable", selectWithItems2.get(0).getSelect().getPlainSelect().toString());
+        assertEquals(" a", selectWithItems2.get(0).getAlias().toString());
     }
 
     @Test
@@ -348,9 +363,16 @@ public class InsertTest {
 
     @Test
     public void testWithDeparsingIssue406() throws JSQLParserException {
-        assertSqlCanBeParsedAndDeparsed(
-                "insert into mytab3 (a,b,c) select a,b,c from mytab where exists(with t as (select * from mytab2) select * from t)",
-                true);
+        String sqlStr = "insert into mytab3 (a,b,c) select a,b,c from mytab where exists(with t as (select * from mytab2) select * from t)";
+        assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        Insert insert = (Insert) CCJSqlParserUtil.parse(sqlStr);
+        List<WithItem> insertWithItems = insert.getWithItemsList();
+        List<WithItem> selectWithItems = insert.getSelect().getWithItemsList();
+        assertEquals("mytab3", insert.getTable().getFullyQualifiedName());
+        assertNull(insertWithItems);
+        assertNull(selectWithItems);
+        ExistsExpression exists = (ExistsExpression) insert.getPlainSelect().getWhere();
+        assertEquals("(WITH t AS (SELECT * FROM mytab2) SELECT * FROM t)", exists.getRightExpression().toString());
     }
 
     @Test
@@ -390,9 +412,17 @@ public class InsertTest {
 
     @Test
     public void testWithAtFront() throws JSQLParserException {
-        assertSqlCanBeParsedAndDeparsed(
-                "WITH foo AS ( SELECT attr FROM bar ) INSERT INTO lalelu (attr) SELECT attr FROM foo",
-                true);
+        String sqlStr = "WITH foo AS ( SELECT attr FROM bar ) INSERT INTO lalelu (attr) SELECT attr FROM foo";
+        assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        Insert insert = (Insert) CCJSqlParserUtil.parse(sqlStr);
+        List<WithItem> insertWithItems = insert.getWithItemsList();
+        assertEquals("lalelu", insert.getTable().getFullyQualifiedName());
+        assertEquals(1, insertWithItems.size());
+        assertEquals("SELECT attr FROM bar", insertWithItems.get(0).getSelect().getPlainSelect().toString());
+        assertEquals(" foo", insertWithItems.get(0).getAlias().toString());
+        assertEquals("SELECT attr FROM foo", insert.getSelect().toString());
+        assertEquals("foo", insert.getSelect().getPlainSelect().getFromItem().toString());
+        assertEquals("[attr]", insert.getSelect().getPlainSelect().getSelectItems().toString());
     }
 
     @Test
@@ -427,8 +457,17 @@ public class InsertTest {
 
     @Test
     public void testWithListIssue282() throws JSQLParserException {
-        assertSqlCanBeParsedAndDeparsed(
-                "WITH myctl AS (SELECT a, b FROM mytable) INSERT INTO mytable SELECT a, b FROM myctl");
+        String sqlStr = "WITH myctl AS (SELECT a, b FROM mytable) INSERT INTO mytable SELECT a, b FROM myctl";
+        assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        Insert insert = (Insert) CCJSqlParserUtil.parse(sqlStr);
+        List<WithItem> insertWithItems = insert.getWithItemsList();
+        assertEquals("mytable", insert.getTable().getFullyQualifiedName());
+        assertEquals(1, insertWithItems.size());
+        assertEquals("SELECT a, b FROM mytable", insertWithItems.get(0).getSelect().getPlainSelect().toString());
+        assertEquals(" myctl", insertWithItems.get(0).getAlias().toString());
+        assertEquals("SELECT a, b FROM myctl", insert.getSelect().toString());
+        assertEquals("myctl", insert.getSelect().getPlainSelect().getFromItem().toString());
+        assertEquals("[a, b]", insert.getSelect().getPlainSelect().getSelectItems().toString());
     }
 
     @Test
@@ -468,8 +507,19 @@ public class InsertTest {
         assertSqlCanBeParsedAndDeparsed("insert into table1 (tf1,tf2,tf2)\n"
                 + "((select sf1,sf2,sf3 from s1)" + "union " + "(select rf1,rf2,rf2 from r1))",
                 true);
+    }
 
-        assertSqlCanBeParsedAndDeparsed("(with a as (select * from dual) select * from a)", true);
+    @Test
+    public void testWithSelectFromDual() throws JSQLParserException {
+        String sqlStr = "(with a as (select * from dual) select * from a)";
+        assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        ParenthesedSelect parenthesedSelect = (ParenthesedSelect) CCJSqlParserUtil.parse(sqlStr);
+        List<WithItem> withItems = parenthesedSelect.getSelect().getWithItemsList();
+        assertEquals(1, withItems.size());
+        assertEquals("SELECT * FROM dual", withItems.get(0).getSelect().getPlainSelect().toString());
+        assertEquals(" a", withItems.get(0).getAlias().toString());
+        assertEquals("a", parenthesedSelect.getPlainSelect().getFromItem().toString());
+        assertEquals("[*]", parenthesedSelect.getPlainSelect().getSelectItems().toString());
     }
 
     @Test
@@ -528,6 +578,11 @@ public class InsertTest {
         String sqlStr = "WITH a ( a, b , c ) \n" + "AS (SELECT  1 , 2 , 3 )\n"
                 + "insert into test\n" + "select * from a";
         Insert insert = (Insert) CCJSqlParserUtil.parse(sqlStr);
+        List<WithItem> withItems = insert.getWithItemsList();
+        assertEquals("test", insert.getTable().getFullyQualifiedName());
+        assertEquals(1, withItems.size());
+        assertEquals("[1, 2, 3]", withItems.get(0).getSelect().getPlainSelect().getSelectItems().toString());
+        assertEquals(" a", withItems.get(0).getAlias().toString());
 
         Expression whereExpression = CCJSqlParserUtil.parseExpression("a=1", false);
         Expression valueExpression = CCJSqlParserUtil.parseExpression("b/2", false);

--- a/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
@@ -278,8 +278,7 @@ public class InsertTest {
     @Test
     public void testInsertWithSelect() throws JSQLParserException {
         String sqlStr1 = "INSERT INTO mytable (mycolumn) WITH a AS (SELECT mycolumn FROM mytable) SELECT mycolumn FROM a";
-        assertSqlCanBeParsedAndDeparsed(sqlStr1, true);
-        Insert insert1 = (Insert) CCJSqlParserUtil.parse(sqlStr1);
+        Insert insert1 = (Insert) assertSqlCanBeParsedAndDeparsed(sqlStr1, true);
         List<WithItem> insertWithItems1 = insert1.getWithItemsList();
         List<WithItem> selectWithItems1 = insert1.getSelect().getWithItemsList();
         assertEquals("mytable", insert1.getTable().getFullyQualifiedName());
@@ -289,12 +288,12 @@ public class InsertTest {
         assertEquals(" a", selectWithItems1.get(0).getAlias().toString());
 
         String sqlStr2 = "INSERT INTO mytable (mycolumn) (WITH a AS (SELECT mycolumn FROM mytable) SELECT mycolumn FROM a)";
-        assertSqlCanBeParsedAndDeparsed(sqlStr2, true);
-        Insert insert2 = (Insert) CCJSqlParserUtil.parse(sqlStr1);
+        Insert insert2 = (Insert) assertSqlCanBeParsedAndDeparsed(sqlStr2, true);
         List<WithItem> insertWithItems2 = insert2.getWithItemsList();
-        List<WithItem> selectWithItems2 = insert2.getSelect().getWithItemsList();
         assertEquals("mytable", insert2.getTable().getFullyQualifiedName());
         assertNull(insertWithItems2);
+        ParenthesedSelect select = (ParenthesedSelect) insert2.getSelect();
+        List<WithItem> selectWithItems2 = select.getSelect().getWithItemsList();
         assertEquals(1, selectWithItems2.size());
         assertEquals("SELECT mycolumn FROM mytable", selectWithItems2.get(0).getSelect().getPlainSelect().toString());
         assertEquals(" a", selectWithItems2.get(0).getAlias().toString());
@@ -364,8 +363,7 @@ public class InsertTest {
     @Test
     public void testWithDeparsingIssue406() throws JSQLParserException {
         String sqlStr = "insert into mytab3 (a,b,c) select a,b,c from mytab where exists(with t as (select * from mytab2) select * from t)";
-        assertSqlCanBeParsedAndDeparsed(sqlStr, true);
-        Insert insert = (Insert) CCJSqlParserUtil.parse(sqlStr);
+        Insert insert = (Insert) assertSqlCanBeParsedAndDeparsed(sqlStr, true);
         List<WithItem> insertWithItems = insert.getWithItemsList();
         List<WithItem> selectWithItems = insert.getSelect().getWithItemsList();
         assertEquals("mytab3", insert.getTable().getFullyQualifiedName());
@@ -413,8 +411,7 @@ public class InsertTest {
     @Test
     public void testWithAtFront() throws JSQLParserException {
         String sqlStr = "WITH foo AS ( SELECT attr FROM bar ) INSERT INTO lalelu (attr) SELECT attr FROM foo";
-        assertSqlCanBeParsedAndDeparsed(sqlStr, true);
-        Insert insert = (Insert) CCJSqlParserUtil.parse(sqlStr);
+        Insert insert = (Insert) assertSqlCanBeParsedAndDeparsed(sqlStr, true);
         List<WithItem> insertWithItems = insert.getWithItemsList();
         assertEquals("lalelu", insert.getTable().getFullyQualifiedName());
         assertEquals(1, insertWithItems.size());
@@ -458,8 +455,7 @@ public class InsertTest {
     @Test
     public void testWithListIssue282() throws JSQLParserException {
         String sqlStr = "WITH myctl AS (SELECT a, b FROM mytable) INSERT INTO mytable SELECT a, b FROM myctl";
-        assertSqlCanBeParsedAndDeparsed(sqlStr, true);
-        Insert insert = (Insert) CCJSqlParserUtil.parse(sqlStr);
+        Insert insert = (Insert) assertSqlCanBeParsedAndDeparsed(sqlStr, true);
         List<WithItem> insertWithItems = insert.getWithItemsList();
         assertEquals("mytable", insert.getTable().getFullyQualifiedName());
         assertEquals(1, insertWithItems.size());
@@ -512,8 +508,7 @@ public class InsertTest {
     @Test
     public void testWithSelectFromDual() throws JSQLParserException {
         String sqlStr = "(with a as (select * from dual) select * from a)";
-        assertSqlCanBeParsedAndDeparsed(sqlStr, true);
-        ParenthesedSelect parenthesedSelect = (ParenthesedSelect) CCJSqlParserUtil.parse(sqlStr);
+        ParenthesedSelect parenthesedSelect = (ParenthesedSelect) assertSqlCanBeParsedAndDeparsed(sqlStr, true);
         List<WithItem> withItems = parenthesedSelect.getSelect().getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals("SELECT * FROM dual", withItems.get(0).getSelect().getPlainSelect().toString());
@@ -663,8 +658,7 @@ public class InsertTest {
     @Test
     public void testDefaultValuesWithAlias() throws JSQLParserException {
         String statement = "INSERT INTO mytable x DEFAULT VALUES";
-        assertSqlCanBeParsedAndDeparsed(statement);
-        Insert insert = (Insert) parserManager.parse(new StringReader(statement));
+        Insert insert = (Insert) assertSqlCanBeParsedAndDeparsed(statement);
         assertEquals("mytable", insert.getTable().getFullyQualifiedName());
         assertEquals("INSERT INTO MYTABLE X DEFAULT VALUES", insert.toString().toUpperCase());
         assertEquals("x", insert.getTable().getAlias().getName());
@@ -678,8 +672,7 @@ public class InsertTest {
     @Test
     public void testDefaultValuesWithAliasAndAs() throws JSQLParserException {
         String statement = "INSERT INTO mytable AS x DEFAULT VALUES";
-        assertSqlCanBeParsedAndDeparsed(statement);
-        Insert insert = (Insert) parserManager.parse(new StringReader(statement));
+        Insert insert = (Insert) assertSqlCanBeParsedAndDeparsed(statement);
         assertEquals("mytable", insert.getTable().getFullyQualifiedName());
         assertEquals("INSERT INTO MYTABLE AS X DEFAULT VALUES", insert.toString().toUpperCase());
         assertEquals("x", insert.getTable().getAlias().getName());

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -1701,8 +1701,7 @@ public class SelectTest {
                 + "SELECT THIS_EMP.EMPNO, THIS_EMP.SALARY, DINFO.AVGSALARY, DINFO.EMPCOUNT, DINFOMAX.AVGMAX "
                 + "FROM EMPLOYEE AS THIS_EMP INNER JOIN DINFO INNER JOIN DINFOMAX "
                 + "WHERE THIS_EMP.JOB = 'SALESREP' AND THIS_EMP.WORKDEPT = DINFO.DEPTNO";
-        assertSqlCanBeParsedAndDeparsed(statement);
-        Select select = (Select) parserManager.parse(new StringReader(statement));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(statement);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(2, withItems.size());
         assertEquals("SELECT OTHERS.WORKDEPT, AVG(OTHERS.SALARY), COUNT(*) FROM EMPLOYEE AS OTHERS GROUP BY OTHERS.WORKDEPT", withItems.get(0).getSelect().getPlainSelect().toString());
@@ -1714,8 +1713,7 @@ public class SelectTest {
     @Test
     public void testWithRecursive() throws JSQLParserException {
         String statement = "WITH RECURSIVE t (n) AS ((SELECT 1) UNION ALL (SELECT n + 1 FROM t WHERE n < 100)) SELECT sum(n) FROM t";
-        assertSqlCanBeParsedAndDeparsed(statement);
-        Select select = (Select) parserManager.parse(new StringReader(statement));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(statement);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals("((SELECT 1) UNION ALL (SELECT n + 1 FROM t WHERE n < 100))", withItems.get(0).getSelect().toString());
@@ -2374,8 +2372,7 @@ public class SelectTest {
     public void testWithStatement() throws JSQLParserException {
         String stmt =
                 "WITH test AS (SELECT mslink FROM feature) SELECT * FROM feature WHERE mslink IN (SELECT mslink FROM test)";
-        assertSqlCanBeParsedAndDeparsed(stmt);
-        Select select = (Select) parserManager.parse(new StringReader(stmt));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(stmt);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals("SELECT mslink FROM feature", withItems.get(0).getSelect().getPlainSelect().toString());
@@ -2392,8 +2389,7 @@ public class SelectTest {
     public void testWithUnionProblem() throws JSQLParserException {
         String stmt =
                 "WITH test AS ((SELECT mslink FROM tablea) UNION (SELECT mslink FROM tableb)) SELECT * FROM tablea WHERE mslink IN (SELECT mslink FROM test)";
-        assertSqlCanBeParsedAndDeparsed(stmt);
-        Select select = (Select) parserManager.parse(new StringReader(stmt));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(stmt);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals("((SELECT mslink FROM tablea) UNION (SELECT mslink FROM tableb))", withItems.get(0).getSelect().toString());
@@ -2404,8 +2400,7 @@ public class SelectTest {
     public void testWithUnionAllProblem() throws JSQLParserException {
         String stmt =
                 "WITH test AS ((SELECT mslink FROM tablea) UNION ALL (SELECT mslink FROM tableb)) SELECT * FROM tablea WHERE mslink IN (SELECT mslink FROM test)";
-        assertSqlCanBeParsedAndDeparsed(stmt);
-        Select select = (Select) parserManager.parse(new StringReader(stmt));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(stmt);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals("((SELECT mslink FROM tablea) UNION ALL (SELECT mslink FROM tableb))", withItems.get(0).getSelect().toString());
@@ -2416,8 +2411,7 @@ public class SelectTest {
     public void testWithUnionProblem3() throws JSQLParserException {
         String stmt =
                 "WITH test AS ((SELECT mslink, CAST(tablea.fname AS varchar) FROM tablea INNER JOIN tableb ON tablea.mslink = tableb.mslink AND tableb.deleted = 0 WHERE tablea.fname IS NULL AND 1 = 0) UNION ALL (SELECT mslink FROM tableb)) SELECT * FROM tablea WHERE mslink IN (SELECT mslink FROM test)";
-        assertSqlCanBeParsedAndDeparsed(stmt);
-        Select select = (Select) parserManager.parse(new StringReader(stmt));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(stmt);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals("((SELECT mslink, CAST(tablea.fname AS varchar) FROM tablea INNER JOIN tableb ON tablea.mslink = tableb.mslink AND tableb.deleted = 0 WHERE tablea.fname IS NULL AND 1 = 0) UNION ALL (SELECT mslink FROM tableb))", withItems.get(0).getSelect().toString());
@@ -2428,8 +2422,7 @@ public class SelectTest {
     public void testWithUnionProblem4() throws JSQLParserException {
         String stmt =
                 "WITH hist AS ((SELECT gl.mslink, ba.gl_name AS txt, ba.gl_nummer AS nr, 0 AS level, CAST(gl.mslink AS VARCHAR) AS path, ae.feature FROM tablea AS gl INNER JOIN tableb AS ba ON gl.mslink = ba.gl_mslink INNER JOIN tablec AS ae ON gl.mslink = ae.mslink AND ae.deleted = 0 WHERE gl.parent IS NULL AND gl.mslink <> 0) UNION ALL (SELECT gl.mslink, ba.gl_name AS txt, ba.gl_nummer AS nr, hist.level + 1 AS level, CAST(hist.path + '.' + CAST(gl.mslink AS VARCHAR) AS VARCHAR) AS path, ae.feature FROM tablea AS gl INNER JOIN tableb AS ba ON gl.mslink = ba.gl_mslink INNER JOIN tablec AS ae ON gl.mslink = ae.mslink AND ae.deleted = 0 INNER JOIN hist ON gl.parent = hist.mslink WHERE gl.mslink <> 0)) SELECT mslink, space(level * 4) + txt AS txt, nr, feature, path FROM hist WHERE EXISTS (SELECT feature FROM tablec WHERE mslink = 0 AND ((feature IN (1, 2) AND hist.feature = 3) OR (feature IN (4) AND hist.feature = 2)))";
-        assertSqlCanBeParsedAndDeparsed(stmt);
-        Select select = (Select) parserManager.parse(new StringReader(stmt));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(stmt);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals("((SELECT gl.mslink, ba.gl_name AS txt, ba.gl_nummer AS nr, 0 AS level, CAST(gl.mslink AS VARCHAR) AS path, ae.feature FROM tablea AS gl INNER JOIN tableb AS ba ON gl.mslink = ba.gl_mslink INNER JOIN tablec AS ae ON gl.mslink = ae.mslink AND ae.deleted = 0 WHERE gl.parent IS NULL AND gl.mslink <> 0) UNION ALL (SELECT gl.mslink, ba.gl_name AS txt, ba.gl_nummer AS nr, hist.level + 1 AS level, CAST(hist.path + '.' + CAST(gl.mslink AS VARCHAR) AS VARCHAR) AS path, ae.feature FROM tablea AS gl INNER JOIN tableb AS ba ON gl.mslink = ba.gl_mslink INNER JOIN tablec AS ae ON gl.mslink = ae.mslink AND ae.deleted = 0 INNER JOIN hist ON gl.parent = hist.mslink WHERE gl.mslink <> 0))", withItems.get(0).getSelect().toString());
@@ -2440,8 +2433,7 @@ public class SelectTest {
     public void testWithUnionProblem5() throws JSQLParserException {
         String stmt =
                 "WITH hist AS ((SELECT gl.mslink, ba.gl_name AS txt, ba.gl_nummer AS nr, 0 AS level, CAST(gl.mslink AS VARCHAR) AS path, ae.feature FROM tablea AS gl INNER JOIN tableb AS ba ON gl.mslink = ba.gl_mslink INNER JOIN tablec AS ae ON gl.mslink = ae.mslink AND ae.deleted = 0 WHERE gl.parent IS NULL AND gl.mslink <> 0) UNION ALL (SELECT gl.mslink, ba.gl_name AS txt, ba.gl_nummer AS nr, hist.level + 1 AS level, CAST(hist.path + '.' + CAST(gl.mslink AS VARCHAR) AS VARCHAR) AS path, 5 AS feature FROM tablea AS gl INNER JOIN tableb AS ba ON gl.mslink = ba.gl_mslink INNER JOIN tablec AS ae ON gl.mslink = ae.mslink AND ae.deleted = 0 INNER JOIN hist ON gl.parent = hist.mslink WHERE gl.mslink <> 0)) SELECT * FROM hist";
-        assertSqlCanBeParsedAndDeparsed(stmt);
-        Select select = (Select) parserManager.parse(new StringReader(stmt));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(stmt);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals("((SELECT gl.mslink, ba.gl_name AS txt, ba.gl_nummer AS nr, 0 AS level, CAST(gl.mslink AS VARCHAR) AS path, ae.feature FROM tablea AS gl INNER JOIN tableb AS ba ON gl.mslink = ba.gl_mslink INNER JOIN tablec AS ae ON gl.mslink = ae.mslink AND ae.deleted = 0 WHERE gl.parent IS NULL AND gl.mslink <> 0) UNION ALL (SELECT gl.mslink, ba.gl_name AS txt, ba.gl_nummer AS nr, hist.level + 1 AS level, CAST(hist.path + '.' + CAST(gl.mslink AS VARCHAR) AS VARCHAR) AS path, 5 AS feature FROM tablea AS gl INNER JOIN tableb AS ba ON gl.mslink = ba.gl_mslink INNER JOIN tablec AS ae ON gl.mslink = ae.mslink AND ae.deleted = 0 INNER JOIN hist ON gl.parent = hist.mslink WHERE gl.mslink <> 0))", withItems.get(0).getSelect().toString());
@@ -3173,8 +3165,7 @@ public class SelectTest {
     @Test
     public void testSelectInnerWith() throws JSQLParserException {
         String stmt = "SELECT * FROM (WITH actor AS (SELECT 'a' aid FROM DUAL) SELECT aid FROM actor)";
-        assertSqlCanBeParsedAndDeparsed(stmt);
-        Select select = (Select) parserManager.parse(new StringReader(stmt));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(stmt);
         List<WithItem> withItems1 = select.getWithItemsList();
         assertNull(withItems1);
         ParenthesedSelect parenthesedSelect = (ParenthesedSelect) select.getPlainSelect().getFromItem();
@@ -3193,8 +3184,7 @@ public class SelectTest {
     @Test
     public void testSelectInnerWithAndUnionIssue1084_2() throws JSQLParserException {
         String stmt = "WITH actor AS (SELECT 'b' aid FROM DUAL) SELECT aid FROM actor UNION SELECT aid FROM actor2";
-        assertSqlCanBeParsedAndDeparsed(stmt);
-        Select select = (Select) parserManager.parse(new StringReader(stmt));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(stmt);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals("(SELECT 'b' aid FROM DUAL)", withItems.get(0).getSelect().toString());
@@ -4589,8 +4579,7 @@ public class SelectTest {
     @Test
     public void testInnerWithBlock() throws JSQLParserException {
         String stmt = "select 1 from (with mytable1 as (select 2 ) select 3 from mytable1 ) first";
-        assertSqlCanBeParsedAndDeparsed(stmt, true);
-        Select select = (Select) parserManager.parse(new StringReader(stmt));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(stmt, true);
         List<WithItem> withItems1 = select.getWithItemsList();
         assertNull(withItems1);
         ParenthesedSelect parenthesedSelect = (ParenthesedSelect) select.getPlainSelect().getFromItem();
@@ -4740,8 +4729,7 @@ public class SelectTest {
     @Test
     public void testWithAsRecursiveIssue874() throws JSQLParserException {
         String stmt = "WITH rn AS (SELECT rownum rn FROM dual CONNECT BY level <= (SELECT max(cases) FROM t1)) SELECT pname FROM t1, rn WHERE rn <= cases ORDER BY pname";
-        assertSqlCanBeParsedAndDeparsed(stmt);
-        Select select = (Select) parserManager.parse(new StringReader(stmt));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(stmt);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals("(SELECT rownum rn FROM dual CONNECT BY level <= (SELECT max(cases) FROM t1))", withItems.get(0).getSelect().toString());
@@ -5183,8 +5171,7 @@ public class SelectTest {
     @Test
     public void testKeywordCostsIssue1185() throws JSQLParserException {
         String stmt = "WITH costs AS (SELECT * FROM MY_TABLE1 AS ALIAS_TABLE1) SELECT * FROM TESTSTMT";
-        assertSqlCanBeParsedAndDeparsed(stmt);
-        Select select = (Select) parserManager.parse(new StringReader(stmt));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(stmt);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals("(SELECT * FROM MY_TABLE1 AS ALIAS_TABLE1)", withItems.get(0).getSelect().toString());
@@ -5204,8 +5191,7 @@ public class SelectTest {
     @Test
     public void testWithValueListWithExtraBrackets1135() throws JSQLParserException {
         String stmt = "with sample_data(day, value) as (values ((0, 13), (1, 12), (2, 15), (3, 4), (4, 8), (5, 16))) select day, value from sample_data";
-        assertSqlCanBeParsedAndDeparsed(stmt, true);
-        Select select = (Select) parserManager.parse(new StringReader(stmt));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(stmt, true);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals("VALUES ((0, 13), (1, 12), (2, 15), (3, 4), (4, 8), (5, 16))", withItems.get(0).getSelect().getValues().toString());
@@ -5216,16 +5202,14 @@ public class SelectTest {
     public void testWithValueListWithOutExtraBrackets1135() throws JSQLParserException {
         String stmt1 = "with sample_data(\"DAY\") as (values 0, 1, 2)\n"
                 + "           select \"DAY\" from sample_data";
-        assertSqlCanBeParsedAndDeparsed(stmt1, true);
-        Select select1 = (Select) parserManager.parse(new StringReader(stmt1));
+        Select select1 = (Select) assertSqlCanBeParsedAndDeparsed(stmt1, true);
         List<WithItem> withItems1 = select1.getWithItemsList();
         assertEquals(1, withItems1.size());
         assertEquals("VALUES 0, 1, 2", withItems1.get(0).getSelect().getValues().toString());
         assertEquals(" sample_data", withItems1.get(0).getAlias().toString());
 
         String stmt2 = "with sample_data(day, value) as (values (0, 13), (1, 12), (2, 15), (3, 4), (4, 8), (5, 16)) select day, value from sample_data";
-        assertSqlCanBeParsedAndDeparsed(stmt2, true);
-        Select select2 = (Select) parserManager.parse(new StringReader(stmt2));
+        Select select2 = (Select) assertSqlCanBeParsedAndDeparsed(stmt2, true);
         List<WithItem> withItems2 = select2.getWithItemsList();
         assertEquals(1, withItems2.size());
         assertEquals("VALUES (0, 13), (1, 12), (2, 15), (3, 4), (4, 8), (5, 16)", withItems2.get(0).getSelect().getValues().toString());
@@ -5235,8 +5219,7 @@ public class SelectTest {
     @Test
     public void testWithInsideWithIssue1186() throws JSQLParserException {
         String stmt = "WITH TESTSTMT1 AS ( WITH TESTSTMT2 AS (SELECT * FROM MY_TABLE2) SELECT col1, col2 FROM TESTSTMT2) SELECT * FROM TESTSTMT";
-        assertSqlCanBeParsedAndDeparsed(stmt, true);
-        Select select = (Select) parserManager.parse(new StringReader(stmt));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(stmt, true);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals(" TESTSTMT1", withItems.get(0).getAlias().toString());
@@ -5747,8 +5730,7 @@ public class SelectTest {
     void testNestedWithItems() throws JSQLParserException {
         String sqlStr =
                 "with a as ( with b as ( with c as (select 1) select c.* from c) select b.* from b) select a.* from a";
-        TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
-        Select select = (Select) parserManager.parse(new StringReader(sqlStr));
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(sqlStr, true);
         List<WithItem> withItems = select.getWithItemsList();
         assertEquals(1, withItems.size());
         assertEquals(" a", withItems.get(0).getAlias().toString());

--- a/src/test/java/net/sf/jsqlparser/statement/update/UpdateTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/update/UpdateTest.java
@@ -231,8 +231,7 @@ public class UpdateTest {
                 + "SET id_instrument=null\n"
                 + "WHERE  id_instrument_ref = (SELECT id_instrument_ref\n"
                 + "                            FROM   a)";
-        assertSqlCanBeParsedAndDeparsed(statement, true);
-        Update update = (Update) CCJSqlParserUtil.parse(statement);
+        Update update = (Update) assertSqlCanBeParsedAndDeparsed(statement, true);
         List<WithItem> withItems = update.getWithItemsList();
         assertEquals("cfe.instrument_ref", update.getTable().getFullyQualifiedName());
         assertEquals(2, withItems.size());
@@ -281,9 +280,7 @@ public class UpdateTest {
                 + "     , b.packageunit = '4101170402' -- this is supposed to be UpdateSet 3\n"
                 + "WHERE b.payrefno = 'B370202091026000005'";
 
-        assertSqlCanBeParsedAndDeparsed(sqlStr, true);
-
-        Update update = (Update) CCJSqlParserUtil.parse(sqlStr);
+        Update update = (Update) assertSqlCanBeParsedAndDeparsed(sqlStr, true);
         assertEquals(3, update.getUpdateSets().size());
 
         assertEquals(3, update.getUpdateSets().get(0).getColumns().size());


### PR DESCRIPTION
I have a future change in mind to do with CTEs. When I make the PR for this change I would like the unit tests changes (if any) to be simple and easy to understand. So, before I start to look at my CTE related change, I've added extra details to the `UpdateTest`, `InsertTest`, `DeleteTest` and `SelectTest` unit test scenarios.

There are zero functionality changes made here, only unit tests updates, I've been very careful not to change any SQL statements being tested.