### PR TITLE
add support for MATERIALIZED in WITH clause

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/WithItem.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/WithItem.java
@@ -28,6 +28,8 @@ public class WithItem<T extends ParenthesedStatement> {
     private List<SelectItem<?>> withItemList;
     private boolean recursive = false;
 
+    private boolean materialized = false;
+
     public WithItem(T statement, Alias alias) {
         this.statement = statement;
         this.alias = alias;
@@ -79,6 +81,14 @@ public class WithItem<T extends ParenthesedStatement> {
         this.recursive = recursive;
     }
 
+    public boolean isMaterialized() {
+        return materialized;
+    }
+
+    public void setMaterialized(boolean materialized) {
+        this.materialized = materialized;
+    }
+
     /**
      * The {@link SelectItem}s in this WITH (for example the A,B,C in "WITH mywith (A,B,C) AS ...")
      *
@@ -108,6 +118,7 @@ public class WithItem<T extends ParenthesedStatement> {
             builder.append(")");
         }
         builder.append(" AS ");
+        builder.append(materialized ? "MATERIALIZED " : "");
         builder.append(statement);
         return builder.toString();
     }
@@ -121,8 +132,9 @@ public class WithItem<T extends ParenthesedStatement> {
         return this;
     }
 
-    public WithItem<?> withRecursive(boolean recursive) {
+    public WithItem<?> withRecursive(boolean recursive, boolean materialized) {
         this.setRecursive(recursive);
+        this.setMaterialized(materialized);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -682,6 +682,9 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
                     .append(PlainSelect.getStringList(withItem.getWithItemList(), true, true));
         }
         buffer.append(" AS ");
+        if (withItem.isMaterialized()) {
+            buffer.append("MATERIALIZED ");
+        }
         StatementDeParser statementDeParser =
                 new StatementDeParser((ExpressionDeParser) expressionVisitor, this, buffer);
         statementDeParser.deParse(withItem.getParenthesedStatement());

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2705,6 +2705,7 @@ List<WithItem<?>> WithList():
 WithItem<?> WithItem() #WithItem:
 {
     boolean recursive = false;
+    boolean materialized = false;
     String name;
     List<SelectItem<?>> selectItems = null;
     ParenthesedStatement statement;
@@ -2714,6 +2715,7 @@ WithItem<?> WithItem() #WithItem:
      name=RelObjectName()
      [ "(" selectItems=SelectItemsList() ")" ]
      <K_AS>
+     [ LOOKAHEAD(2) <K_MATERIALIZED>  { materialized = true; } ]
      (
          LOOKAHEAD(2) statement = ParenthesedSelect()
          |
@@ -2726,7 +2728,7 @@ WithItem<?> WithItem() #WithItem:
      {
         WithItem<?> withItem = new WithItem(statement, new Alias(name, false));
         return withItem
-            .withRecursive(recursive)
+            .withRecursive(recursive, materialized)
             .withWithItemList(selectItems);
      }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -3187,6 +3187,12 @@ public class SelectTest {
     }
 
     @Test
+    public void testSelectWithMaterializedWith() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "WITH tokens_with_supply AS MATERIALIZED (SELECT * FROM tokens) SELECT * FROM tokens_with_supply");
+    }
+
+    @Test
     public void testSelectInnerWith() throws JSQLParserException {
         String stmt =
                 "SELECT * FROM (WITH actor AS (SELECT 'a' aid FROM DUAL) SELECT aid FROM actor)";


### PR DESCRIPTION
This PR adds support for MATERIALIZED CTEs: `WITH table AS MATERIALIZED ...`

Reference: https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-CTE-MATERIALIZATION