### PR TITLE
Fix[2312] - Fixes issue with array<double> in function declaration

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/WithFunctionDeclaration.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/WithFunctionDeclaration.java
@@ -10,6 +10,7 @@
 package net.sf.jsqlparser.statement.select;
 
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
 
 import java.io.Serializable;
 import java.util.List;
@@ -98,6 +99,13 @@ public class WithFunctionDeclaration implements Serializable {
                 .append(returnType)
                 .append(" RETURN ")
                 .append(returnExpression);
+    }
+
+    public <T, S> T accept(ExpressionVisitor<T> expressionVisitor, S context) {
+        if (returnExpression != null) {
+            return returnExpression.accept(expressionVisitor, context);
+        }
+        return null;
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/statement/select/WithItem.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/WithItem.java
@@ -171,7 +171,10 @@ public class WithItem<K extends ParenthesedStatement> implements Serializable {
     }
 
     public <T, S> T accept(StatementVisitor<T> statementVisitor, S context) {
-        return statement.accept(statementVisitor, context);
+        if (statement != null) {
+            return statement.accept(statementVisitor, context);
+        }
+        return null;
     }
 
     public WithItem<?> withWithItemList(List<SelectItem<?>> withItemList) {

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -318,8 +318,12 @@ public class TablesNamesFinder<Void>
 
     @Override
     public <S> Void visit(WithItem<?> withItem, S context) {
-        otherItemNames.add(withItem.getAlias().getName());
-        withItem.getSelect().accept((SelectVisitor<?>) this, context);
+        if (withItem.getAlias() != null) {
+            otherItemNames.add(withItem.getAlias().getName());
+        }
+        if (withItem.getSelect() != null) {
+            withItem.getSelect().accept((SelectVisitor<?>) this, context);
+        }
         return null;
     }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4405,11 +4405,20 @@ WithFunctionDeclaration WithFunctionDeclaration() #WithFunctionDeclaration:
 WithFunctionParameter WithFunctionParameter() #WithFunctionParameter:
 {
      String name;
-     String type;
+     String type = null;
+     String arrayType = null;
 }
 {
-    name = RelObjectName() type = RelObjectName()
+    name = RelObjectName()
+    (
+        LOOKAHEAD(2) <K_ARRAY_LITERAL> "<" arrayType = RelObjectName() ">"
+        |
+        type = RelObjectName()
+    )
     {
+        if (arrayType != null) {
+            type = "ARRAY<" + arrayType + ">";
+        }
         return new WithFunctionParameter(name, type);
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/WithFunctionDeclarationTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/WithFunctionDeclarationTest.java
@@ -1,6 +1,16 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2025 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
 package net.sf.jsqlparser.statement.select;
 
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -10,6 +20,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -92,5 +104,25 @@ class WithFunctionDeclarationTest {
 
         assertThat(withFunctionDeclaration.toString())
                 .isEqualTo("FUNCTION func1() RETURNS integer RETURN 1 + 1");
+    }
+
+    @Test
+    void expressionVisitorIsNotCalledWhenNoReturnExpressionDeclared(@Mock ExpressionVisitor<Void> expressionVisitor) {
+        withFunctionDeclaration = new WithFunctionDeclaration();
+
+        withFunctionDeclaration.accept(expressionVisitor, "RANDOM_CONTEXT");
+
+        verifyNoInteractions(expressionVisitor);
+    }
+
+    @Test
+    void expressionVisitorCalledWhenReturnExpressionDeclared(@Mock ExpressionVisitor<Void> expressionVisitor) {
+        String context = "RANDOM_CONTEXT";
+        withFunctionDeclaration = new WithFunctionDeclaration()
+                .withReturnExpression(expression);
+
+        withFunctionDeclaration.accept(expressionVisitor, context);
+
+        verify(expression).accept(expressionVisitor, context);
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/WithFunctionParameterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/WithFunctionParameterTest.java
@@ -1,3 +1,12 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2025 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
 package net.sf.jsqlparser.statement.select;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/net/sf/jsqlparser/statement/select/WithItemTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/WithItemTest.java
@@ -42,7 +42,13 @@ class WithItemTest {
                     "  FUNCTION doubleupplusone(x integer)\n" +
                     "    RETURNS integer\n" +
                     "    RETURN doubleup(x) + 1\n" +
-                    "SELECT doubleupplusone(21);"
+                    "SELECT doubleupplusone(21);",
+            "WITH\n" +
+                    "  FUNCTION takesArray(x array<double>)\n" +
+                    "    RETURNS double\n" +
+                    "    RETURN x[1] + x[2] + x[3]\n" +
+                    "SELECT takesArray(ARRAY[1.0, 2.0, 3.0]);"
+
     })
     void testWithFunction(String sqlStr) throws JSQLParserException {
         TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);

--- a/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -696,6 +697,19 @@ public class TablesNamesFinderTest {
                 ";";
         Set<String> tables = TablesNamesFinder.findTables(sqlStr);
         assertThat(tables).containsExactlyInAnyOrder("tbl");
+    }
+
+    @Test
+    void assertWithItemWithFunctionDeclarationDoesNotThrowException() throws JSQLParserException {
+        String sqlStr = "WITH FUNCTION my_with_item(param1 INT) RETURNS INT RETURN param1 + 1 SELECT * FROM my_table;";
+        assertThatCode(() -> TablesNamesFinder.findTables(sqlStr))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void assertWithItemWithFunctionDeclarationReturnsTableInSelect() throws JSQLParserException {
+        String sqlStr = "WITH FUNCTION my_with_item(param1 INT) RETURNS INT RETURN param1 + 1 SELECT * FROM my_table;";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactly("my_table");
     }
 }
 

--- a/src/test/resources/simple_parsing.txt
+++ b/src/test/resources/simple_parsing.txt
@@ -243,3 +243,9 @@ WITH
     RETURNS varchar
     RETURN format('Bye %s!', 'name')
 SELECT hello('Finn') || ' and ' || bye('Joe');
+
+WITH
+  FUNCTION takesArray(x array<double>)
+    RETURNS double
+    RETURN x[1] + x[2] + x[3]
+SELECT takesArray(array[1.0, 2.0, 3.0]);


### PR DESCRIPTION
```sql
WITH
  FUNCTION takesArray(x array<double>)
    RETURNS double
    RETURN x[1] + x[2] + x[3]
SELECT takesArray(array[1.0, 2.0, 3.0]);
```
Is unable to be parsed as we're not able to capture the array<double> correctly. This PR fixes that, as well as some missing visitor changes from my previous PR.

Fixes #2312 2312