### PR TITLE
feat: add support SELECT all columns from function result

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -60,6 +60,7 @@ import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.piped.FromQuery;
 import net.sf.jsqlparser.statement.select.AllColumns;
 import net.sf.jsqlparser.statement.select.AllTableColumns;
+import net.sf.jsqlparser.statement.select.FunctionAllColumns;
 import net.sf.jsqlparser.statement.select.ParenthesedSelect;
 import net.sf.jsqlparser.statement.select.Select;
 
@@ -584,6 +585,8 @@ public interface ExpressionVisitor<T> {
     }
 
     <S> T visit(AllColumns allColumns, S context);
+
+    <S> T visit(FunctionAllColumns functionColumns, S context);
 
     default void visit(AllColumns allColumns) {
         this.visit(allColumns, null);

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -60,6 +60,7 @@ import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.piped.FromQuery;
 import net.sf.jsqlparser.statement.select.AllColumns;
 import net.sf.jsqlparser.statement.select.AllTableColumns;
+import net.sf.jsqlparser.statement.select.FunctionAllColumns;
 import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.ParenthesedSelect;
 import net.sf.jsqlparser.statement.select.Pivot;
@@ -597,6 +598,11 @@ public class ExpressionVisitorAdapter<T>
     @Override
     public <S> T visit(AllTableColumns allTableColumns, S context) {
         return visitExpression(allTableColumns, context);
+    }
+
+    @Override
+    public <S> T visit(FunctionAllColumns functionAllColumns, S context) {
+        return visitExpression(functionAllColumns, context);
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/statement/select/FunctionAllColumns.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/FunctionAllColumns.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2025 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.select;
+
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.expression.Function;
+
+
+public class FunctionAllColumns extends AllColumns {
+    private Function function;
+
+    public FunctionAllColumns(Function function) {
+        super(null, null, null);
+        this.function = function;
+    }
+
+    public Function getFunction() {
+        return function;
+    }
+
+    public FunctionAllColumns setFunction(Function function) {
+        this.function = function;
+        return this;
+    }
+
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("(");
+        builder.append(function);
+        builder.append(").*");
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return appendTo(new StringBuilder()).toString();
+    }
+
+    @Override
+    public <T, S> T accept(ExpressionVisitor<T> expressionVisitor, S context) {
+        return expressionVisitor.visit(this, context);
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -165,6 +165,7 @@ import net.sf.jsqlparser.statement.refresh.RefreshMaterializedViewStatement;
 import net.sf.jsqlparser.statement.select.AllColumns;
 import net.sf.jsqlparser.statement.select.AllTableColumns;
 import net.sf.jsqlparser.statement.select.FromItemVisitor;
+import net.sf.jsqlparser.statement.select.FunctionAllColumns;
 import net.sf.jsqlparser.statement.select.Join;
 import net.sf.jsqlparser.statement.select.LateralSubSelect;
 import net.sf.jsqlparser.statement.select.OrderByElement;
@@ -944,6 +945,12 @@ public class TablesNamesFinder<Void>
 
     @Override
     public <S> Void visit(AllTableColumns allTableColumns, S context) {
+
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(FunctionAllColumns functionAllColumns, S context) {
 
         return null;
     }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -123,6 +123,7 @@ import net.sf.jsqlparser.statement.create.table.ColDataType;
 import net.sf.jsqlparser.statement.piped.FromQuery;
 import net.sf.jsqlparser.statement.select.AllColumns;
 import net.sf.jsqlparser.statement.select.AllTableColumns;
+import net.sf.jsqlparser.statement.select.FunctionAllColumns;
 import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.ParenthesedSelect;
 import net.sf.jsqlparser.statement.select.Select;
@@ -1649,6 +1650,12 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
     @Override
     public <S> StringBuilder visit(AllTableColumns allTableColumns, S context) {
         builder.append(allTableColumns.toString());
+        return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(FunctionAllColumns functionAllColumns, S context) {
+        builder.append(functionAllColumns.toString());
         return builder;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
@@ -123,6 +123,7 @@ import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.piped.FromQuery;
 import net.sf.jsqlparser.statement.select.AllColumns;
 import net.sf.jsqlparser.statement.select.AllTableColumns;
+import net.sf.jsqlparser.statement.select.FunctionAllColumns;
 import net.sf.jsqlparser.statement.select.ParenthesedSelect;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
@@ -1057,6 +1058,11 @@ public class ExpressionValidator extends AbstractValidator<Expression>
 
     @Override
     public <S> Void visit(AllTableColumns allTableColumns, S context) {
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(FunctionAllColumns functionColumns, S context) {
         return null;
     }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -3273,6 +3273,16 @@ List<SelectItem<?>> SelectItemsList():
     { return selectItemsList; }
 }
 
+FunctionAllColumns FunctionAllColumns() #FunctionAllColumns:
+{
+    Function function;
+}
+{
+    "(" ( "(" )* function=Function() ")" ( ")" )* "." "*"
+    {
+        return new FunctionAllColumns(function);
+    }
+}
 
 SelectItem<?> SelectItem() #SelectItem:
 {
@@ -5331,6 +5341,8 @@ Expression PrimaryExpression() #PrimaryExpression:
         | LOOKAHEAD(AllColumns()) retval=AllColumns()
 
         | LOOKAHEAD(AllTableColumns()) retval=AllTableColumns()
+
+        | LOOKAHEAD(FunctionAllColumns()) retval=FunctionAllColumns()
 
         // support timestamp expressions
         | LOOKAHEAD(2, {!interrupted}) (token=<K_TIME_KEY_EXPR> | token=<K_CURRENT>) { retval = new TimeKeyExpression(token.image); }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -6173,4 +6173,41 @@ public class SelectTest {
                 select.getPlainSelect().getSelectItems().toString());
     }
 
+    @Test
+    public void testSelectAllColumnsFromFunctionReturn() throws JSQLParserException {
+        String sql = "SELECT (pg_stat_file('postgresql.conf')).*";
+        Statement statement = CCJSqlParserUtil.parse(sql);
+        assertNotNull(statement);
+        assertTrue(statement instanceof Select);
+
+        // Ensure the function is recognized correctly
+        Select select = (Select) statement;
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertNotNull(plainSelect);
+        assertEquals(1, plainSelect.getSelectItems().size());
+        assertTrue(plainSelect.getSelectItems().get(0)
+                .getExpression() instanceof FunctionAllColumns);
+        assertEquals("(pg_stat_file('postgresql.conf')).*",
+                plainSelect.getSelectItems().get(0).toString());
+    }
+
+    @Test
+    public void testSelectAllColumnsFromFunctionReturnWithMultipleParentheses()
+            throws JSQLParserException {
+        String sql = "SELECT ( ( ( pg_stat_file('postgresql.conf') ) )) . *";
+        Statement statement = CCJSqlParserUtil.parse(sql);
+        assertNotNull(statement);
+        assertTrue(statement instanceof Select);
+
+        // Ensure the function is recognized correctly
+        Select select = (Select) statement;
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+        assertNotNull(plainSelect);
+        assertEquals(1, plainSelect.getSelectItems().size());
+        assertTrue(plainSelect.getSelectItems().get(0)
+                .getExpression() instanceof FunctionAllColumns);
+        assertEquals("(pg_stat_file('postgresql.conf')).*",
+                plainSelect.getSelectItems().get(0).toString());
+    }
+
 }


### PR DESCRIPTION
PostgreSQL supports composite type expansion using `.*`, for example,  below query is valid in PostgreSQL:
```SQL
SELECT (pg_stat_file('postgresql.conf')).*
```
More generic one is like below one in queries or sub-queries:
```
SELECT (function_name(param1, ... paramN)).* FROM my_table ...
```
There might be multiple duplicated parentheses surround the function call, such as:
```
SELECT (((pg_stat_file('postgresql.conf')))).* -- this is same effect as one `()` surrounding
```

The PR is adding the support to parse/deparse this type of SQLs.