### PR TITLE
Add support for AllTableColumns in PrimaryExpression

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3252,11 +3252,7 @@ SelectItem<?> SelectItem() #SelectItem:
     // @fixme: Oracle's SEQUENCE.nextval is parsed as COLUMN with a name part nextval
     // @todo: parse a proper SEQUENCE instead of a COLUMN
     (
-        expression = AllColumns()
-        |
         LOOKAHEAD( 3 ) expression = ConnectByPriorOperator()
-        |
-        LOOKAHEAD(AllTableColumns()) expression = AllTableColumns()
         |
         LOOKAHEAD( 3 ) expression = XorExpression()
         |
@@ -5301,6 +5297,9 @@ Expression PrimaryExpression() #PrimaryExpression:
 
         | LOOKAHEAD(2, {!interrupted}) retval=CastExpression()
 
+        | LOOKAHEAD(AllColumns()) retval=AllColumns()
+
+        | LOOKAHEAD(AllTableColumns()) retval=AllTableColumns()
 
         // support timestamp expressions
         | LOOKAHEAD(2, {!interrupted}) (token=<K_TIME_KEY_EXPR> | token=<K_CURRENT>) { retval = new TimeKeyExpression(token.image); }
@@ -6450,10 +6449,6 @@ Function InternalFunction(boolean escaped):
             )
         ]
         (
-            "*" { expr = new AllColumns(); expressionList = new ExpressionList(expr); }
-            |
-            LOOKAHEAD( AllTableColumns() ) expr=AllTableColumns() { expressionList = new ExpressionList(expr); }
-            |
             LOOKAHEAD(3) [ LOOKAHEAD(2) extraKeywordToken = <K_TABLE> { retval.setExtraKeyword(extraKeywordToken.image); } ]
             expressionList=ExpressionList()
             [ orderByList = OrderByElements() { retval.setOrderByElements(orderByList); } ]

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -5487,6 +5487,12 @@ public class SelectTest {
     }
 
     @Test
+    public void testGroupByWithAllTableColumns() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "select c.post_id, p.* from posts p inner join comments c on c.post_id = p.post_id group by p.post_id, c.post_id, p.*;");
+    }
+
+    @Test
     public void testTableSpaceKeyword() throws JSQLParserException {
         // without extra brackets
         assertSqlCanBeParsedAndDeparsed(


### PR DESCRIPTION
PostgreSQL supports expressions such as `posts.*` (all columns from the `posts` table) in many places, such as the `GROUP BY` clause.

For example, in this query:
```sql
select c.post_id, p.* from posts p inner join comments c on c.post_id = p.post_id group by p.post_id, c.post_id, p.*;
```

This PR adds support for AllTableColumns in PrimaryExpression.

I wasn't sure if PrimaryExpression is the best fit for this, so will be happy for suggestions on relocating it if there's a better expression group for it.