### PR TITLE
feat: Support unknown keyword

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -42,6 +42,7 @@ import net.sf.jsqlparser.expression.operators.relational.IncludesExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsBooleanExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsDistinctExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsNullExpression;
+import net.sf.jsqlparser.expression.operators.relational.IsUnknownExpression;
 import net.sf.jsqlparser.expression.operators.relational.JsonOperator;
 import net.sf.jsqlparser.expression.operators.relational.LikeExpression;
 import net.sf.jsqlparser.expression.operators.relational.Matches;
@@ -265,6 +266,12 @@ public interface ExpressionVisitor<T> {
 
     default void visit(IsBooleanExpression isBooleanExpression) {
         this.visit(isBooleanExpression, null);
+    }
+
+    <S> T visit(IsUnknownExpression isUnknownExpression, S context);
+
+    default void visit(IsUnknownExpression isUnknownExpression) {
+        this.visit(isUnknownExpression, null);
     }
 
     <S> T visit(LikeExpression likeExpression, S context);

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -42,6 +42,7 @@ import net.sf.jsqlparser.expression.operators.relational.IncludesExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsBooleanExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsDistinctExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsNullExpression;
+import net.sf.jsqlparser.expression.operators.relational.IsUnknownExpression;
 import net.sf.jsqlparser.expression.operators.relational.JsonOperator;
 import net.sf.jsqlparser.expression.operators.relational.LikeExpression;
 import net.sf.jsqlparser.expression.operators.relational.Matches;
@@ -261,6 +262,11 @@ public class ExpressionVisitorAdapter<T>
     @Override
     public <S> T visit(IsBooleanExpression isBooleanExpression, S context) {
         return isBooleanExpression.getLeftExpression().accept(this, context);
+    }
+
+    @Override
+    public <S> T visit(IsUnknownExpression isUnknownExpression, S context) {
+        return isUnknownExpression.getLeftExpression().accept(this, context);
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsUnknownExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsUnknownExpression.java
@@ -1,0 +1,60 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2025 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression.operators.relational;
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
+public class IsUnknownExpression extends ASTNodeAccessImpl implements Expression {
+
+    private Expression leftExpression;
+    private boolean isNot = false;
+
+    public Expression getLeftExpression() {
+        return leftExpression;
+    }
+
+    public void setLeftExpression(Expression expression) {
+        leftExpression = expression;
+    }
+
+    public boolean isNot() {
+        return isNot;
+    }
+
+    public void setNot(boolean isNot) {
+        this.isNot = isNot;
+    }
+
+    @Override
+    public <T, S> T accept(ExpressionVisitor<T> expressionVisitor, S context) {
+        return expressionVisitor.visit(this, context);
+    }
+
+    @Override
+    public String toString() {
+        return leftExpression + " IS" + (isNot ? " NOT" : "") + " UNKNOWN";
+    }
+
+    public IsUnknownExpression withLeftExpression(Expression leftExpression) {
+        this.setLeftExpression(leftExpression);
+        return this;
+    }
+
+    public IsUnknownExpression withNot(boolean isNot) {
+        this.setNot(isNot);
+        return this;
+    }
+
+    public <E extends Expression> E getLeftExpression(Class<E> type) {
+        return type.cast(getLeftExpression());
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/parser/ParserKeywordsUtils.java
+++ b/src/main/java/net/sf/jsqlparser/parser/ParserKeywordsUtils.java
@@ -133,6 +133,7 @@ public class ParserKeywordsUtils {
             {"UNBOUNDED", RESTRICTED_JSQLPARSER},
             {"UNION", RESTRICTED_SQL2016},
             {"UNIQUE", RESTRICTED_SQL2016},
+            {"UNKNOWN", RESTRICTED_SQL2016},
             {"UNPIVOT", RESTRICTED_JSQLPARSER},
             {"USE", RESTRICTED_JSQLPARSER},
             {"USING", RESTRICTED_SQL2016},

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -101,6 +101,7 @@ import net.sf.jsqlparser.expression.operators.relational.IncludesExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsBooleanExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsDistinctExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsNullExpression;
+import net.sf.jsqlparser.expression.operators.relational.IsUnknownExpression;
 import net.sf.jsqlparser.expression.operators.relational.JsonOperator;
 import net.sf.jsqlparser.expression.operators.relational.LikeExpression;
 import net.sf.jsqlparser.expression.operators.relational.Matches;
@@ -526,6 +527,12 @@ public class TablesNamesFinder<Void>
 
     @Override
     public <S> Void visit(IsBooleanExpression isBooleanExpression, S context) {
+
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(IsUnknownExpression isUnknownExpression, S context) {
 
         return null;
     }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -101,6 +101,7 @@ import net.sf.jsqlparser.expression.operators.relational.IncludesExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsBooleanExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsDistinctExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsNullExpression;
+import net.sf.jsqlparser.expression.operators.relational.IsUnknownExpression;
 import net.sf.jsqlparser.expression.operators.relational.JsonOperator;
 import net.sf.jsqlparser.expression.operators.relational.LikeExpression;
 import net.sf.jsqlparser.expression.operators.relational.Matches;
@@ -429,6 +430,17 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
     }
 
     @Override
+    public <S> StringBuilder visit(IsUnknownExpression isUnknownExpression, S context) {
+        isUnknownExpression.getLeftExpression().accept(this, context);
+        if (isUnknownExpression.isNot()) {
+            buffer.append(" IS NOT UNKNOWN");
+        } else {
+            buffer.append(" IS UNKNOWN");
+        }
+        return buffer;
+    }
+
+    @Override
     public <S> StringBuilder visit(JdbcParameter jdbcParameter, S context) {
         buffer.append(jdbcParameter.getParameterCharacter());
         if (jdbcParameter.isUseFixedIndex()) {
@@ -512,6 +524,10 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
 
     public void visit(IsBooleanExpression isBooleanExpression) {
         visit(isBooleanExpression, null);
+    }
+
+    public void visit(IsUnknownExpression isUnknownExpression) {
+        visit(isUnknownExpression, null);
     }
 
     public void visit(JdbcParameter jdbcParameter) {

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
@@ -102,6 +102,7 @@ import net.sf.jsqlparser.expression.operators.relational.IncludesExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsBooleanExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsDistinctExpression;
 import net.sf.jsqlparser.expression.operators.relational.IsNullExpression;
+import net.sf.jsqlparser.expression.operators.relational.IsUnknownExpression;
 import net.sf.jsqlparser.expression.operators.relational.JsonOperator;
 import net.sf.jsqlparser.expression.operators.relational.LikeExpression;
 import net.sf.jsqlparser.expression.operators.relational.Matches;
@@ -290,6 +291,12 @@ public class ExpressionValidator extends AbstractValidator<Expression>
     }
 
     @Override
+    public <S> Void visit(IsUnknownExpression isUnknownExpression, S context) {
+        isUnknownExpression.getLeftExpression().accept(this, context);
+        return null;
+    }
+
+    @Override
     public <S> Void visit(JdbcParameter jdbcParameter, S context) {
         validateFeature(Feature.jdbcParameter);
         return null;
@@ -381,6 +388,10 @@ public class ExpressionValidator extends AbstractValidator<Expression>
 
     public void visit(IsBooleanExpression isBooleanExpression) {
         visit(isBooleanExpression, null); // Call the parametrized visit method with null context
+    }
+
+    public void visit(IsUnknownExpression isUnknownExpression) {
+        visit(isUnknownExpression, null); // Call the parametrized visit method with null context
     }
 
     public void visit(JdbcParameter jdbcParameter) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -495,6 +495,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_UNBOUNDED: "UNBOUNDED">
 |   <K_UNION:"UNION">
 |   <K_UNIQUE:"UNIQUE">
+|   <K_UNKNOWN:"UNKNOWN">
 |   <K_UNLOGGED: "UNLOGGED">
 |   <K_UNPIVOT:"UNPIVOT">
 |   <K_UPDATE:"UPDATE">
@@ -4153,6 +4154,8 @@ Expression SQLCondition():
                 |
                 LOOKAHEAD(IsBooleanExpression()) result=IsBooleanExpression(left)
                 |
+                LOOKAHEAD(IsUnknownExpression()) result=IsUnknownExpression(left)
+                |
                 LOOKAHEAD(2) result=LikeExpression(left)
                 |
                 LOOKAHEAD(IsDistinctExpression()) result=IsDistinctExpression(left)
@@ -4358,6 +4361,21 @@ Expression IsBooleanExpression(Expression leftExpression):
 {
         (
           <K_IS> [<K_NOT> { result.setNot(true); } ] (<K_TRUE> { result.setIsTrue(true); } | <K_FALSE> { result.setIsTrue(false); })
+        )
+
+    {
+        result.setLeftExpression(leftExpression);
+        return result;
+    }
+}
+
+Expression IsUnknownExpression(Expression leftExpression):
+{
+    IsUnknownExpression result = new IsUnknownExpression();
+}
+{
+        (
+          <K_IS> [<K_NOT> { result.setNot(true); } ] <K_UNKNOWN>
         )
 
     {

--- a/src/site/sphinx/keywords.rst
+++ b/src/site/sphinx/keywords.rst
@@ -77,7 +77,7 @@ The following Keywords are **restricted** in JSQLParser-|JSQLPARSER_VERSION| and
 +----------------------+-------------+-----------+
 | QUALIFY              | Yes         |           | 
 +----------------------+-------------+-----------+
-| HAVING               | Yes         | Yes       |
+| HAVING               | Yes         | Yes       | 
 +----------------------+-------------+-----------+
 | IF                   | Yes         | Yes       | 
 +----------------------+-------------+-----------+
@@ -97,7 +97,7 @@ The following Keywords are **restricted** in JSQLParser-|JSQLPARSER_VERSION| and
 +----------------------+-------------+-----------+
 | INTERVAL             | Yes         | Yes       | 
 +----------------------+-------------+-----------+
-| INTO                 | Yes         | Yes       |
+| INTO                 | Yes         | Yes       | 
 +----------------------+-------------+-----------+
 | IS                   | Yes         | Yes       | 
 +----------------------+-------------+-----------+
@@ -109,7 +109,7 @@ The following Keywords are **restricted** in JSQLParser-|JSQLPARSER_VERSION| and
 +----------------------+-------------+-----------+
 | LIKE                 | Yes         | Yes       | 
 +----------------------+-------------+-----------+
-| LIMIT                | Yes         | Yes       |
+| LIMIT                | Yes         | Yes       | 
 +----------------------+-------------+-----------+
 | MINUS                | Yes         | Yes       | 
 +----------------------+-------------+-----------+
@@ -139,7 +139,9 @@ The following Keywords are **restricted** in JSQLParser-|JSQLPARSER_VERSION| and
 +----------------------+-------------+-----------+
 | OPTIMIZE             | Yes         | Yes       | 
 +----------------------+-------------+-----------+
-| PIVOT                | Yes         | Yes       |
+| OVERWRITE            | Yes         | Yes       | 
++----------------------+-------------+-----------+
+| PIVOT                | Yes         | Yes       | 
 +----------------------+-------------+-----------+
 | PREFERRING           | Yes         | Yes       | 
 +----------------------+-------------+-----------+
@@ -180,6 +182,8 @@ The following Keywords are **restricted** in JSQLParser-|JSQLPARSER_VERSION| and
 | UNION                | Yes         | Yes       | 
 +----------------------+-------------+-----------+
 | UNIQUE               | Yes         | Yes       | 
++----------------------+-------------+-----------+
+| UNKNOWN              | Yes         | Yes       | 
 +----------------------+-------------+-----------+
 | UNPIVOT              | Yes         | Yes       | 
 +----------------------+-------------+-----------+

--- a/src/test/java/net/sf/jsqlparser/expression/operators/relational/IsUnknownExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/operators/relational/IsUnknownExpressionTest.java
@@ -1,0 +1,47 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2023 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression.operators.relational;
+
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.test.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class IsUnknownExpressionTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "SELECT * FROM mytable WHERE 1 IS UNKNOWN",
+            "SELECT * FROM mytable WHERE 1 IS NOT UNKNOWN",
+    })
+    public void testIsUnknownExpression(String sqlStr) {
+        assertDoesNotThrow(() -> TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr));
+    }
+
+    @Test
+    void testStringConstructor() {
+        Column column = new Column("x");
+
+        IsUnknownExpression defaultIsUnknownExpression =
+                new IsUnknownExpression().withLeftExpression(column);
+        TestUtils.assertExpressionCanBeDeparsedAs(defaultIsUnknownExpression, "x IS UNKNOWN");
+
+        IsUnknownExpression isUnknownExpression =
+                new IsUnknownExpression().withLeftExpression(column).withNot(false);
+        TestUtils.assertExpressionCanBeDeparsedAs(isUnknownExpression, "x IS UNKNOWN");
+
+        IsUnknownExpression isNotUnknownExpression =
+                new IsUnknownExpression().withLeftExpression(column).withNot(true);
+        TestUtils.assertExpressionCanBeDeparsedAs(isNotUnknownExpression, "x IS NOT UNKNOWN");
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/statement/builder/ReflectionModelTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/builder/ReflectionModelTest.java
@@ -110,6 +110,7 @@ public class ReflectionModelTest {
             new net.sf.jsqlparser.expression.operators.relational.InExpression(),
             new net.sf.jsqlparser.expression.operators.relational.IsBooleanExpression(),
             new net.sf.jsqlparser.expression.operators.relational.IsNullExpression(),
+            new net.sf.jsqlparser.expression.operators.relational.IsUnknownExpression(),
             new net.sf.jsqlparser.expression.operators.relational.JsonOperator("@>"),
             new net.sf.jsqlparser.expression.operators.relational.LikeExpression(),
             new net.sf.jsqlparser.expression.operators.relational.Matches(),

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -2272,6 +2272,18 @@ public class SelectTest {
     }
 
     @Test
+    public void testIsUnknown() throws JSQLParserException {
+        String statement = "SELECT col FROM tbl WHERE col IS UNKNOWN";
+        assertSqlCanBeParsedAndDeparsed(statement);
+    }
+
+    @Test
+    public void testIsNotUnknown() throws JSQLParserException {
+        String statement = "SELECT col FROM tbl WHERE col IS NOT UNKNOWN";
+        assertSqlCanBeParsedAndDeparsed(statement);
+    }
+
+    @Test
     public void testTSQLJoin() throws JSQLParserException {
         String stmt = "SELECT * FROM tabelle1, tabelle2 WHERE tabelle1.a *= tabelle2.b";
         assertSqlCanBeParsedAndDeparsed(stmt);

--- a/src/test/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidatorTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidatorTest.java
@@ -151,6 +151,12 @@ public class ExpressionValidatorTest extends ValidationTestAsserts {
     }
 
     @Test
+    public void testIsUnknown() {
+        validateNoErrors("SELECT * FROM tab t WHERE t.col IS UNKNOWN", 1, EXPRESSIONS);
+        validateNoErrors("SELECT * FROM tab t WHERE t.col IS NOT UNKNOWN", 1, EXPRESSIONS);
+    }
+
+    @Test
     public void testLike() {
         validateNoErrors("SELECT * FROM tab t WHERE t.col LIKE '%search for%'", 1, EXPRESSIONS);
         validateNoErrors("SELECT * FROM tab t WHERE t.col NOT LIKE '%search for%'", 1, EXPRESSIONS);


### PR DESCRIPTION
This PR adds support for the `UNKNOWN` keyword and `IsUnknownExpression` in order to parse [`IS UNKNOWN`](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#operator_is) and [`IS NOT UNKNOWN`](https://dev.mysql.com/doc/refman/8.4/en/comparison-operators.html#operator_is-not) operations in MySQL.