### PR TITLE
[fix] Enable qualified table name for DROP INDEX command

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -8782,8 +8782,15 @@ Drop Drop():
 
     name = Table() { drop.setName(name); }
     [ LOOKAHEAD(2)  funcArgs = FuncArgsList() ]
-    ((tk=<S_IDENTIFIER> | tk=<K_CASCADE> | tk=<K_RESTRICT> | tk=<K_ON>) { dropArgs.add(tk.image); })*
-
+    (
+        (
+            tk=<S_IDENTIFIER> | tk=<K_CASCADE> | tk=<K_RESTRICT>
+        ) { dropArgs.add(tk.image); }
+        |
+        (
+            <K_ON> name = Table() { dropArgs.add("ON"); dropArgs.add(name.toString()); }
+        )
+    )*
     {
         if (dropArgs.size() > 0) {
             drop.setParameters(dropArgs);

--- a/src/test/java/net/sf/jsqlparser/statement/drop/DropTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/drop/DropTest.java
@@ -54,6 +54,16 @@ public class DropTest {
     }
 
     @Test
+    public void testDropIndexOnQualifiedTable() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("DROP INDEX idx ON qual.tbl");
+    }
+
+    @Test
+    public void testDropIndexOnDoubleQualifiedTable() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("DROP INDEX idx ON dbl.qual.tbl");
+    }
+
+    @Test
     public void testDrop2() throws JSQLParserException {
         Drop drop = (Drop) parserManager.parse(new StringReader("DROP TABLE \"testtable\""));
         assertEquals("TABLE", drop.getType());


### PR DESCRIPTION
Features:
- Enable the use of qualified table name for `DROP INDEX idx ON qual.tbl`
- Add unit test for fix

Resolves #2343 