### PR TITLE
Resolve parser choice conflicts by adjusting lookahead in index-related rules

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -7659,7 +7659,7 @@ void IndexOptionList(List<String> list) :
 {}
 {
     (
-      IndexOption(list)
+       LOOKAHEAD(2) IndexOption(list)
     )*
 }
 
@@ -7857,11 +7857,11 @@ AlterExpression AlterExpression():
                   constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
                 )
                 |
+                LOOKAHEAD(4)
                 (
                   ( tk=<K_SPATIAL> | tk=<K_FULLTEXT> )
                   [ tk2=<K_INDEX> | tk2=<K_KEY> ]
                   (
-                      LOOKAHEAD(2)
                       sk3 = RelObjectName()
                       columnNames = ColumnsNamesList()
                       |


### PR DESCRIPTION
Hi @manticore-projects,

This PR addresses multiple parser choice conflicts by increasing the LOOKAHEAD values in the index-related grammar rules.

✅ Resolved Warnings:
The following conflicts have been resolved:

```
Warning: Choice conflict in (...)* construct at line 7661, column 5.
         Expansion nested within construct and expansion following construct
         have common prefixes, one of which is: "WITH"
         Consider using a lookahead of 2 or more for nested expansion.
Warning: Choice conflict involving two expansions at
         line 7860, column 17 and line 7888, column 17 respectively.
         A common prefix is: "SPATIAL" "COMMENT"
         Consider using a lookahead of 3 or more for earlier expansion.
```

⚠️ Remaining Warnings:
However, the following two warnings still remain:

```
Warning: Choice conflict in [...] construct at line 7863, column 19.
         Expansion nested within construct and expansion following construct
         have common prefixes, one of which is: "INDEX"
         Consider using a lookahead of 2 or more for nested expansion.
Warning: Choice conflict in [...] construct at line 8363, column 9.
         Expansion nested within construct and expansion following construct
         have common prefixes, one of which is: "WITH"
         Consider using a lookahead of 2 or more for nested expansion.
```

From what I can tell, these may stem from ambiguities involving Identifier vs keyword-based starts (INDEX, WITH, etc.). I suspect a deeper refactoring of how Identifier and keyword lookahead are handled might be needed.

If there’s a better pattern or common best practice to resolve such nested choice conflicts (especially those involving Identifier vs keyword lookahead), I’d appreciate your advice before going further.

Thanks!