### PR TITLE
Fix issue 2089: Enhance MySQL CONVERT Statement Parsing

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -196,7 +196,7 @@ public class AlterExpression implements Serializable {
     /**
      * @param onDeleteCascade
      * @deprecated use
-     *             {@link #setReferentialAction(ReferentialAction.Type, ReferentialAction.Action, boolean)}
+     * {@link #setReferentialAction(ReferentialAction.Type, ReferentialAction.Action, boolean)}
      */
     @Deprecated
     public void setOnDeleteCascade(boolean onDeleteCascade) {
@@ -216,7 +216,7 @@ public class AlterExpression implements Serializable {
     /**
      * @param onDeleteRestrict
      * @deprecated use
-     *             {@link #setReferentialAction(ReferentialAction.Type, ReferentialAction.Action, boolean)}
+     * {@link #setReferentialAction(ReferentialAction.Type, ReferentialAction.Action, boolean)}
      */
     @Deprecated
     public void setOnDeleteRestrict(boolean onDeleteRestrict) {
@@ -236,7 +236,7 @@ public class AlterExpression implements Serializable {
     /**
      * @param onDeleteSetNull
      * @deprecated use
-     *             {@link #setReferentialAction(ReferentialAction.Type, ReferentialAction.Action, boolean)}
+     * {@link #setReferentialAction(ReferentialAction.Type, ReferentialAction.Action, boolean)}
      */
     @Deprecated
     public void setOnDeleteSetNull(boolean onDeleteSetNull) {
@@ -485,6 +485,14 @@ public class AlterExpression implements Serializable {
         } else if (operation == AlterOperation.DROP_PRIMARY_KEY) {
 
             b.append("DROP PRIMARY KEY ");
+        } else if (operation == AlterOperation.CONVERT) {
+            b.append("CONVERT TO CHARACTER SET ");
+            if (getCharacterSet() != null) {
+                b.append(getCharacterSet());
+            }
+            if (getCollation() != null) {
+                b.append(" COLLATE ").append(getCollation());
+            }
         } else if (operation == AlterOperation.DROP_UNIQUE) {
 
             b.append("DROP UNIQUE (").append(PlainSelect.getStringList(pkColumns)).append(')');

--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -53,6 +53,11 @@ public class AlterExpression implements Serializable {
     private List<PartitionDefinition> partitionDefinitions;
     private List<ConstraintState> constraints;
     private List<String> parameters;
+
+    private ConvertType convertType;
+    private boolean hasEqualForCharacterSet;
+    private boolean hasEqualForCollate;
+
     private String characterSet;
     private String collation;
     private String lockOption;
@@ -196,7 +201,7 @@ public class AlterExpression implements Serializable {
     /**
      * @param onDeleteCascade
      * @deprecated use
-     * {@link #setReferentialAction(ReferentialAction.Type, ReferentialAction.Action, boolean)}
+     *             {@link #setReferentialAction(ReferentialAction.Type, ReferentialAction.Action, boolean)}
      */
     @Deprecated
     public void setOnDeleteCascade(boolean onDeleteCascade) {
@@ -216,7 +221,7 @@ public class AlterExpression implements Serializable {
     /**
      * @param onDeleteRestrict
      * @deprecated use
-     * {@link #setReferentialAction(ReferentialAction.Type, ReferentialAction.Action, boolean)}
+     *             {@link #setReferentialAction(ReferentialAction.Type, ReferentialAction.Action, boolean)}
      */
     @Deprecated
     public void setOnDeleteRestrict(boolean onDeleteRestrict) {
@@ -236,7 +241,7 @@ public class AlterExpression implements Serializable {
     /**
      * @param onDeleteSetNull
      * @deprecated use
-     * {@link #setReferentialAction(ReferentialAction.Type, ReferentialAction.Action, boolean)}
+     *             {@link #setReferentialAction(ReferentialAction.Type, ReferentialAction.Action, boolean)}
      */
     @Deprecated
     public void setOnDeleteSetNull(boolean onDeleteSetNull) {
@@ -401,6 +406,14 @@ public class AlterExpression implements Serializable {
         return parameters;
     }
 
+    public ConvertType getConvertType() {
+        return convertType;
+    }
+
+    public void setConvertType(ConvertType convertType) {
+        this.convertType = convertType;
+    }
+
     public String getCharacterSet() {
         return characterSet;
     }
@@ -486,12 +499,30 @@ public class AlterExpression implements Serializable {
 
             b.append("DROP PRIMARY KEY ");
         } else if (operation == AlterOperation.CONVERT) {
-            b.append("CONVERT TO CHARACTER SET ");
+            if (convertType == ConvertType.CONVERT_TO) {
+                b.append("CONVERT TO CHARACTER SET ");
+            } else if (convertType == ConvertType.DEFAULT_CHARACTER_SET) {
+                b.append("DEFAULT CHARACTER SET ");
+                if (hasEqualForCharacterSet) {
+                    b.append("= ");
+                }
+            } else if (convertType == ConvertType.CHARACTER_SET) {
+                b.append("CHARACTER SET ");
+                if (hasEqualForCharacterSet) {
+                    b.append("= ");
+                }
+            }
+
             if (getCharacterSet() != null) {
                 b.append(getCharacterSet());
             }
+
             if (getCollation() != null) {
-                b.append(" COLLATE ").append(getCollation());
+                b.append(" COLLATE ");
+                if (hasEqualForCollate) {
+                    b.append("= ");
+                }
+                b.append(getCollation());
             }
         } else if (operation == AlterOperation.DROP_UNIQUE) {
 
@@ -805,6 +836,14 @@ public class AlterExpression implements Serializable {
         this.partitionDefinitions = partitionDefinition;
     }
 
+    public void setHasEqualForCharacterSet(boolean hasEqualForCharacterSet) {
+        this.hasEqualForCharacterSet = hasEqualForCharacterSet;
+    }
+
+    public void setHasEqualForCollate(boolean hasEqualForCollate) {
+        this.hasEqualForCollate = hasEqualForCollate;
+    }
+
     public static final class ColumnDataType extends ColumnDefinition {
 
         private final boolean withType;
@@ -897,5 +936,9 @@ public class AlterExpression implements Serializable {
         public String toString() {
             return columnName + " DROP DEFAULT";
         }
+    }
+
+    public enum ConvertType {
+        CONVERT_TO, DEFAULT_CHARACTER_SET, CHARACTER_SET
     }
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -7430,11 +7430,31 @@ AlterExpression AlterExpression():
         <K_RENAME> <K_TO> {alterExp.setOperation(AlterOperation.RENAME_TABLE);}
         (tk2=<S_IDENTIFIER> | tk2=<S_QUOTED_IDENTIFIER>) { alterExp.setNewTableName(tk2.image);}
       )
-      |
-      (<K_CONVERT> { alterExp.setOperation(AlterOperation.CONVERT); }
+      | (<K_CONVERT> {
+          alterExp.setOperation(AlterOperation.CONVERT);
+          alterExp.setConvertType(AlterExpression.ConvertType.CONVERT_TO);
+        }
         <K_TO> <K_CHARACTER> <K_SET> tk=<S_IDENTIFIER> { alterExp.setCharacterSet(tk.image); }
         [<K_COLLATE> tk2=<S_IDENTIFIER> { alterExp.setCollation(tk2.image); }]
-        )
+      )
+      | (<K_DEFAULT> {
+          alterExp.setOperation(AlterOperation.CONVERT);
+          alterExp.setConvertType(AlterExpression.ConvertType.DEFAULT_CHARACTER_SET);
+        }
+        <K_CHARACTER> <K_SET> [ "=" { alterExp.setHasEqualForCharacterSet(true); } ]
+        tk=<S_IDENTIFIER> { alterExp.setCharacterSet(tk.image); }
+        [<K_COLLATE> [ "=" { alterExp.setHasEqualForCollate(true); } ]
+            tk2=<S_IDENTIFIER> { alterExp.setCollation(tk2.image); }]
+      )
+      | (<K_CHARACTER> <K_SET> [ "=" { alterExp.setHasEqualForCharacterSet(true); } ]
+        tk=<S_IDENTIFIER> {
+          alterExp.setOperation(AlterOperation.CONVERT);
+          alterExp.setConvertType(AlterExpression.ConvertType.CHARACTER_SET);
+          alterExp.setCharacterSet(tk.image);
+        }
+        [<K_COLLATE> [ "=" { alterExp.setHasEqualForCollate(true); } ]
+            tk2=<S_IDENTIFIER> { alterExp.setCollation(tk2.image); }]
+      )
       |
       (<K_COMMENT> {alterExp.setOperation(AlterOperation.COMMENT);}
           ["=" {alterExp.setOperation(AlterOperation.COMMENT_WITH_EQUAL_SIGN);} ]

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -24,10 +24,14 @@ import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.table.*;
 import net.sf.jsqlparser.statement.create.table.Index.ColumnParams;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static net.sf.jsqlparser.test.TestUtils.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -834,7 +838,7 @@ public class AlterTest {
     }
 
     private void assertReferentialActionOnConstraint(Alter parsed, Action onUpdate,
-                                                     Action onDelete) {
+            Action onDelete) {
         AlterExpression alterExpression = parsed.getAlterExpressions().get(0);
         ForeignKeyIndex index = (ForeignKeyIndex) alterExpression.getIndex();
 
@@ -1092,43 +1096,54 @@ public class AlterTest {
         assertEquals("EXCLUSIVE", lockExp.getLockOption());
     }
 
-    @Test
-    public void testIssue2089() throws JSQLParserException {
-        String sql = "ALTER TABLE test_table CONVERT TO CHARACTER SET utf8mb4";
+    @ParameterizedTest
+    @MethodSource("provideMySQLConvertTestCases")
+    public void testIssue2089(String sql, String expectedCharacterSet, String expectedCollation)
+            throws JSQLParserException {
         Statement stmt = CCJSqlParserUtil.parse(sql);
-        assertTrue(stmt instanceof Alter);
+        assertTrue(stmt instanceof Alter,
+                "Expected instance of Alter but got: " + stmt.getClass().getSimpleName());
+
         Alter alter = (Alter) stmt;
         assertEquals("test_table", alter.getTable().getFullyQualifiedName());
 
         List<AlterExpression> alterExpressions = alter.getAlterExpressions();
-        assertNotNull(alterExpressions);
-        assertEquals(1, alterExpressions.size());
+        assertNotNull(alterExpressions, "Alter expressions should not be null for SQL: " + sql);
+        assertEquals(1, alterExpressions.size(), "Expected 1 alter expression for SQL: " + sql);
 
         AlterExpression convertExp = alterExpressions.get(0);
         assertEquals(AlterOperation.CONVERT, convertExp.getOperation());
-        assertEquals("utf8mb4", convertExp.getCharacterSet());
-        assertNull(convertExp.getCollation());
+
+        assertEquals(expectedCharacterSet, convertExp.getCharacterSet(),
+                "CHARACTER SET mismatch for SQL: " + sql);
+        assertEquals(expectedCollation, convertExp.getCollation(),
+                "COLLATE mismatch for SQL: " + sql);
+        assertSqlCanBeParsedAndDeparsed(sql);
     }
 
-    @Test
-    public void testIssue2089ConvertWithCollation() throws JSQLParserException {
-        String sql =
-                "ALTER TABLE test_table CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
-        Statement stmt = CCJSqlParserUtil.parse(sql);
-        assertTrue(stmt instanceof Alter);
-        Alter alter = (Alter) stmt;
-        assertEquals("test_table", alter.getTable().getFullyQualifiedName());
-
-        List<AlterExpression> alterExpressions = alter.getAlterExpressions();
-        assertNotNull(alterExpressions);
-        assertEquals(1, alterExpressions.size());
-
-        AlterExpression convertExp = alterExpressions.get(0);
-        assertEquals(AlterOperation.CONVERT, convertExp.getOperation());
-        assertEquals("utf8mb4", convertExp.getCharacterSet());
-        assertEquals("utf8mb4_general_ci", convertExp.getCollation());
-
-        assertSqlCanBeParsedAndDeparsed(sql);
+    private static Stream<Arguments> provideMySQLConvertTestCases() {
+        return Stream.of(
+                Arguments.of("ALTER TABLE test_table CONVERT TO CHARACTER SET utf8mb4", "utf8mb4",
+                        null),
+                Arguments.of(
+                        "ALTER TABLE test_table CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci",
+                        "utf8mb4", "utf8mb4_general_ci"),
+                Arguments.of(
+                        "ALTER TABLE test_table DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci",
+                        "utf8mb4", "utf8mb4_general_ci"),
+                Arguments.of(
+                        "ALTER TABLE test_table DEFAULT CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci",
+                        "utf8mb4", "utf8mb4_general_ci"),
+                Arguments.of(
+                        "ALTER TABLE test_table CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci",
+                        "utf8mb4", "utf8mb4_general_ci"),
+                Arguments.of(
+                        "ALTER TABLE test_table CHARACTER SET = utf8mb4 COLLATE = utf8mb4_general_ci",
+                        "utf8mb4", "utf8mb4_general_ci"),
+                Arguments.of("ALTER TABLE test_table DEFAULT CHARACTER SET utf8mb4", "utf8mb4",
+                        null),
+                Arguments.of("ALTER TABLE test_table DEFAULT CHARACTER SET = utf8mb4", "utf8mb4",
+                        null));
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.List;
 
 import static net.sf.jsqlparser.test.TestUtils.*;
-import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class AlterTest {
@@ -835,7 +834,7 @@ public class AlterTest {
     }
 
     private void assertReferentialActionOnConstraint(Alter parsed, Action onUpdate,
-            Action onDelete) {
+                                                     Action onDelete) {
         AlterExpression alterExpression = parsed.getAlterExpressions().get(0);
         ForeignKeyIndex index = (ForeignKeyIndex) alterExpression.getIndex();
 
@@ -1112,7 +1111,7 @@ public class AlterTest {
     }
 
     @Test
-    public void testIssue2089WithCollation() throws JSQLParserException {
+    public void testIssue2089ConvertWithCollation() throws JSQLParserException {
         String sql =
                 "ALTER TABLE test_table CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci";
         Statement stmt = CCJSqlParserUtil.parse(sql);
@@ -1128,6 +1127,8 @@ public class AlterTest {
         assertEquals(AlterOperation.CONVERT, convertExp.getOperation());
         assertEquals("utf8mb4", convertExp.getCharacterSet());
         assertEquals("utf8mb4_general_ci", convertExp.getCollation());
+
+        assertSqlCanBeParsedAndDeparsed(sql);
     }
 
     @Test


### PR DESCRIPTION
**Summary**
This PR fixes and enhances the parsing functionality for MySQL CONVERT statements in ALTER TABLE clauses in JSQLParser. It now supports a wider variety of CONVERT syntax.  

**Changes**
Updated AlterOperation enum to include CONVERT.
Modified the parser to correctly identify and handle the CONVERT clause, including optional COLLATE specifications.

Enhanced the parser to support the following[ ALTER TABLE syntax](https://dev.mysql.com/doc/refman/8.4/en/alter-table.html):
```sql
ALTER TABLE tbl_name
    | [DEFAULT] CHARACTER SET [=] charset_name [COLLATE [=] collation_name]
    | CONVERT TO CHARACTER SET charset_name [COLLATE collation_name]
```