### PR TITLE
chore removing system.out.println lines + minor clean up of unit test scripts

### DIFF
--- a/src/test/java/net/sf/jsqlparser/statement/StatementSeparatorTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/StatementSeparatorTest.java
@@ -53,7 +53,6 @@ public class StatementSeparatorTest {
     void testOracleBlock() throws JSQLParserException {
         String sqlStr = "BEGIN\n" + "\n" + "SELECT * FROM TABLE;\n" + "\n" + "END\n" + "/\n";
         Statement statement = TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
-        System.out.println(statement);
     }
 
     @Test
@@ -69,7 +68,6 @@ public class StatementSeparatorTest {
         String sqlStr =
                 "select name,\ngoods from test_table where option includes ('option1', 'option2')";
         Statement statement = TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
-        System.out.println(statement);
     }
 
     @Test
@@ -77,6 +75,5 @@ public class StatementSeparatorTest {
         String sqlStr =
                 "select name,\ngoods from test_table where option excludes ('option1', 'option2')";
         Statement statement = TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
-        System.out.println(statement);
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -1024,20 +1024,24 @@ public class AlterTest {
     }
 
     @Test
-    public void testIssue2027() throws JSQLParserException{
+    public void testIssue2027() throws JSQLParserException {
         String sql = "ALTER TABLE `foo_bar` ADD COLUMN `baz` text";
         assertSqlCanBeParsedAndDeparsed(sql);
 
-        String sqlText = "ALTER TABLE `foo_bar` ADD COLUMN `baz` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL";
+        String sqlText =
+                "ALTER TABLE `foo_bar` ADD COLUMN `baz` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL";
         assertSqlCanBeParsedAndDeparsed(sqlText);
 
-        String sqlTinyText = "ALTER TABLE `foo_bar` ADD COLUMN `baz` tinytext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL";
+        String sqlTinyText =
+                "ALTER TABLE `foo_bar` ADD COLUMN `baz` tinytext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL";
         assertSqlCanBeParsedAndDeparsed(sqlTinyText);
 
-        String sqlMediumText = "ALTER TABLE `foo_bar` ADD COLUMN `baz` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL";
+        String sqlMediumText =
+                "ALTER TABLE `foo_bar` ADD COLUMN `baz` mediumtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL";
         assertSqlCanBeParsedAndDeparsed(sqlMediumText);
 
-        String sqlLongText = "ALTER TABLE `foo_bar` ADD COLUMN `baz` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL";
+        String sqlLongText =
+                "ALTER TABLE `foo_bar` ADD COLUMN `baz` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL";
         assertSqlCanBeParsedAndDeparsed(sqlLongText);
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -71,15 +71,14 @@ public class AlterTest {
     @Test
     public void testAlterTableBackBrackets() throws JSQLParserException {
         String sql = "ALTER TABLE tablename add column (field  string comment 'aaaaa')";
-        Statement statement = CCJSqlParserUtil.parse(sql);
-        Alter alter = (Alter) statement;
-        System.out.println(alter.toString());
+        Alter alter = (Alter) assertSqlCanBeParsedAndDeparsed(sql);
+        assertEquals("tablename", alter.getTable().toString());
 
         String sql2 =
                 "ALTER TABLE tablename add column (field  string comment 'aaaaa', field2 string comment 'bbbbb');";
         Statement statement2 = CCJSqlParserUtil.parse(sql2);
         Alter alter2 = (Alter) statement2;
-        System.out.println(alter2.toString());
+        assertEquals("tablename", alter2.getTable().toString());
     }
 
 

--- a/src/test/java/net/sf/jsqlparser/statement/merge/MergeTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/merge/MergeTest.java
@@ -42,10 +42,6 @@ public class MergeTest {
                 + "  INSERT (B.employee_id, B.bonus)\n"
                 + "  VALUES (E.employee_id, E.salary * 0.05)  ";
 
-        Statement statement = CCJSqlParserUtil.parse(sql);
-
-        System.out.println(statement.toString());
-
         assertSqlCanBeParsedAndDeparsed(sql, true);
     }
 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -4540,13 +4540,6 @@ public class SelectTest {
     }
 
     @Test
-    public void testLongQualifiedNamesIssue763_2() throws JSQLParserException {
-        Statement parse = CCJSqlParserUtil.parse(new StringReader(
-                "SELECT mongodb.test.test.intField, postgres.test.test.intField, postgres.test.test.datefield FROM mongodb.test.test JOIN postgres.postgres.test.test ON mongodb.test.test.intField = postgres.test.test.intField WHERE mongodb.test.test.intField = 123"));
-        System.out.println(parse.toString());
-    }
-
-    @Test
     public void testSubQueryAliasIssue754() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed(
                 "SELECT C0 FROM T0 INNER JOIN T1 ON C1 = C0 INNER JOIN (SELECT W1 FROM T2) S1 ON S1.W1 = C0 ORDER BY C0");


### PR DESCRIPTION
Nothing major just clean up.

When I was working on [this change](https://github.com/JSQLParser/JSqlParser/pull/2055) I noticed a few surplus `System.out.println` lines. This PR removes them and cleans up a few other unit tests.