### PR TITLE
Fix[2288] - Support parenthesed expressions within Between

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -5746,18 +5746,18 @@ Expression Between(Expression leftExpression) :
             )
         ]
         (
-            LOOKAHEAD( 3 ) betweenExpressionStart = ParenthesedSelect()
+            LOOKAHEAD( ParenthesedSelect() ) betweenExpressionStart = ParenthesedSelect()
             |
-            LOOKAHEAD( 11 ) betweenExpressionStart = RegularCondition()
+            LOOKAHEAD( RegularCondition() ) betweenExpressionStart = RegularCondition()
             |
             betweenExpressionStart  = SimpleExpression()
         )
 
         <K_AND>
         (
-            LOOKAHEAD( 3 ) betweenExpressionEnd = ParenthesedSelect()
+            LOOKAHEAD( ParenthesedSelect() ) betweenExpressionEnd = ParenthesedSelect()
             |
-            LOOKAHEAD( 11 ) betweenExpressionEnd = RegularCondition()
+            LOOKAHEAD( RegularCondition() ) betweenExpressionEnd = RegularCondition()
             |
             betweenExpressionEnd = SimpleExpression()
         )

--- a/src/test/resources/simple_parsing.txt
+++ b/src/test/resources/simple_parsing.txt
@@ -211,3 +211,9 @@ AND THIS_EMP.WORKDEPT = DINFO.DEPTNO
 select * from Person where deptname='it' AND NOT (age=24)
 
 select * from unnest(array[4,5,6]) with ordinality;
+
+SELECT * FROM tbl WHERE
+day BETWEEN
+  CAST(CAST((NOW() + INTERVAL '-30 day') AS date) AS timestamptz)
+AND
+  CAST(CAST((NOW() + INTERVAL '-1 day') AS date) AS timestamptz);


### PR DESCRIPTION
Supports SQL of the form:
```sql
SELECT * FROM tbl WHERE
day BETWEEN
  CAST(CAST((NOW() + INTERVAL '-30 day') AS date) AS timestamptz)
AND
  CAST(CAST((NOW() + INTERVAL '-1 day') AS date) AS timestamptz);
```