### PR TITLE
Add pluginRepositories to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,22 @@
             <releases><enabled>false</enabled></releases>
         </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>javacc8-snapshots</id>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <releases><enabled>false</enabled></releases>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>ossrh-snapshots</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+            <snapshots><enabled>true</enabled></snapshots>
+            <releases><enabled>false</enabled></releases>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencies>
         <!-- needed for parsing the Keywords via JTree in ParserKeywordsUtils -->

--- a/src/test/java/net/sf/jsqlparser/statement/select/TimeTravelTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/TimeTravelTest.java
@@ -1,3 +1,12 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2025 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
 package net.sf.jsqlparser.statement.select;
 
 import net.sf.jsqlparser.JSQLParserException;

--- a/src/test/java/net/sf/jsqlparser/statement/select/WithItemTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/WithItemTest.java
@@ -1,3 +1,12 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2025 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
 package net.sf.jsqlparser.statement.select;
 
 import net.sf.jsqlparser.JSQLParserException;


### PR DESCRIPTION
Adds pluginRepositories to the pom.xml to allow the javacc plugin to not download from insecure repositories (https vs http). Also adds missing copyrights which were added by maven.