### PR TITLE
feat: support distinctrow keyword

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/ParserKeywordsUtils.java
+++ b/src/main/java/net/sf/jsqlparser/parser/ParserKeywordsUtils.java
@@ -63,6 +63,7 @@ public class ParserKeywordsUtils {
             {"CURRENT", RESTRICTED_JSQLPARSER},
             {"DEFAULT", RESTRICTED_ALIAS},
             {"DISTINCT", RESTRICTED_SQL2016},
+            {"DISTINCTROW", RESTRICTED_SQL2016},
             {"DOUBLE", RESTRICTED_ALIAS},
             {"ELSE", RESTRICTED_JSQLPARSER},
             {"EXCEPT", RESTRICTED_SQL2016},

--- a/src/main/java/net/sf/jsqlparser/statement/select/Distinct.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Distinct.java
@@ -20,6 +20,7 @@ public class Distinct implements Serializable {
 
     private List<SelectItem<?>> onSelectItems;
     private boolean useUnique = false;
+    private boolean useDistinctRow = false;
 
     public Distinct() {}
 
@@ -43,9 +44,18 @@ public class Distinct implements Serializable {
         this.useUnique = useUnique;
     }
 
+    public boolean isUseDistinctRow() {
+        return useDistinctRow;
+    }
+
+    public void setUseDistinctRow(boolean useDistinctRow) {
+        this.useDistinctRow = useDistinctRow;
+    }
+
     @Override
     public String toString() {
-        String sql = useUnique ? "UNIQUE" : "DISTINCT";
+        String distinctIdentifier = useDistinctRow ? "DISTINCTROW" : "DISTINCT";
+        String sql = useUnique ? "UNIQUE" : distinctIdentifier;
 
         if (onSelectItems != null && !onSelectItems.isEmpty()) {
             sql += " ON (" + PlainSelect.getStringList(onSelectItems) + ")";

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -397,6 +397,8 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
         if (distinct != null) {
             if (distinct.isUseUnique()) {
                 builder.append("UNIQUE ");
+            } else if (distinct.isUseDistinctRow()) {
+                builder.append("DISTINCTROW ");
             } else {
                 builder.append("DISTINCT ");
             }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -316,6 +316,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_DISCARD : "DISCARD">
 |   <K_DISCONNECT:"DISCONNECT">
 |   <K_DISTINCT:"DISTINCT">
+|   <K_DISTINCTROW:"DISTINCTROW">
 |   <K_DIV:"DIV">
 |   <K_DDL:"DDL">
 |   <K_DML:"DML">
@@ -3147,7 +3148,9 @@ PlainSelect PlainSelect() #PlainSelect:
             [ LOOKAHEAD(2) "ON" "(" distinctOn=SelectItemsList() { plainSelect.getDistinct().setOnSelectItems(distinctOn); } ")" ]
         )
         |
-        <K_UNIQUE> {  distinct = new Distinct(true); plainSelect.setDistinct(distinct); }
+        <K_DISTINCTROW> { distinct = new Distinct(); distinct.setUseDistinctRow(true); plainSelect.setDistinct(distinct); }
+        |
+        <K_UNIQUE> { distinct = new Distinct(true); plainSelect.setDistinct(distinct); }
         |
         <K_SQL_CALC_FOUND_ROWS> { plainSelect.setMySqlSqlCalcFoundRows(true); }
         |

--- a/src/site/sphinx/keywords.rst
+++ b/src/site/sphinx/keywords.rst
@@ -43,6 +43,8 @@ The following Keywords are **restricted** in JSQLParser-|JSQLPARSER_VERSION| and
 +----------------------+-------------+-----------+
 | DISTINCT             | Yes         | Yes       | 
 +----------------------+-------------+-----------+
+| DISTINCTROW          | Yes         | Yes       | 
++----------------------+-------------+-----------+
 | DOUBLE               | Yes         |           | 
 +----------------------+-------------+-----------+
 | ELSE                 | Yes         | Yes       | 

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -1059,6 +1059,27 @@ public class SelectTest {
     }
 
     @Test
+    public void testDistinctRow() throws JSQLParserException {
+        String statement =
+                "SELECT DISTINCTROW col1, col2 FROM mytable WHERE mytable.col = 9";
+        Select select = (Select) TestUtils.assertSqlCanBeParsedAndDeparsed(statement, true);
+
+        assertInstanceOf(PlainSelect.class, select);
+
+        PlainSelect plainSelect = (PlainSelect) select;
+        Distinct distinct = plainSelect.getDistinct();
+
+        assertNotNull(distinct);
+        assertTrue(distinct.isUseDistinctRow());
+        assertNull(distinct.getOnSelectItems());
+
+        assertEquals("col1", ((Column) (plainSelect.getSelectItems().get(0))
+                .getExpression()).getColumnName());
+        assertEquals("col2", ((Column) (plainSelect.getSelectItems().get(1))
+                .getExpression()).getColumnName());
+    }
+
+    @Test
     public void testIsDistinctFrom() throws JSQLParserException {
         String stmt = "SELECT name FROM tbl WHERE name IS DISTINCT FROM foo";
         assertSqlCanBeParsedAndDeparsed(stmt);


### PR DESCRIPTION
This PR adds support for the `DISTINCTROW` keyword available in [MySQL](https://dev.mysql.com/doc/refman/8.4/en/select.html) and [MariaDB](https://mariadb.com/kb/en/select/#distinct).

> ```sql
> SELECT
>     [ALL | DISTINCT | DISTINCTROW ]
>     ....
>     select_expr [, select_expr]
> ...
> ```