### PR TITLE
Failure to parse query with PRIOR in select list

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ConnectByPriorOperator.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ConnectByPriorOperator.java
@@ -1,0 +1,63 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2021 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+/*
+ * Copyright (C) 2021 JSQLParser.
+ *
+ * This library is free software; you can redistribute it and/or modify it under the terms of the
+ * GNU Lesser General Public License as published by the Free Software Foundation; either version
+ * 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this library;
+ * if not, write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301 USA
+ */
+
+package net.sf.jsqlparser.expression;
+
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+import net.sf.jsqlparser.schema.Column;
+
+import java.util.Objects;
+
+/**
+ *
+ * @author are
+ */
+public class ConnectByPriorOperator extends ASTNodeAccessImpl implements Expression {
+    private final Column column;
+
+    public ConnectByPriorOperator(Column column) {
+        this.column = Objects.requireNonNull(column,
+                "The COLUMN of the ConnectByRoot Operator must not be null");
+    }
+
+    public Column getColumn() {
+        return column;
+    }
+
+    @Override
+    public <T, S> T accept(ExpressionVisitor<T> expressionVisitor, S context) {
+        return expressionVisitor.visit(this, context);
+    }
+
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("PRIOR ").append(column);
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return appendTo(new StringBuilder()).toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/expression/ConnectByPriorOperator.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ConnectByPriorOperator.java
@@ -39,7 +39,7 @@ public class ConnectByPriorOperator extends ASTNodeAccessImpl implements Express
 
     public ConnectByPriorOperator(Column column) {
         this.column = Objects.requireNonNull(column,
-                "The COLUMN of the ConnectByRoot Operator must not be null");
+                "The COLUMN of the ConnectByPrior Operator must not be null");
     }
 
     public Column getColumn() {

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -557,6 +557,12 @@ public interface ExpressionVisitor<T> {
         this.visit(connectByRootOperator, null);
     }
 
+    <S> T visit(ConnectByPriorOperator connectByPriorOperator, S context);
+
+    default void visit(ConnectByPriorOperator connectByPriorOperator) {
+        this.visit(connectByPriorOperator, null);
+    }
+
     <S> T visit(OracleNamedFunctionParameter oracleNamedFunctionParameter, S context);
 
     default void visit(OracleNamedFunctionParameter oracleNamedFunctionParameter) {

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -704,6 +704,11 @@ public class ExpressionVisitorAdapter<T>
     }
 
     @Override
+    public <S> T visit(ConnectByPriorOperator connectByPriorOperator, S context) {
+        return connectByPriorOperator.getColumn().accept(this, context);
+    }
+
+    @Override
     public <S> T visit(OracleNamedFunctionParameter oracleNamedFunctionParameter, S context) {
         return oracleNamedFunctionParameter.getExpression().accept(this, context);
     }

--- a/src/main/java/net/sf/jsqlparser/parser/ParserKeywordsUtils.java
+++ b/src/main/java/net/sf/jsqlparser/parser/ParserKeywordsUtils.java
@@ -56,6 +56,7 @@ public class ParserKeywordsUtils {
             {"CHECK", RESTRICTED_SQL2016},
             {"CONNECT", RESTRICTED_ALIAS},
             {"CONNECT_BY_ROOT", RESTRICTED_JSQLPARSER},
+            {"PRIOR", RESTRICTED_JSQLPARSER},
             {"CONSTRAINT", RESTRICTED_SQL2016},
             {"CREATE", RESTRICTED_ALIAS},
             {"CROSS", RESTRICTED_SQL2016},

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -20,6 +20,7 @@ import net.sf.jsqlparser.expression.CaseExpression;
 import net.sf.jsqlparser.expression.CastExpression;
 import net.sf.jsqlparser.expression.CollateExpression;
 import net.sf.jsqlparser.expression.ConnectByRootOperator;
+import net.sf.jsqlparser.expression.ConnectByPriorOperator;
 import net.sf.jsqlparser.expression.DateTimeLiteralExpression;
 import net.sf.jsqlparser.expression.DateValue;
 import net.sf.jsqlparser.expression.DoubleValue;
@@ -1719,6 +1720,12 @@ public class TablesNamesFinder<Void>
     @Override
     public <S> Void visit(ConnectByRootOperator connectByRootOperator, S context) {
         connectByRootOperator.getColumn().accept(this, context);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(ConnectByPriorOperator connectByPriorOperator, S context) {
+        connectByPriorOperator.getColumn().accept(this, context);
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -20,6 +20,7 @@ import net.sf.jsqlparser.expression.CaseExpression;
 import net.sf.jsqlparser.expression.CastExpression;
 import net.sf.jsqlparser.expression.CollateExpression;
 import net.sf.jsqlparser.expression.ConnectByRootOperator;
+import net.sf.jsqlparser.expression.ConnectByPriorOperator;
 import net.sf.jsqlparser.expression.DateTimeLiteralExpression;
 import net.sf.jsqlparser.expression.DateValue;
 import net.sf.jsqlparser.expression.DoubleValue;
@@ -1580,6 +1581,13 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
     public <S> StringBuilder visit(ConnectByRootOperator connectByRootOperator, S context) {
         buffer.append("CONNECT_BY_ROOT ");
         connectByRootOperator.getColumn().accept(this, context);
+        return buffer;
+    }
+
+    @Override
+    public <S> StringBuilder visit(ConnectByPriorOperator connectByPriorOperator, S context) {
+        buffer.append("PRIOR ");
+        connectByPriorOperator.getColumn().accept(this, context);
         return buffer;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
@@ -19,6 +19,7 @@ import net.sf.jsqlparser.expression.CaseExpression;
 import net.sf.jsqlparser.expression.CastExpression;
 import net.sf.jsqlparser.expression.CollateExpression;
 import net.sf.jsqlparser.expression.ConnectByRootOperator;
+import net.sf.jsqlparser.expression.ConnectByPriorOperator;
 import net.sf.jsqlparser.expression.DateTimeLiteralExpression;
 import net.sf.jsqlparser.expression.DateValue;
 import net.sf.jsqlparser.expression.DoubleValue;
@@ -1011,6 +1012,12 @@ public class ExpressionValidator extends AbstractValidator<Expression>
     @Override
     public <S> Void visit(ConnectByRootOperator connectByRootOperator, S context) {
         connectByRootOperator.getColumn().accept(this, context);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(ConnectByPriorOperator connectByPriorOperator, S context) {
+        connectByPriorOperator.getColumn().accept(this, context);
         return null;
     }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2749,6 +2749,8 @@ SelectItem<?> SelectItem() #SelectItem:
     (
         expression = AllColumns()
         |
+        expression = ConnectByPriorOperator()
+        |
         LOOKAHEAD(AllTableColumns()) expression = AllTableColumns()
         |
         LOOKAHEAD( 3 ) expression = XorExpression()
@@ -4898,6 +4900,17 @@ ConnectByRootOperator ConnectByRootOperator() #ConnectByRootOperator: {
       return new ConnectByRootOperator(column);
     }
 }
+
+ConnectByPriorOperator ConnectByPriorOperator() #ConnectByPriorOperator: {
+    Column column;
+}
+{
+    <K_PRIOR> column = Column()
+    {
+      return new ConnectByPriorOperator(column);
+    }
+}
+
 
 NextValExpression NextValExpression() : {
     ObjectNames data = null;

--- a/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/connect_by08.sql
+++ b/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/connect_by08.sql
@@ -1,0 +1,15 @@
+---
+-- #%L
+-- JSQLParser library
+-- %%
+-- Copyright (C) 2004 - 2019 JSQLParser
+-- %%
+-- Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+-- #L%
+---
+select t.*, connect_by_root t.id as root_id
+from test t
+start with t.id = 1
+connect by prior t.id = t.parent_id
+order siblings by t.some_text
+--@SUCCESSFULLY_PARSED_AND_DEPARSED first on Oct 2, 2024, 8:11:58 PM

--- a/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/connect_by09.sql
+++ b/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/connect_by09.sql
@@ -1,0 +1,15 @@
+---
+-- #%L
+-- JSQLParser library
+-- %%
+-- Copyright (C) 2004 - 2019 JSQLParser
+-- %%
+-- Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+-- #L%
+---
+select t.*, prior t.id parent_id
+from test t
+start with t.id = 1
+connect by prior t.id = t.parent_id
+order siblings by t.some_text
+--@SUCCESSFULLY_PARSED_AND_DEPARSED first on Oct 2, 2024, 8:14:31 PM

--- a/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/connect_by10.sql
+++ b/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/connect_by10.sql
@@ -1,0 +1,15 @@
+---
+-- #%L
+-- JSQLParser library
+-- %%
+-- Copyright (C) 2004 - 2019 JSQLParser
+-- %%
+-- Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+-- #L%
+---
+select t.*, prior t.id as parent_id
+from test t
+start with t.id = 1
+connect by prior t.id = t.parent_id
+order siblings by t.some_text
+--@SUCCESSFULLY_PARSED_AND_DEPARSED first on Oct 2, 2024, 8:14:33 PM


### PR DESCRIPTION
Encountered a failure with parsing queries having PRIOR in the select list (select t.id, prior t.id as parent_id ...).
Thought I would give it a try and fix it myself, but this is my first encounter with AST:s and parser libs in general so do keep that in mind.