### PR TITLE
Fix[2306] - Adds support for Trino UDF

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/ParserKeywordsUtils.java
+++ b/src/main/java/net/sf/jsqlparser/parser/ParserKeywordsUtils.java
@@ -124,6 +124,7 @@ public class ParserKeywordsUtils {
             {"PRIOR", RESTRICTED_ALIAS},
             {"PROCEDURE", RESTRICTED_ALIAS},
             {"PUBLIC", RESTRICTED_ALIAS},
+            {"RETURNS", RESTRICTED_JSQLPARSER},
             {"RETURNING", RESTRICTED_JSQLPARSER},
             {"RIGHT", RESTRICTED_SQL2016},
             {"SAMPLE", RESTRICTED_ALIAS},

--- a/src/main/java/net/sf/jsqlparser/statement/select/WithFunctionDeclaration.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/WithFunctionDeclaration.java
@@ -1,0 +1,107 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2025 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.select;
+
+import net.sf.jsqlparser.expression.Expression;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class WithFunctionDeclaration implements Serializable {
+    private String functionName;
+    private List<WithFunctionParameter> parameters;
+    private String returnType;
+    private Expression returnExpression;
+
+    public WithFunctionDeclaration() {
+    }
+
+    public WithFunctionDeclaration(String functionName, List<WithFunctionParameter> parameters, String returnType, Expression returnExpression) {
+        this.functionName = functionName;
+        this.parameters = parameters;
+        this.returnType = returnType;
+        this.returnExpression = returnExpression;
+    }
+
+    public String getFunctionName() {
+        return functionName;
+    }
+
+    public void setFunctionName(String functionName) {
+        this.functionName = functionName;
+    }
+
+    public List<WithFunctionParameter> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(List<WithFunctionParameter> parameters) {
+        this.parameters = parameters;
+    }
+
+    public String getReturnType() {
+        return returnType;
+    }
+
+    public void setReturnType(String returnType) {
+        this.returnType = returnType;
+    }
+
+    public Expression getReturnExpression() {
+        return returnExpression;
+    }
+
+    public void setReturnExpression(Expression returnExpression) {
+        this.returnExpression = returnExpression;
+    }
+
+    public WithFunctionDeclaration withFunctionName(String functionName) {
+        this.setFunctionName(functionName);
+        return this;
+    }
+
+    public WithFunctionDeclaration withParameters(List<WithFunctionParameter> parameters) {
+        this.setParameters(parameters);
+        return this;
+    }
+
+    public WithFunctionDeclaration withReturnType(String returnType) {
+        this.setReturnType(returnType);
+        return this;
+    }
+
+    public WithFunctionDeclaration withReturnExpression(Expression returnExpression) {
+        this.setReturnExpression(returnExpression);
+        return this;
+    }
+
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder
+                .append("FUNCTION ")
+                .append(functionName)
+                .append("(");
+        for (int i = 0; parameters != null && i < parameters.size(); i++) {
+            if (i > 0) {
+                builder.append(", ");
+            }
+            parameters.get(i).appendTo(builder);
+        }
+        return builder
+                .append(") RETURNS ")
+                .append(returnType)
+                .append(" RETURN ")
+                .append(returnExpression);
+    }
+
+    @Override
+    public String toString() {
+        return appendTo(new StringBuilder()).toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/select/WithFunctionDeclaration.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/WithFunctionDeclaration.java
@@ -20,10 +20,10 @@ public class WithFunctionDeclaration implements Serializable {
     private String returnType;
     private Expression returnExpression;
 
-    public WithFunctionDeclaration() {
-    }
+    public WithFunctionDeclaration() {}
 
-    public WithFunctionDeclaration(String functionName, List<WithFunctionParameter> parameters, String returnType, Expression returnExpression) {
+    public WithFunctionDeclaration(String functionName, List<WithFunctionParameter> parameters,
+            String returnType, Expression returnExpression) {
         this.functionName = functionName;
         this.parameters = parameters;
         this.returnType = returnType;

--- a/src/main/java/net/sf/jsqlparser/statement/select/WithFunctionParameter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/WithFunctionParameter.java
@@ -15,8 +15,7 @@ public class WithFunctionParameter implements Serializable {
     private String name;
     private String type; // e.g., INT
 
-    public WithFunctionParameter() {
-    }
+    public WithFunctionParameter() {}
 
     public WithFunctionParameter(String name, String type) {
         this.name = name;

--- a/src/main/java/net/sf/jsqlparser/statement/select/WithFunctionParameter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/WithFunctionParameter.java
@@ -1,0 +1,60 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2025 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.select;
+
+import java.io.Serializable;
+
+public class WithFunctionParameter implements Serializable {
+    private String name;
+    private String type; // e.g., INT
+
+    public WithFunctionParameter() {
+    }
+
+    public WithFunctionParameter(String name, String type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public WithFunctionParameter withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public WithFunctionParameter withType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public StringBuilder appendTo(StringBuilder builder) {
+        return builder.append(name).append(" ").append(type);
+    }
+
+    @Override
+    public String toString() {
+        return appendTo(new StringBuilder()).toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/select/WithItem.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/WithItem.java
@@ -27,6 +27,7 @@ public class WithItem<K extends ParenthesedStatement> implements Serializable {
     private K statement;
     private Alias alias;
     private List<SelectItem<?>> withItemList;
+    private WithFunctionDeclaration withFunctionDeclaration;
     private boolean recursive = false;
     private boolean usingNot = false;
     private boolean materialized = false;
@@ -121,28 +122,45 @@ public class WithItem<K extends ParenthesedStatement> implements Serializable {
         this.withItemList = withItemList;
     }
 
+    public WithFunctionDeclaration getWithFunctionDeclaration() {
+        return withFunctionDeclaration;
+    }
+
+    public void setWithFunctionDeclaration(WithFunctionDeclaration withFunctionDeclaration) {
+        this.withFunctionDeclaration = withFunctionDeclaration;
+    }
+
+    public WithItem<K> withWithFunctionDeclaration(WithFunctionDeclaration withFunctionDeclaration) {
+        this.setWithFunctionDeclaration(withFunctionDeclaration);
+        return this;
+    }
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        builder.append(recursive ? "RECURSIVE " : "");
-        if (alias != null) {
-            builder.append(alias.getName());
-        }
-        if (withItemList != null) {
-            builder.append("(");
-            int size = withItemList.size();
-            for (int i = 0; i < size; i++) {
-                builder.append(withItemList.get(i)).append(i < size - 1 ? "," : "");
+        if (withFunctionDeclaration != null) {
+            builder.append(withFunctionDeclaration);
+        } else {
+            builder.append(recursive ? "RECURSIVE " : "");
+            if (alias != null) {
+                builder.append(alias.getName());
             }
-            builder.append(")");
+            if (withItemList != null) {
+                builder.append("(");
+                int size = withItemList.size();
+                for (int i = 0; i < size; i++) {
+                    builder.append(withItemList.get(i)).append(i < size - 1 ? "," : "");
+                }
+                builder.append(")");
+            }
+            builder.append(" AS ");
+            if (materialized) {
+                builder.append(usingNot
+                        ? "NOT MATERIALIZED "
+                        : "MATERIALIZED ");
+            }
+            builder.append(statement);
         }
-        builder.append(" AS ");
-        if (materialized) {
-            builder.append(usingNot
-                    ? "NOT MATERIALIZED "
-                    : "MATERIALIZED ");
-        }
-        builder.append(statement);
         return builder.toString();
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/select/WithItem.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/WithItem.java
@@ -130,7 +130,8 @@ public class WithItem<K extends ParenthesedStatement> implements Serializable {
         this.withFunctionDeclaration = withFunctionDeclaration;
     }
 
-    public WithItem<K> withWithFunctionDeclaration(WithFunctionDeclaration withFunctionDeclaration) {
+    public WithItem<K> withWithFunctionDeclaration(
+            WithFunctionDeclaration withFunctionDeclaration) {
         this.setWithFunctionDeclaration(withFunctionDeclaration);
         return this;
     }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -717,23 +717,27 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
 
     @Override
     public <S> StringBuilder visit(WithItem<?> withItem, S context) {
-        if (withItem.isRecursive()) {
-            builder.append("RECURSIVE ");
+        if (withItem.getWithFunctionDeclaration() == null) {
+            if (withItem.isRecursive()) {
+                builder.append("RECURSIVE ");
+            }
+            builder.append(withItem.getAlias().getName());
+            if (withItem.getWithItemList() != null) {
+                builder.append(" ")
+                        .append(PlainSelect.getStringList(withItem.getWithItemList(), true, true));
+            }
+            builder.append(" AS ");
+            if (withItem.isMaterialized()) {
+                builder.append(withItem.isUsingNot()
+                        ? "NOT MATERIALIZED "
+                        : "MATERIALIZED ");
+            }
+            StatementDeParser statementDeParser =
+                    new StatementDeParser((ExpressionDeParser) expressionVisitor, this, builder);
+            statementDeParser.deParse(withItem.getParenthesedStatement());
+        } else {
+            builder.append(withItem.getWithFunctionDeclaration().toString());
         }
-        builder.append(withItem.getAlias().getName());
-        if (withItem.getWithItemList() != null) {
-            builder.append(" ")
-                    .append(PlainSelect.getStringList(withItem.getWithItemList(), true, true));
-        }
-        builder.append(" AS ");
-        if (withItem.isMaterialized()) {
-            builder.append(withItem.isUsingNot()
-                    ? "NOT MATERIALIZED "
-                    : "MATERIALIZED ");
-        }
-        StatementDeParser statementDeParser =
-                new StatementDeParser((ExpressionDeParser) expressionVisitor, this, builder);
-        statementDeParser.deParse(withItem.getParenthesedStatement());
         return builder;
     }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -570,6 +570,7 @@ TOKEN: /* SQL Keywords. prefixed with K_ to avoid name clashes */
 |   <K_RESTRICT: "RESTRICT">
 |   <K_RESTRICTED: "RESTRICTED">
 |   <K_RETURN: "RETURN">
+|   <K_RETURNS: "RETURNS">
 |   <K_RETURNING: "RETURNING">
 |   <K_RIGHT:"RIGHT">
 |   <K_ROLLBACK:"ROLLBACK">
@@ -4336,31 +4337,79 @@ WithItem<?> WithItem() #WithItem:
     boolean recursive = false;
     boolean materialized = false;
     boolean usingNot = false;
-    String name;
+    String name = null;
     List<SelectItem<?>> selectItems = null;
-    ParenthesedStatement statement;
+    WithFunctionDeclaration withFunctionDeclaration = null;
+    ParenthesedStatement statement = null;
+    WithItem<?> withItem;
 }
 {
-     [ LOOKAHEAD(2) <K_RECURSIVE>  { recursive = true; } ]
-     name=RelObjectName()
-     [ "(" selectItems=SelectItemsList() ")" ]
-     <K_AS>
-     [ LOOKAHEAD(2) [ <K_NOT> { usingNot = true; } ] <K_MATERIALIZED>  { materialized = true; } ]
-     (
-         LOOKAHEAD(2) statement = ParenthesedSelect()
+    (
+         LOOKAHEAD(2) <K_FUNCTION>
+         withFunctionDeclaration = WithFunctionDeclaration()
+         {
+             withItem = new WithItem().withWithFunctionDeclaration(withFunctionDeclaration);
+         }
          |
-         LOOKAHEAD(2) statement = ParenthesedInsert()
-         |
-         LOOKAHEAD(2) statement = ParenthesedUpdate()
-         |
-         LOOKAHEAD(2) statement = ParenthesedDelete()
+         (
+             [ LOOKAHEAD(2) <K_RECURSIVE>  { recursive = true; } ]
+             name=RelObjectName()
+             [ "(" selectItems=SelectItemsList() ")" ]
+             <K_AS>
+             [ LOOKAHEAD(2) [ <K_NOT> { usingNot = true; } ] <K_MATERIALIZED>  { materialized = true; } ]
+             (
+                 LOOKAHEAD(2) statement = ParenthesedSelect()
+                 |
+                 LOOKAHEAD(2) statement = ParenthesedInsert()
+                 |
+                 LOOKAHEAD(2) statement = ParenthesedUpdate()
+                 |
+                 LOOKAHEAD(2) statement = ParenthesedDelete()
+             )
+             {
+                withItem = new WithItem(statement, new Alias(name, false))
+                    .withRecursive(recursive, usingNot, materialized)
+                    .withWithItemList(selectItems);
+             }
+         )
      )
      {
-        WithItem<?> withItem = new WithItem(statement, new Alias(name, false));
-        return withItem
-            .withRecursive(recursive, usingNot, materialized)
-            .withWithItemList(selectItems);
+     return withItem;
      }
+}
+
+WithFunctionDeclaration WithFunctionDeclaration() #WithFunctionDeclaration:
+{
+     String functionName;
+     List<WithFunctionParameter> parameters = new ArrayList<WithFunctionParameter>();
+     String returnType;
+     Expression returnExpression;
+     WithFunctionParameter parameter;
+}
+{
+    functionName = RelObjectName()
+    "("
+        [ parameter=WithFunctionParameter() { parameters.add(parameter); }
+          ( "," parameter=WithFunctionParameter() { parameters.add(parameter); } )*
+        ]
+    ")"
+    <K_RETURNS> returnType = RelObjectName()
+    <K_RETURN> returnExpression = Expression()
+    {
+        return new WithFunctionDeclaration(functionName, parameters, returnType, returnExpression);
+    }
+}
+
+WithFunctionParameter WithFunctionParameter() #WithFunctionParameter:
+{
+     String name;
+     String type;
+}
+{
+    name = RelObjectName() type = RelObjectName()
+    {
+        return new WithFunctionParameter(name, type);
+    }
 }
 
 List<SelectItem<Column>> ColumnSelectItemsList():

--- a/src/test/java/net/sf/jsqlparser/statement/select/WithFunctionDeclarationTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/WithFunctionDeclarationTest.java
@@ -1,0 +1,92 @@
+package net.sf.jsqlparser.statement.select;
+
+import net.sf.jsqlparser.expression.Expression;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WithFunctionDeclarationTest {
+    static final String FUNCTION_NAME = "func1";
+    static final String RETURN_TYPE = "integer";
+
+    @Mock
+    Expression expression;
+    @Mock
+    WithFunctionParameter withFunctionParameter1;
+    @Mock
+    WithFunctionParameter withFunctionParameter2;
+
+    WithFunctionDeclaration withFunctionDeclaration;
+
+    @Test
+    void fullConstructorAndGetters() {
+        withFunctionDeclaration = new WithFunctionDeclaration(FUNCTION_NAME,
+                List.of(withFunctionParameter1, withFunctionParameter2), RETURN_TYPE, expression);
+        assertThat(withFunctionDeclaration.getFunctionName()).isEqualTo(FUNCTION_NAME);
+        assertThat(withFunctionDeclaration.getParameters())
+                .isEqualTo(List.of(withFunctionParameter1, withFunctionParameter2));
+        assertThat(withFunctionDeclaration.getReturnType()).isEqualTo(RETURN_TYPE);
+        assertThat(withFunctionDeclaration.getReturnExpression()).isEqualTo(expression);
+    }
+
+    @Test
+    void defaultConstructorAndSetters() {
+        withFunctionDeclaration = new WithFunctionDeclaration();
+        withFunctionDeclaration.setFunctionName(FUNCTION_NAME);
+        withFunctionDeclaration.setParameters(List.of(withFunctionParameter1, withFunctionParameter2));
+        withFunctionDeclaration.setReturnType(RETURN_TYPE);
+        withFunctionDeclaration.setReturnExpression(expression);
+        assertThat(withFunctionDeclaration.getFunctionName()).isEqualTo(FUNCTION_NAME);
+        assertThat(withFunctionDeclaration.getParameters())
+                .isEqualTo(List.of(withFunctionParameter1, withFunctionParameter2));
+        assertThat(withFunctionDeclaration.getReturnType()).isEqualTo(RETURN_TYPE);
+        assertThat(withFunctionDeclaration.getReturnExpression()).isEqualTo(expression);
+    }
+
+    @Test
+    void defaultConstructorAndWithers() {
+        withFunctionDeclaration = new WithFunctionDeclaration()
+                .withFunctionName(FUNCTION_NAME)
+                .withParameters(List.of(withFunctionParameter1, withFunctionParameter2))
+                .withReturnType(RETURN_TYPE)
+                .withReturnExpression(expression);
+        assertThat(withFunctionDeclaration.getFunctionName()).isEqualTo(FUNCTION_NAME);
+        assertThat(withFunctionDeclaration.getParameters())
+                .isEqualTo(List.of(withFunctionParameter1, withFunctionParameter2));
+        assertThat(withFunctionDeclaration.getReturnType()).isEqualTo(RETURN_TYPE);
+        assertThat(withFunctionDeclaration.getReturnExpression()).isEqualTo(expression);
+    }
+
+    @Test
+    void toStringTestWithParameters() {
+        when(withFunctionParameter1.appendTo(any(StringBuilder.class))).thenAnswer(invocation -> {
+            StringBuilder builder = invocation.getArgument(0);
+            return builder.append("param1 bigint");
+        });
+        when(withFunctionParameter2.appendTo(any(StringBuilder.class))).thenAnswer(invocation -> {
+            StringBuilder builder = invocation.getArgument(0);
+            return builder.append("param2 double");
+        });
+        when(expression.toString()).thenReturn("1 + 1");
+        withFunctionDeclaration = new WithFunctionDeclaration(FUNCTION_NAME,
+                List.of(withFunctionParameter1, withFunctionParameter2), RETURN_TYPE, expression);
+
+        assertThat(withFunctionDeclaration.toString()).isEqualTo("FUNCTION func1(param1 bigint, param2 double) RETURNS integer RETURN 1 + 1");
+    }
+
+    @Test
+    void toStringTestWithNoParameters() {
+        when(expression.toString()).thenReturn("1 + 1");
+        withFunctionDeclaration = new WithFunctionDeclaration(FUNCTION_NAME, List.of(), RETURN_TYPE, expression);
+
+        assertThat(withFunctionDeclaration.toString()).isEqualTo("FUNCTION func1() RETURNS integer RETURN 1 + 1");
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/statement/select/WithFunctionDeclarationTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/WithFunctionDeclarationTest.java
@@ -41,7 +41,8 @@ class WithFunctionDeclarationTest {
     void defaultConstructorAndSetters() {
         withFunctionDeclaration = new WithFunctionDeclaration();
         withFunctionDeclaration.setFunctionName(FUNCTION_NAME);
-        withFunctionDeclaration.setParameters(List.of(withFunctionParameter1, withFunctionParameter2));
+        withFunctionDeclaration
+                .setParameters(List.of(withFunctionParameter1, withFunctionParameter2));
         withFunctionDeclaration.setReturnType(RETURN_TYPE);
         withFunctionDeclaration.setReturnExpression(expression);
         assertThat(withFunctionDeclaration.getFunctionName()).isEqualTo(FUNCTION_NAME);
@@ -79,14 +80,17 @@ class WithFunctionDeclarationTest {
         withFunctionDeclaration = new WithFunctionDeclaration(FUNCTION_NAME,
                 List.of(withFunctionParameter1, withFunctionParameter2), RETURN_TYPE, expression);
 
-        assertThat(withFunctionDeclaration.toString()).isEqualTo("FUNCTION func1(param1 bigint, param2 double) RETURNS integer RETURN 1 + 1");
+        assertThat(withFunctionDeclaration.toString()).isEqualTo(
+                "FUNCTION func1(param1 bigint, param2 double) RETURNS integer RETURN 1 + 1");
     }
 
     @Test
     void toStringTestWithNoParameters() {
         when(expression.toString()).thenReturn("1 + 1");
-        withFunctionDeclaration = new WithFunctionDeclaration(FUNCTION_NAME, List.of(), RETURN_TYPE, expression);
+        withFunctionDeclaration =
+                new WithFunctionDeclaration(FUNCTION_NAME, List.of(), RETURN_TYPE, expression);
 
-        assertThat(withFunctionDeclaration.toString()).isEqualTo("FUNCTION func1() RETURNS integer RETURN 1 + 1");
+        assertThat(withFunctionDeclaration.toString())
+                .isEqualTo("FUNCTION func1() RETURNS integer RETURN 1 + 1");
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/WithFunctionParameterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/WithFunctionParameterTest.java
@@ -1,0 +1,43 @@
+package net.sf.jsqlparser.statement.select;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class WithFunctionParameterTest {
+    static final String PARAMETER_NAME = "param1";
+    static final String PARAMETER_TYPE = "integer";
+
+    WithFunctionParameter withFunctionParameter;
+
+    @Test
+    void fullConstructorAndGetters() {
+        withFunctionParameter = new WithFunctionParameter(PARAMETER_NAME, PARAMETER_TYPE);
+        assertThat(withFunctionParameter.getName()).isEqualTo(PARAMETER_NAME);
+        assertThat(withFunctionParameter.getType()).isEqualTo(PARAMETER_TYPE);
+    }
+
+    @Test
+    void defaultConstructorAndSetters() {
+        withFunctionParameter = new WithFunctionParameter();
+        withFunctionParameter.setName(PARAMETER_NAME);
+        withFunctionParameter.setType(PARAMETER_TYPE);
+        assertThat(withFunctionParameter.getName()).isEqualTo(PARAMETER_NAME);
+        assertThat(withFunctionParameter.getType()).isEqualTo(PARAMETER_TYPE);
+    }
+
+    @Test
+    void defaultConstructorAndWithers() {
+        withFunctionParameter = new WithFunctionParameter()
+                .withName(PARAMETER_NAME)
+                .withType(PARAMETER_TYPE);
+        assertThat(withFunctionParameter.getName()).isEqualTo(PARAMETER_NAME);
+        assertThat(withFunctionParameter.getType()).isEqualTo(PARAMETER_TYPE);
+    }
+
+    @Test
+    void testToString() {
+        withFunctionParameter = new WithFunctionParameter(PARAMETER_NAME, PARAMETER_TYPE);
+        assertThat(withFunctionParameter.toString()).isEqualTo("param1 integer");
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/statement/select/WithItemTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/WithItemTest.java
@@ -12,6 +12,8 @@ package net.sf.jsqlparser.statement.select;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.test.TestUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class WithItemTest {
 
@@ -26,4 +28,23 @@ class WithItemTest {
         TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "WITH\n" +
+                    "  FUNCTION doubleup(x integer)\n" +
+                    "    RETURNS integer\n" +
+                    "    RETURN x * 2\n" +
+                    "SELECT doubleup(21);\n",
+            "WITH\n" +
+                    "  FUNCTION doubleup(x integer)\n" +
+                    "    RETURNS integer\n" +
+                    "    RETURN x * 2,\n" +
+                    "  FUNCTION doubleupplusone(x integer)\n" +
+                    "    RETURNS integer\n" +
+                    "    RETURN doubleup(x) + 1\n" +
+                    "SELECT doubleupplusone(21);"
+    })
+    void testWithFunction(String sqlStr) throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+    }
 }

--- a/src/test/resources/simple_parsing.txt
+++ b/src/test/resources/simple_parsing.txt
@@ -219,3 +219,27 @@ AND
   CAST(CAST((NOW() + INTERVAL '-1 day') AS date) AS timestamptz);
 
 SELECT DATE_TRUNC('week',("schema"."tbl"."column" + INTERVAL '1 day')) FROM "schema"."tbl";
+
+WITH
+  FUNCTION doubleup(x integer)
+    RETURNS integer
+    RETURN x * 2
+SELECT doubleup(21);
+
+WITH
+  FUNCTION doubleup(x integer)
+    RETURNS integer
+    RETURN x * 2,
+  FUNCTION doubleupplusone(x integer)
+    RETURNS integer
+    RETURN doubleup(x) + 1
+SELECT doubleupplusone(21);
+
+WITH
+  FUNCTION hello(name varchar)
+    RETURNS varchar
+    RETURN format('Hello %s!', 'name'),
+  FUNCTION bye(name varchar)
+    RETURNS varchar
+    RETURN format('Bye %s!', 'name')
+SELECT hello('Finn') || ' and ' || bye('Joe');


### PR DESCRIPTION
Fixes #2306 
Trino SQL allows you to specify User Defined functions in the WITH clause ahead of a statement. This adds support for this type of statement.