### PR TITLE
feat: enhance ALTER TABLE support with UNIQUE KEY and INVISIBLE index

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -8034,89 +8034,107 @@ AlterExpression AlterExpression():
                 )
                 |
                 (
-                    <K_CONSTRAINT> sk3=RelObjectName()
+                    <K_CONSTRAINT>
                     (
-                         ( tk=<K_FOREIGN> tk2=<K_KEY>
-                            columnNames=ColumnsNamesList()
-                            {
-                                fkIndex = new ForeignKeyIndex()
-                                .withName(sk3)
-                                .withType(tk.image + " " + tk2.image)
-                                .withColumnsNames(columnNames);
-                                                    columnNames = null;
-                            }
-                            <K_REFERENCES> fkTable=Table() [ LOOKAHEAD(2) columnNames=ColumnsNamesList() ]
-                            {
-                                fkIndex.withTable(fkTable).withReferencedColumnNames(columnNames);
-                                alterExp.setIndex(fkIndex);
-                            }
-
-                            [LOOKAHEAD(2) (<K_ON> (tk=<K_DELETE> | tk=<K_UPDATE>) action = Action()
-                                {  fkIndex.setReferentialAction(ReferentialAction.Type.from(tk.image), action); }
-                            )]
-                            [LOOKAHEAD(2) (<K_ON> (tk=<K_DELETE> | tk=<K_UPDATE>) action = Action()
-                                { fkIndex.setReferentialAction(ReferentialAction.Type.from(tk.image), action); }
-                            )]
-                            constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
-                        )
-                        |
-                        ( tk=<K_PRIMARY> tk2=<K_KEY>
-                            columnNames=ColumnsNamesList()
-                            {
-                                index = new NamedConstraint()
-                                .withName(sk3)
-                                .withType(tk.image + " " + tk2.image)
-                                .withColumnsNames(columnNames);
-                                alterExp.setIndex(index);
-                            }
-                            constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
-                            [ <K_USING> sk4=RelObjectName() { alterExp.addParameters("USING", sk4); }]
-                            [ LOOKAHEAD(2) index = IndexWithComment(index) { alterExp.setIndex(index); } ]
-                        )
-                        |
-                        LOOKAHEAD(2) (
-                            { boolean enforced = true; }
-                            [ tk = <K_NOT> { enforced = false; } ]
-                            <K_ENFORCED> {
-                                alterExp.setEnforced(enforced);
-                                alterExp.setConstraintType("CONSTRAINT");
-                                alterExp.setConstraintSymbol(sk3);
-                            }
-                        )
-                        |
+                        LOOKAHEAD(2)
                         (
-                            <K_CHECK>  {Expression exp = null;} (LOOKAHEAD(2) "(" exp = Expression() ")")* {
-                                CheckConstraint checkCs = new CheckConstraint().withName(sk3).withExpression(exp);
-                                alterExp.setIndex(checkCs);
+                            <K_UNIQUE> (<K_KEY> { alterExp.setConstraintType("UNIQUE KEY"); }
+                            | <K_INDEX> { alterExp.setConstraintType("UNIQUE INDEX"); }
+                            | { alterExp.setConstraintType("UNIQUE"); } )
+                            sk3=RelObjectName() {
+                              alterExp.setConstraintSymbol(sk3);
+                              index = new Index();
+                            }
+                            columnNames=ColumnsNamesList() {
+                              index.setColumnsNames(columnNames);
+                              alterExp.setIndex(index);
                             }
                         )
                         |
+                        sk3=RelObjectName()
                         (
-                            tk=<K_UNIQUE> (tk2=<K_KEY> { alterExp.setUk(true); } | tk2=<K_INDEX>)?
-                              columnNames=ColumnsNamesList()
-                              {
-                                  index = new NamedConstraint()
+                             ( tk=<K_FOREIGN> tk2=<K_KEY>
+                                columnNames=ColumnsNamesList()
+                                {
+                                    fkIndex = new ForeignKeyIndex()
                                     .withName(sk3)
-                                    .withType(tk.image + (tk2!=null?" " + tk2.image:""))
+                                    .withType(tk.image + " " + tk2.image)
                                     .withColumnsNames(columnNames);
-                                  alterExp.setIndex(index);
-                              }
-                              constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
-                              [ <K_USING> sk4=RelObjectName() { alterExp.addParameters("USING", sk4); }]
-                              [ LOOKAHEAD(2) index = IndexWithComment(index) { alterExp.setIndex(index); } ]
-                        )
-                        |
-                        (
-                            tk=<K_KEY>
-                            columnNames=ColumnsNamesList()
-                            {
-                                index = new NamedConstraint()
-                                  .withName(sk3)
-                                  .withType(tk.image)
-                                  .withColumnsNames(columnNames);
-                                alterExp.setIndex(index);
-                            }
-                            constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
+                                                        columnNames = null;
+                                }
+                                <K_REFERENCES> fkTable=Table() [ LOOKAHEAD(2) columnNames=ColumnsNamesList() ]
+                                {
+                                    fkIndex.withTable(fkTable).withReferencedColumnNames(columnNames);
+                                    alterExp.setIndex(fkIndex);
+                                }
+
+                                [LOOKAHEAD(2) (<K_ON> (tk=<K_DELETE> | tk=<K_UPDATE>) action = Action()
+                                    {  fkIndex.setReferentialAction(ReferentialAction.Type.from(tk.image), action); }
+                                )]
+                                [LOOKAHEAD(2) (<K_ON> (tk=<K_DELETE> | tk=<K_UPDATE>) action = Action()
+                                    { fkIndex.setReferentialAction(ReferentialAction.Type.from(tk.image), action); }
+                                )]
+                                constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
+                            )
+                            |
+                            ( tk=<K_PRIMARY> tk2=<K_KEY>
+                                columnNames=ColumnsNamesList()
+                                {
+                                    index = new NamedConstraint()
+                                    .withName(sk3)
+                                    .withType(tk.image + " " + tk2.image)
+                                    .withColumnsNames(columnNames);
+                                    alterExp.setIndex(index);
+                                }
+                                constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
+                                [ <K_USING> sk4=RelObjectName() { alterExp.addParameters("USING", sk4); }]
+                                [ LOOKAHEAD(2) index = IndexWithComment(index) { alterExp.setIndex(index); } ]
+                            )
+                            |
+                            LOOKAHEAD(2) (
+                                { boolean enforced = true; }
+                                [ tk = <K_NOT> { enforced = false; } ]
+                                <K_ENFORCED> {
+                                    alterExp.setEnforced(enforced);
+                                    alterExp.setConstraintType("CONSTRAINT");
+                                    alterExp.setConstraintSymbol(sk3);
+                                }
+                            )
+                            |
+                            (
+                                <K_CHECK>  {Expression exp = null;} (LOOKAHEAD(2) "(" exp = Expression() ")")* {
+                                    CheckConstraint checkCs = new CheckConstraint().withName(sk3).withExpression(exp);
+                                    alterExp.setIndex(checkCs);
+                                }
+                            )
+                            |
+                            (
+                                tk=<K_UNIQUE> (tk2=<K_KEY> { alterExp.setUk(true); } | tk2=<K_INDEX>)?
+                                  columnNames=ColumnsNamesList()
+                                  {
+                                      index = new NamedConstraint()
+                                        .withName(sk3)
+                                        .withType(tk.image + (tk2!=null?" " + tk2.image:""))
+                                        .withColumnsNames(columnNames);
+                                      alterExp.setIndex(index);
+                                  }
+                                  constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
+                                  [ <K_USING> sk4=RelObjectName() { alterExp.addParameters("USING", sk4); }]
+                                  [ LOOKAHEAD(2) index = IndexWithComment(index) { alterExp.setIndex(index); } ]
+                            )
+                            |
+                            (
+                                tk=<K_KEY>
+                                columnNames=ColumnsNamesList()
+                                {
+                                    index = new NamedConstraint()
+                                      .withName(sk3)
+                                      .withType(tk.image)
+                                      .withColumnsNames(columnNames);
+                                    alterExp.setIndex(index);
+                                }
+                                constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
+                            )
                         )
                     )
                 )

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -2212,12 +2212,12 @@ public class AlterTest {
         assertNotNull(alterExp.getIndex());
         assertEquals("k_idx", alterExp.getIndex().getName());
         assertEquals("INDEX", alterExp.getIndex().getIndexKeyword());
-        
+
         List<String> columnNames = alterExp.getIndex().getColumnsNames();
         assertNotNull(columnNames);
         assertEquals(1, columnNames.size());
         assertEquals("k", columnNames.get(0));
-        
+
         List<String> indexSpec = alterExp.getIndex().getIndexSpec();
         assertNotNull(indexSpec);
         assertTrue(indexSpec.contains("INVISIBLE"));

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -2138,4 +2138,46 @@ public class AlterTest {
 
         assertSqlCanBeParsedAndDeparsed(sql);
     }
+
+    @Test
+    public void testAlterTableAddConstraintUniqueKey() throws JSQLParserException {
+        String sql = "ALTER TABLE sbtest1 ADD CONSTRAINT UNIQUE KEY ux_c3 (c3)";
+        Statement stmt = CCJSqlParserUtil.parse(sql);
+        assertInstanceOf(Alter.class, stmt);
+
+        Alter alter = (Alter) stmt;
+        assertEquals("sbtest1", alter.getTable().getFullyQualifiedName());
+
+        List<AlterExpression> alterExpressions = alter.getAlterExpressions();
+        assertNotNull(alterExpressions);
+        assertEquals(1, alterExpressions.size());
+
+        AlterExpression alterExp = alterExpressions.get(0);
+        assertEquals(AlterOperation.ADD, alterExp.getOperation());
+        assertEquals("UNIQUE KEY", alterExp.getConstraintType());
+        assertEquals("ux_c3", alterExp.getConstraintSymbol());
+
+        assertSqlCanBeParsedAndDeparsed(sql);
+    }
+
+    @Test
+    public void testAlterTableAlterIndexInvisible() throws JSQLParserException {
+        String sql = "ALTER TABLE sbtest1 ALTER INDEX c4 INVISIBLE";
+        Statement stmt = CCJSqlParserUtil.parse(sql);
+        assertInstanceOf(Alter.class, stmt);
+
+        Alter alter = (Alter) stmt;
+        assertEquals("sbtest1", alter.getTable().getFullyQualifiedName());
+
+        List<AlterExpression> alterExpressions = alter.getAlterExpressions();
+        assertNotNull(alterExpressions);
+        assertEquals(1, alterExpressions.size());
+
+        AlterExpression alterExp = alterExpressions.get(0);
+        assertEquals(AlterOperation.ALTER, alterExp.getOperation());
+        assertEquals("c4", alterExp.getIndex().getName());
+        assertEquals("INVISIBLE", alterExp.getIndex().getIndexSpec().get(0));
+
+        assertSqlCanBeParsedAndDeparsed(sql);
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -9,13 +9,22 @@
  */
 package net.sf.jsqlparser.statement.alter;
 
-import static net.sf.jsqlparser.test.TestUtils.*;
-import static org.junit.jupiter.api.Assertions.*;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.expression.operators.relational.NotEqualsTo;
@@ -28,12 +37,16 @@ import net.sf.jsqlparser.statement.ReferentialAction.Type;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.alter.AlterExpression.ColumnDataType;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
-import net.sf.jsqlparser.statement.create.table.*;
+import net.sf.jsqlparser.statement.create.table.CheckConstraint;
+import net.sf.jsqlparser.statement.create.table.ForeignKeyIndex;
+import net.sf.jsqlparser.statement.create.table.Index;
 import net.sf.jsqlparser.statement.create.table.Index.ColumnParams;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import net.sf.jsqlparser.statement.create.table.NamedConstraint;
+import net.sf.jsqlparser.statement.create.table.PartitionDefinition;
+import static net.sf.jsqlparser.test.TestUtils.assertDeparse;
+import static net.sf.jsqlparser.test.TestUtils.assertEqualsObjectTree;
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static net.sf.jsqlparser.test.TestUtils.assertStatementCanBeDeparsedAs;
 
 public class AlterTest {
 
@@ -2177,6 +2190,37 @@ public class AlterTest {
         assertEquals(AlterOperation.ALTER, alterExp.getOperation());
         assertEquals("c4", alterExp.getIndex().getName());
         assertEquals("INVISIBLE", alterExp.getIndex().getIndexSpec().get(0));
+
+        assertSqlCanBeParsedAndDeparsed(sql);
+    }
+
+    @Test
+    public void testAlterTableAddIndexInvisible() throws JSQLParserException {
+        String sql = "ALTER TABLE t1 ADD INDEX k_idx (k) INVISIBLE";
+        Statement stmt = CCJSqlParserUtil.parse(sql);
+        assertInstanceOf(Alter.class, stmt);
+
+        Alter alter = (Alter) stmt;
+        assertEquals("t1", alter.getTable().getFullyQualifiedName());
+
+        List<AlterExpression> alterExpressions = alter.getAlterExpressions();
+        assertNotNull(alterExpressions);
+        assertEquals(1, alterExpressions.size());
+
+        AlterExpression alterExp = alterExpressions.get(0);
+        assertEquals(AlterOperation.ADD, alterExp.getOperation());
+        assertNotNull(alterExp.getIndex());
+        assertEquals("k_idx", alterExp.getIndex().getName());
+        assertEquals("INDEX", alterExp.getIndex().getIndexKeyword());
+        
+        List<String> columnNames = alterExp.getIndex().getColumnsNames();
+        assertNotNull(columnNames);
+        assertEquals(1, columnNames.size());
+        assertEquals("k", columnNames.get(0));
+        
+        List<String> indexSpec = alterExp.getIndex().getIndexSpec();
+        assertNotNull(indexSpec);
+        assertTrue(indexSpec.contains("INVISIBLE"));
 
         assertSqlCanBeParsedAndDeparsed(sql);
     }


### PR DESCRIPTION
# Description
This PR adds support for two MySQL DDL statements:

`ALTER TABLE ADD CONSTRAINT UNIQUE KEY syntax`
`ALTER TABLE ALTER INDEX INVISIBLE syntax`


# Problem Solved
Previously, JSqlParser couldn't properly parse the following SQL statements:
```sql
ALTER TABLE sbtest1 ADD CONSTRAINT UNIQUE KEY ux_c3 (c3);
ALTER TABLE sbtest1 ALTER INDEX c4 INVISIBLE;
```

These are valid MySQL syntax for adding a unique constraint with a custom name and for making an index invisible to the query optimizer while keeping it maintained.


# Related Issue
#2076 
