### PR TITLE
Fix[2283] - Fix broken ParserKeywordsUtilsTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
             <groupId>org.javacc.generator</groupId>
             <artifactId>java</artifactId>
             <version>8.1.0-SNAPSHOT</version>
-            <type>pom</type>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Javacc java generator was only being included as a pom artefact in test, but the jar is required for the ParserKeywordsUtilsTest to succeed.