### PR TITLE
Fix null exception in ExpressionVisitorAdapter with simple INTERVAL expression

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -430,7 +430,10 @@ public class ExpressionVisitorAdapter<T>
 
     @Override
     public <S> T visit(IntervalExpression intervalExpression, S context) {
-        return intervalExpression.getExpression().accept(this, context);
+        if (intervalExpression.getExpression() != null) {
+            intervalExpression.getExpression().accept(this, context);
+        }
+        return null;
     }
 
     @Override

--- a/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapterTest.java
@@ -321,4 +321,11 @@ public class ExpressionVisitorAdapterTest {
         assertInstanceOf(Column.class, exprList.get(0));
         assertInstanceOf(ParenthesedExpressionList.class, exprList.get(1));
     }
+
+    @Test
+    public void testIntervalWithNoExpression() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil.parseExpression("INTERVAL 1 DAY");
+        ExpressionVisitorAdapter<Void> adapter = new ExpressionVisitorAdapter<>();
+        expr.accept(adapter, null);
+    }
 }


### PR DESCRIPTION
`ExpressionVisitorAdapter` was throwing a `NullPointerException` when a simple `INTERVAL` expression was provided, which didn't contain an actual expression (`.getExpression()` returns `null`).

Sample expression that causes the issue: `INTERVAL 1 DAY`

This PR adds validation around that code to fix this issue.