### PR TITLE
Fix[2290] - Fix overeager lambda function parsing

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -5979,7 +5979,7 @@ ExpressionList SimpleExpressionList():
     (
         LOOKAHEAD(2, {!interrupted} ) ","
         (
-            LOOKAHEAD( 6 ) expr=LambdaExpression()
+            LOOKAHEAD( 7 ) expr=LambdaExpression()
             |
             expr=SimpleExpression()
         )
@@ -6038,7 +6038,7 @@ ExpressionList ComplexExpressionList():
         (
             LOOKAHEAD(2) expr=OracleNamedFunctionParameter()
             |
-            LOOKAHEAD(6) expr=LambdaExpression()
+            LOOKAHEAD(7) expr=LambdaExpression()
             |
             expr=Expression()
         ) { expressions.add(expr); }

--- a/src/test/resources/simple_parsing.txt
+++ b/src/test/resources/simple_parsing.txt
@@ -217,3 +217,5 @@ day BETWEEN
   CAST(CAST((NOW() + INTERVAL '-30 day') AS date) AS timestamptz)
 AND
   CAST(CAST((NOW() + INTERVAL '-1 day') AS date) AS timestamptz);
+
+SELECT DATE_TRUNC('week',("schema"."tbl"."column" + INTERVAL '1 day')) FROM "schema"."tbl";


### PR DESCRIPTION
`SELECT DATE_TRUNC('week',("schema"."tbl"."column" + INTERVAL '1 day')) FROM "schema"."tbl";` is parsing the `("schema"."tbl"."column" + INTERVAL '1 day')` as a LambdaFunction incorrectly, and crashes out. Increasing the lookahead depth by 1 ensures it fails to match on the `->` keyword (I believe), and falls into a simple expression instead.

Fixes #2290 

JMH
```
jmh {
    includes = ['.*JSQLParserBenchmark.*']
    warmupIterations = 2
    fork = 5
    iterations = 5
    timeOnIteration = '5s'
}
```
After:
```
  33.970 ±(99.9%) 1.773 ms/op [Average]
  (min, avg, max) = (31.405, 33.970, 37.302), stdev = 2.367
  CI (99.9%): [32.197, 35.743] (assumes normal distribution)
```
Before:
```
  34.882 ±(99.9%) 1.923 ms/op [Average]
  (min, avg, max) = (31.191, 34.882, 37.406), stdev = 2.567
  CI (99.9%): [32.959, 36.805] (assumes normal distribution)
```