### PR TITLE
support opengauss "on duplicate key update nothing" grammar

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/insert/ConflictActionType.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/ConflictActionType.java
@@ -10,9 +10,7 @@
 package net.sf.jsqlparser.statement.insert;
 
 public enum ConflictActionType {
-    NOTHING,
-    DO_NOTHING,
-    DO_UPDATE;
+    NOTHING, DO_NOTHING, DO_UPDATE;
 
     public static ConflictActionType from(String type) {
         return Enum.valueOf(ConflictActionType.class, type.toUpperCase());

--- a/src/main/java/net/sf/jsqlparser/statement/insert/ConflictActionType.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/ConflictActionType.java
@@ -10,7 +10,9 @@
 package net.sf.jsqlparser.statement.insert;
 
 public enum ConflictActionType {
-    DO_NOTHING, DO_UPDATE;
+    NOTHING,
+    DO_NOTHING,
+    DO_UPDATE;
 
     public static ConflictActionType from(String type) {
         return Enum.valueOf(ConflictActionType.class, type.toUpperCase());

--- a/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
@@ -167,7 +167,8 @@ public class Insert implements Statement {
 
     @Deprecated
     public boolean isUseDuplicate() {
-        return duplicateAction != null && duplicateAction.getUpdateSets() != null && !duplicateAction.getUpdateSets().isEmpty();
+        return duplicateAction != null && duplicateAction.getUpdateSets() != null
+                && !duplicateAction.getUpdateSets().isEmpty();
     }
 
     public InsertModifierPriority getModifierPriority() {
@@ -273,7 +274,7 @@ public class Insert implements Statement {
         StringBuilder sql = new StringBuilder();
         if (withItemsList != null && !withItemsList.isEmpty()) {
             sql.append("WITH ");
-            for (Iterator<WithItem<?>> iter = withItemsList.iterator(); iter.hasNext(); ) {
+            for (Iterator<WithItem<?>> iter = withItemsList.iterator(); iter.hasNext();) {
                 WithItem<?> withItem = iter.next();
                 sql.append(withItem);
                 if (iter.hasNext()) {
@@ -397,7 +398,8 @@ public class Insert implements Statement {
     }
 
     public Insert addColumns(Collection<Column> columns) {
-        ExpressionList<Column> collection = Optional.ofNullable(getColumns()).orElseGet(ExpressionList::new);
+        ExpressionList<Column> collection =
+                Optional.ofNullable(getColumns()).orElseGet(ExpressionList::new);
         collection.addAll(columns);
         return this.withColumns(collection);
     }

--- a/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
@@ -18,7 +18,11 @@ import net.sf.jsqlparser.statement.OutputClause;
 import net.sf.jsqlparser.statement.ReturningClause;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
-import net.sf.jsqlparser.statement.select.*;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SetOperationList;
+import net.sf.jsqlparser.statement.select.Values;
+import net.sf.jsqlparser.statement.select.WithItem;
 import net.sf.jsqlparser.statement.update.UpdateSet;
 
 import java.util.*;

--- a/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
@@ -25,7 +25,11 @@ import net.sf.jsqlparser.statement.select.Values;
 import net.sf.jsqlparser.statement.select.WithItem;
 import net.sf.jsqlparser.statement.update.UpdateSet;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
 
 @SuppressWarnings({"PMD.CyclomaticComplexity"})
 public class Insert implements Statement {

--- a/src/main/java/net/sf/jsqlparser/statement/insert/InsertDuplicateAction.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/InsertDuplicateAction.java
@@ -1,0 +1,117 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2025 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.insert;
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.update.UpdateSet;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * on duplicate key is one of:
+ *
+ * ON DUPLICATE KEY UPDATE NOTHING ON DUPLICATE KEY UPDATE { column_name = { expression | DEFAULT } | ( column_name [, ...] ) = [ ROW ] ( { expression | DEFAULT
+ * } [, ...] ) | ( column_name [, ...] ) = ( sub-SELECT ) } [, ...] [ WHERE condition ]
+ *
+ * @author zhangconan
+ */
+public class InsertDuplicateAction implements Serializable {
+
+    ConflictActionType conflictActionType;
+    Expression whereExpression;
+    private List<UpdateSet> updateSets;
+
+    public InsertDuplicateAction(ConflictActionType conflictActionType) {
+        this.conflictActionType = Objects.requireNonNull(conflictActionType, "The Conflict Action Type is mandatory and must not be Null.");
+    }
+
+    public List<UpdateSet> getUpdateSets() {
+        return updateSets;
+    }
+
+    public void setUpdateSets(List<UpdateSet> updateSets) {
+        this.updateSets = updateSets;
+    }
+
+    public InsertDuplicateAction withUpdateSets(List<UpdateSet> updateSets) {
+        this.setUpdateSets(updateSets);
+        return this;
+    }
+
+    public ConflictActionType getConflictActionType() {
+        return conflictActionType;
+    }
+
+    public void setConflictActionType(ConflictActionType conflictActionType) {
+        this.conflictActionType = Objects.requireNonNull(conflictActionType, "The Conflict Action Type is mandatory and must not be Null.");
+    }
+
+    public InsertDuplicateAction withConflictActionType(ConflictActionType conflictActionType) {
+        setConflictActionType(conflictActionType);
+        return this;
+    }
+
+    public InsertDuplicateAction addUpdateSet(Column column, Expression expression) {
+        return this.addUpdateSet(new UpdateSet());
+    }
+
+    public InsertDuplicateAction addUpdateSet(UpdateSet updateSet) {
+        if (updateSets == null) {
+            updateSets = new ArrayList<>();
+        }
+        this.updateSets.add(updateSet);
+        return this;
+    }
+
+    public InsertDuplicateAction withUpdateSets(Collection<UpdateSet> updateSets) {
+        this.setUpdateSets(new ArrayList<>(updateSets));
+        return this;
+    }
+
+    public Expression getWhereExpression() {
+        return whereExpression;
+    }
+
+    public void setWhereExpression(Expression whereExpression) {
+        this.whereExpression = whereExpression;
+    }
+
+    public InsertDuplicateAction withWhereExpression(Expression whereExpression) {
+        setWhereExpression(whereExpression);
+        return this;
+    }
+
+    @SuppressWarnings("PMD.SwitchStmtsShouldHaveDefault")
+    public StringBuilder appendTo(StringBuilder builder) {
+        switch (conflictActionType) {
+            case NOTHING:
+                builder.append(" NOTHING ");
+                break;
+            default:
+                UpdateSet.appendUpdateSetsTo(builder, updateSets);
+
+                if (whereExpression != null) {
+                    builder.append(" WHERE ").append(whereExpression);
+                }
+                break;
+        }
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return appendTo(new StringBuilder()).toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/insert/InsertDuplicateAction.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/InsertDuplicateAction.java
@@ -22,8 +22,9 @@ import java.util.Objects;
 /**
  * on duplicate key is one of:
  *
- * ON DUPLICATE KEY UPDATE NOTHING ON DUPLICATE KEY UPDATE { column_name = { expression | DEFAULT } | ( column_name [, ...] ) = [ ROW ] ( { expression | DEFAULT
- * } [, ...] ) | ( column_name [, ...] ) = ( sub-SELECT ) } [, ...] [ WHERE condition ]
+ * ON DUPLICATE KEY UPDATE NOTHING ON DUPLICATE KEY UPDATE { column_name = { expression | DEFAULT }
+ * | ( column_name [, ...] ) = [ ROW ] ( { expression | DEFAULT } [, ...] ) | ( column_name [, ...]
+ * ) = ( sub-SELECT ) } [, ...] [ WHERE condition ]
  *
  * @author zhangconan
  */
@@ -34,7 +35,8 @@ public class InsertDuplicateAction implements Serializable {
     private List<UpdateSet> updateSets;
 
     public InsertDuplicateAction(ConflictActionType conflictActionType) {
-        this.conflictActionType = Objects.requireNonNull(conflictActionType, "The Conflict Action Type is mandatory and must not be Null.");
+        this.conflictActionType = Objects.requireNonNull(conflictActionType,
+                "The Conflict Action Type is mandatory and must not be Null.");
     }
 
     public List<UpdateSet> getUpdateSets() {
@@ -55,7 +57,8 @@ public class InsertDuplicateAction implements Serializable {
     }
 
     public void setConflictActionType(ConflictActionType conflictActionType) {
-        this.conflictActionType = Objects.requireNonNull(conflictActionType, "The Conflict Action Type is mandatory and must not be Null.");
+        this.conflictActionType = Objects.requireNonNull(conflictActionType,
+                "The Conflict Action Type is mandatory and must not be Null.");
     }
 
     public InsertDuplicateAction withConflictActionType(ConflictActionType conflictActionType) {

--- a/src/main/java/net/sf/jsqlparser/statement/upsert/Upsert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/upsert/Upsert.java
@@ -226,7 +226,8 @@ public class Upsert implements Statement {
     }
 
     public Upsert addColumns(Collection<? extends Column> columns) {
-        ExpressionList<Column> collection = Optional.ofNullable(getColumns()).orElseGet(ExpressionList::new);
+        ExpressionList<Column> collection =
+                Optional.ofNullable(getColumns()).orElseGet(ExpressionList::new);
         collection.addAll(columns);
         return this.withColumns(collection);
     }

--- a/src/main/java/net/sf/jsqlparser/statement/upsert/Upsert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/upsert/Upsert.java
@@ -14,6 +14,8 @@ import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
+import net.sf.jsqlparser.statement.insert.ConflictActionType;
+import net.sf.jsqlparser.statement.insert.InsertDuplicateAction;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.select.SetOperationList;
@@ -35,6 +37,7 @@ public class Upsert implements Statement {
     private List<UpdateSet> duplicateUpdateSets;
     private UpsertType upsertType = UpsertType.UPSERT;
     private boolean isUsingInto;
+    private InsertDuplicateAction duplicateAction;
 
     public List<UpdateSet> getUpdateSets() {
         return updateSets;
@@ -46,11 +49,20 @@ public class Upsert implements Statement {
     }
 
     public List<UpdateSet> getDuplicateUpdateSets() {
+        if (duplicateAction != null) {
+            return duplicateAction.getUpdateSets();
+        }
         return duplicateUpdateSets;
     }
 
     public Upsert setDuplicateUpdateSets(List<UpdateSet> duplicateUpdateSets) {
-        this.duplicateUpdateSets = duplicateUpdateSets;
+        if (duplicateAction != null) {
+            duplicateAction.setConflictActionType(ConflictActionType.DO_UPDATE);
+            duplicateAction.setUpdateSets(duplicateUpdateSets);
+        } else {
+            duplicateAction = new InsertDuplicateAction(ConflictActionType.DO_UPDATE);
+            duplicateAction.setUpdateSets(duplicateUpdateSets);
+        }
         return this;
     }
 
@@ -181,9 +193,9 @@ public class Upsert implements Statement {
             }
         }
 
-        if (duplicateUpdateSets != null) {
+        if (duplicateAction != null) {
             sb.append(" ON DUPLICATE KEY UPDATE ");
-            UpdateSet.appendUpdateSetsTo(sb, duplicateUpdateSets);
+            duplicateAction.appendTo(sb);
         }
 
         return sb.toString();
@@ -214,9 +226,16 @@ public class Upsert implements Statement {
     }
 
     public Upsert addColumns(Collection<? extends Column> columns) {
-        ExpressionList<Column> collection =
-                Optional.ofNullable(getColumns()).orElseGet(ExpressionList::new);
+        ExpressionList<Column> collection = Optional.ofNullable(getColumns()).orElseGet(ExpressionList::new);
         collection.addAll(columns);
         return this.withColumns(collection);
+    }
+
+    public InsertDuplicateAction getDuplicateAction() {
+        return duplicateAction;
+    }
+
+    public void setDuplicateAction(InsertDuplicateAction duplicateAction) {
+        this.duplicateAction = duplicateAction;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/InsertDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/InsertDeParser.java
@@ -29,18 +29,21 @@ public class InsertDeParser extends AbstractDeParser<Insert> {
         super(new StringBuilder());
     }
 
-    public InsertDeParser(ExpressionVisitor<StringBuilder> expressionVisitor, SelectVisitor<StringBuilder> selectVisitor, StringBuilder buffer) {
+    public InsertDeParser(ExpressionVisitor<StringBuilder> expressionVisitor,
+            SelectVisitor<StringBuilder> selectVisitor, StringBuilder buffer) {
         super(buffer);
         this.expressionVisitor = expressionVisitor;
         this.selectVisitor = selectVisitor;
     }
 
     @Override
-    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.ExcessiveMethodLength", "PMD.NPathComplexity"})
+    @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.ExcessiveMethodLength",
+            "PMD.NPathComplexity"})
     public void deParse(Insert insert) {
         if (insert.getWithItemsList() != null && !insert.getWithItemsList().isEmpty()) {
             builder.append("WITH ");
-            for (Iterator<WithItem<?>> iter = insert.getWithItemsList().iterator(); iter.hasNext(); ) {
+            for (Iterator<WithItem<?>> iter = insert.getWithItemsList().iterator(); iter
+                    .hasNext();) {
                 WithItem<?> withItem = iter.next();
                 withItem.accept(this.selectVisitor, null);
                 if (iter.hasNext()) {
@@ -77,7 +80,7 @@ public class InsertDeParser extends AbstractDeParser<Insert> {
 
         if (insert.getColumns() != null) {
             builder.append(" (");
-            for (Iterator<Column> iter = insert.getColumns().iterator(); iter.hasNext(); ) {
+            for (Iterator<Column> iter = insert.getColumns().iterator(); iter.hasNext();) {
                 Column column = iter.next();
                 builder.append(column.getColumnName());
                 if (iter.hasNext()) {
@@ -114,7 +117,8 @@ public class InsertDeParser extends AbstractDeParser<Insert> {
 
         if (insert.getDuplicateAction() != null) {
             builder.append(" ON DUPLICATE KEY UPDATE ");
-            if (ConflictActionType.DO_UPDATE.equals(insert.getDuplicateAction().getConflictActionType())) {
+            if (ConflictActionType.DO_UPDATE
+                    .equals(insert.getDuplicateAction().getConflictActionType())) {
                 deparseUpdateSets(insert.getDuplicateUpdateSets(), builder, expressionVisitor);
             } else {
                 insert.getDuplicateAction().appendTo(builder);

--- a/src/main/java/net/sf/jsqlparser/util/deparser/UpsertDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/UpsertDeParser.java
@@ -10,6 +10,7 @@
 package net.sf.jsqlparser.util.deparser;
 
 import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.statement.insert.ConflictActionType;
 import net.sf.jsqlparser.statement.select.SelectVisitor;
 import net.sf.jsqlparser.statement.upsert.Upsert;
 
@@ -19,8 +20,7 @@ public class UpsertDeParser extends AbstractDeParser<Upsert> {
     private ExpressionDeParser expressionVisitor;
     private SelectDeParser selectVisitor;
 
-    public UpsertDeParser(ExpressionDeParser expressionVisitor, SelectDeParser selectVisitor,
-            StringBuilder buffer) {
+    public UpsertDeParser(ExpressionDeParser expressionVisitor, SelectDeParser selectVisitor, StringBuilder buffer) {
         super(buffer);
         this.expressionVisitor = expressionVisitor;
         this.expressionVisitor.setSelectVisitor(selectVisitor);
@@ -78,9 +78,13 @@ public class UpsertDeParser extends AbstractDeParser<Upsert> {
                 upsert.getSelect().accept((SelectVisitor<StringBuilder>) selectVisitor, null);
             }
 
-            if (upsert.getDuplicateUpdateSets() != null) {
+            if (upsert.getDuplicateAction() != null) {
                 builder.append(" ON DUPLICATE KEY UPDATE ");
-                deparseUpdateSets(upsert.getDuplicateUpdateSets(), builder, expressionVisitor);
+                if (ConflictActionType.DO_UPDATE.equals(upsert.getDuplicateAction().getConflictActionType())) {
+                    deparseUpdateSets(upsert.getDuplicateUpdateSets(), builder, expressionVisitor);
+                } else {
+                    upsert.getDuplicateAction().appendTo(builder);
+                }
             }
         }
     }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/UpsertDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/UpsertDeParser.java
@@ -20,7 +20,8 @@ public class UpsertDeParser extends AbstractDeParser<Upsert> {
     private ExpressionDeParser expressionVisitor;
     private SelectDeParser selectVisitor;
 
-    public UpsertDeParser(ExpressionDeParser expressionVisitor, SelectDeParser selectVisitor, StringBuilder buffer) {
+    public UpsertDeParser(ExpressionDeParser expressionVisitor, SelectDeParser selectVisitor,
+            StringBuilder buffer) {
         super(buffer);
         this.expressionVisitor = expressionVisitor;
         this.expressionVisitor.setSelectVisitor(selectVisitor);
@@ -80,7 +81,8 @@ public class UpsertDeParser extends AbstractDeParser<Upsert> {
 
             if (upsert.getDuplicateAction() != null) {
                 builder.append(" ON DUPLICATE KEY UPDATE ");
-                if (ConflictActionType.DO_UPDATE.equals(upsert.getDuplicateAction().getConflictActionType())) {
+                if (ConflictActionType.DO_UPDATE
+                        .equals(upsert.getDuplicateAction().getConflictActionType())) {
                     deparseUpdateSets(upsert.getDuplicateUpdateSets(), builder, expressionVisitor);
                 } else {
                     upsert.getDuplicateAction().appendTo(builder);

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2742,6 +2742,8 @@ Insert Insert():
 
     InsertConflictTarget conflictTarget = null;
     InsertConflictAction conflictAction = null;
+
+    InsertDuplicateAction duplicateAction = null;
 }
 {
     <K_INSERT> { insert.setOracleHint(getOracleHint()); }
@@ -2780,7 +2782,7 @@ Insert Insert():
     )
 
     [ LOOKAHEAD(2) <K_ON> <K_DUPLICATE> <K_KEY> <K_UPDATE>
-         duplicateUpdateSets = UpdateSets() { insert.withDuplicateUpdateSets(duplicateUpdateSets); }
+                 duplicateAction = InsertDuplicateAction() { insert.setDuplicateAction(duplicateAction); }
     ]
 
     [
@@ -2860,6 +2862,30 @@ InsertConflictAction InsertConflictAction():
                 .withWhereExpression(whereExpression); }
 }
 
+InsertDuplicateAction InsertDuplicateAction():
+{
+    InsertDuplicateAction duplicateAction;
+    Expression whereExpression = null;
+    List<UpdateSet> updateSets;
+}
+{
+    (
+        LOOKAHEAD(2) (
+            <K_NOTHING> { duplicateAction = new InsertDuplicateAction( ConflictActionType.NOTHING ); }
+        )
+        |
+        (
+            { duplicateAction = new InsertDuplicateAction( ConflictActionType.DO_UPDATE ); }
+            updateSets = UpdateSets() { duplicateAction.setUpdateSets(updateSets); }
+            [ whereExpression = WhereClause() ]
+        )
+    )
+
+    { return duplicateAction
+                .withWhereExpression(whereExpression); }
+}
+
+
 OutputClause OutputClause():
 {
     List<SelectItem<?>> selectItemList = null;
@@ -2895,6 +2921,7 @@ Upsert Upsert():
 
     Select select = null;
     List<UpdateSet> duplicateUpdateSets;
+    InsertDuplicateAction duplicateAction = null;
     Token tk = null;
 }
 {
@@ -2925,7 +2952,7 @@ Upsert Upsert():
 
     [
         <K_ON> <K_DUPLICATE> <K_KEY> <K_UPDATE>
-        duplicateUpdateSets = UpdateSets() { upsert.setDuplicateUpdateSets(duplicateUpdateSets); }
+        duplicateAction = InsertDuplicateAction() { upsert.setDuplicateAction(duplicateAction); }
     ]
 
     {

--- a/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
@@ -916,5 +916,9 @@ public class InsertTest {
         TestUtils.assertStatementCanBeDeparsedAs(
                 insert, "INSERT INTO test VALUES ('A', 'B')");
     }
-
+    @Test
+    public void testSimpleDuplicateInsert() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO example (num, name, address, tel) VALUES (1, 'name', 'test ', '1234-1234') ON DUPLICATE KEY update NOTHING");
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
@@ -916,6 +916,7 @@ public class InsertTest {
         TestUtils.assertStatementCanBeDeparsedAs(
                 insert, "INSERT INTO test VALUES ('A', 'B')");
     }
+
     @Test
     public void testSimpleDuplicateInsert() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed(

--- a/src/test/java/net/sf/jsqlparser/statement/upsert/UpsertTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/upsert/UpsertTest.java
@@ -107,11 +107,14 @@ public class UpsertTest {
         assertSqlCanBeParsedAndDeparsed("UPSERT INTO mytable (col1, col2) VALUES (a, b), (d, e)",
                 true);
     }
+
     @Test
     public void testUpsertMultiRowValueDoNothing() throws JSQLParserException {
-        assertSqlCanBeParsedAndDeparsed("UPSERT INTO mytable (col1, col2) VALUES (a, b) ON DUPLICATE KEY UPDATE nothing",
+        assertSqlCanBeParsedAndDeparsed(
+                "UPSERT INTO mytable (col1, col2) VALUES (a, b) ON DUPLICATE KEY UPDATE nothing",
                 true);
     }
+
     @Test
     @Disabled
     /* not the job of the parser to validate this, it even may be valid eventually */

--- a/src/test/java/net/sf/jsqlparser/statement/upsert/UpsertTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/upsert/UpsertTest.java
@@ -107,7 +107,11 @@ public class UpsertTest {
         assertSqlCanBeParsedAndDeparsed("UPSERT INTO mytable (col1, col2) VALUES (a, b), (d, e)",
                 true);
     }
-
+    @Test
+    public void testUpsertMultiRowValueDoNothing() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("UPSERT INTO mytable (col1, col2) VALUES (a, b) ON DUPLICATE KEY UPDATE nothing",
+                true);
+    }
     @Test
     @Disabled
     /* not the job of the parser to validate this, it even may be valid eventually */

--- a/src/test/java/net/sf/jsqlparser/util/deparser/StatementDeParserTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/deparser/StatementDeParserTest.java
@@ -129,7 +129,7 @@ public class StatementDeParserTest {
         then(withItem2).should().accept((SelectVisitor<?>) selectDeParser, null);
         then(select).should().accept((SelectVisitor<StringBuilder>) selectDeParser, null);
         then(duplicateUpdateExpression1).should().accept(expressionDeParser, null);
-        then(duplicateUpdateExpression1).should().accept(expressionDeParser, null);
+        then(duplicateUpdateExpression2).should().accept(expressionDeParser, null);
     }
 
     // @Test


### PR DESCRIPTION
Add a new feature to support opengauss "on duplicate key update nothing" syntax. I have executed mvn clean package locally, and all code format checks and unit tests have passed.