### PR TITLE
[fix] Add 'K_DATA' to KeywordOrIdentifier to allow usages of 'data' as an identifier

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -886,7 +886,7 @@ TOKEN:
  * Supported tokens:
  *  - <S_IDENTIFIER>: Standard unquoted SQL identifier
  *  - <S_QUOTED_IDENTIFIER>: Quoted identifier (e.g., `identifier` or "identifier")
- *  - <K_NAME>, <K_NEXT>, <K_VALUE>, <K_PUBLIC>, <K_STRING>: Specific keywords treated as identifiers
+ *  - <K_NAME>, <K_NEXT>, <K_VALUE>, <K_PUBLIC>, <K_STRING>, <K_DATA>: Specific keywords treated as identifiers
  *
  * @return Token representing the identifier or keyword used as identifier
  */
@@ -903,6 +903,7 @@ Token KeywordOrIdentifier():
       | tk = <K_VALUE>
       | tk = <K_PUBLIC>
       | tk = <K_STRING>
+      | tk = <K_DATA>
     )
     { return tk; }
 }
@@ -9414,7 +9415,7 @@ AlterExpression AlterExpression():
         <K_CHANGE> { alterExp.setOperation(AlterOperation.CHANGE); }
         [ <K_COLUMN> { alterExp.hasColumn(true); alterExp.setOptionalSpecifier("COLUMN"); } ]
         (
-          (tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER>)
+          (tk=KeywordOrIdentifier())
           alterExpressionColumnDataType = AlterExpressionColumnDataType() {  alterExp.withColumnOldName(tk.image).addColDataType(alterExpressionColumnDataType); }
         )
       )
@@ -9448,7 +9449,7 @@ AlterExpression AlterExpression():
                     ( LOOKAHEAD(2) <K_COLUMN> { alterExp.hasColumn(true); } )?
                     [<K_IF> <K_EXISTS> { alterExp.setUsingIfExists(true); } ]
                     // @todo: replace with a proper identifier
-                    (tk=<S_IDENTIFIER>  | tk=<S_QUOTED_IDENTIFIER> | tk=<K_NAME>) { alterExp.setColumnName(tk.image); }
+                    (tk=KeywordOrIdentifier() ) { alterExp.setColumnName(tk.image); }
 
                     [ "INVALIDATE" { alterExp.addParameters("INVALIDATE"); } ]
 

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -250,6 +250,11 @@ public class AlterTest {
     }
 
     @Test
+    public void testAlterTableDropColumnIssue2339() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE test DROP COLUMN Data");
+    }
+
+    @Test
     public void testAlterTableDropConstraint() throws JSQLParserException {
         final String sql = "ALTER TABLE test DROP CONSTRAINT YYY";
         Statement stmt = CCJSqlParserUtil.parse(sql);
@@ -453,6 +458,11 @@ public class AlterTest {
     @Test
     public void testAlterTableChangeColumn4() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE tb_test CHANGE c1 c2 INT (10)");
+    }
+
+    @Test
+    public void testAlterTableChangeColumnIssue2339() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE tb_test CHANGE data INT (10)");
     }
 
     @Test


### PR DESCRIPTION
Allows for support of 'data' as a column name when changing or dropping a column in an alter table statement.

See https://github.com/JSQLParser/JSqlParser/issues/2339