### PR TITLE
Allow specific keywords to be parsed as identifiers (fix issue with RENAME COLUMN)

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -719,6 +719,35 @@ TOKEN:
     }
 }
 
+/**
+ * Parses identifiers including standard SQL identifiers, quoted identifiers, and specific keywords.
+ *
+ * This is used in cases where certain SQL keywords (like NAME, NEXT, VALUE, etc.) can appear
+ * as identifiers (e.g., table names, column names) depending on the SQL dialect or context.
+ *
+ * Supported tokens:
+ *  - <S_IDENTIFIER>: Standard unquoted SQL identifier
+ *  - <S_QUOTED_IDENTIFIER>: Quoted identifier (e.g., `identifier` or "identifier")
+ *  - <K_NAME>, <K_NEXT>, <K_VALUE>, <K_PUBLIC>, <K_STRING>: Specific keywords treated as identifiers
+ *
+ * @return Token representing the identifier or keyword used as identifier
+ */
+Token KeywordOrIdentifier():
+{
+    Token tk;
+}
+{
+    (
+        tk = <S_IDENTIFIER>
+      | tk = <S_QUOTED_IDENTIFIER>
+      | tk = <K_NAME>
+      | tk = <K_NEXT>
+      | tk = <K_VALUE>
+      | tk = <K_PUBLIC>
+      | tk = <K_STRING>
+    )
+    { return tk; }
+}
 
 Statement Statement() #Statement:
 {
@@ -7997,9 +8026,9 @@ AlterExpression AlterExpression():
         )
       |
       LOOKAHEAD(2)  <K_RENAME> { alterExp.setOperation(AlterOperation.RENAME); } [ <K_COLUMN> {  alterExp.hasColumn(true);} ]
-                    ( tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER> ) { alterExp.setColOldName(tk.image); }
+                    ( tk=KeywordOrIdentifier() ) { alterExp.setColOldName(tk.image); }
                     <K_TO>
-                    (tk2=<S_IDENTIFIER> | tk2=<S_QUOTED_IDENTIFIER>) { alterExp.setColumnName(tk2.image); }
+                    ( tk2=KeywordOrIdentifier() ) { alterExp.setColumnName(tk2.image); }
       |
       LOOKAHEAD(2)(
         <K_RENAME> <K_TO> {alterExp.setOperation(AlterOperation.RENAME_TABLE);}

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -622,6 +622,19 @@ public class AlterTest {
     }
 
     @Test
+    public void testAlterTableRenameColumn2() throws JSQLParserException {
+        // Additional test case: Renaming column from 'name' to 'full_name'
+        String sql = "ALTER TABLE test_table RENAME COLUMN name TO full_name";
+        assertSqlCanBeParsedAndDeparsed(sql);
+
+        Alter alter = (Alter) CCJSqlParserUtil.parse(sql);
+        AlterExpression expression = alter.getAlterExpressions().get(0);
+        assertEquals(expression.getOperation(), AlterOperation.RENAME);
+        assertEquals(expression.getColOldName(), "name");
+        assertEquals(expression.getColumnName(), "full_name");
+    }
+
+    @Test
     public void testAlterTableForeignKeyIssue981() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed(
                 "ALTER TABLE atconfigpro "


### PR DESCRIPTION
## Summary
This PR introduces a new parser rule `KeywordOrIdentifier()` to handle cases where certain keywords are used as identifiers. This addresses issues that arose after specific tokens like `NAME` were introduced as keywords.

## Problem
While parsing a statement like:
```sql
ALTER TABLE test_table RENAME COLUMN name TO full_name;
```

the parser failed because `name` was recognized strictly as a `<K_NAME>` keyword after [this commit](https://github.com/JSQLParser/JSqlParser/commit/f932b8f9807530cebbcb280308fb05fe0dd1d983), instead of being allowed as an identifier.

## Solution
- Introduced `KeywordOrIdentifier()` rule that accepts:
  - `<S_IDENTIFIER>`
  - `<S_QUOTED_IDENTIFIER>`
  - Selected keywords like `<K_NAME>`, `<K_NEXT>`, `<K_VALUE>`, `<K_PUBLIC>`, `<K_STRING>`
  - Additional tokens can be added as needed in the future.
- Replaced relevant parts of the grammar to use `KeywordOrIdentifier()`.

---
I’m open to any feedback or suggestions on this approach!