### PR TITLE
refactor: deprecate Join.getRightItem() and remove duplicate call

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/Join.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Join.java
@@ -277,10 +277,12 @@ public class Join extends ASTNodeAccessImpl {
     /**
      * Returns the right item of the join
      */
+    @Deprecated
     public FromItem getRightItem() {
         return fromItem;
     }
 
+    @Deprecated
     public void setRightItem(FromItem item) {
         fromItem = item;
     }

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -1379,7 +1379,6 @@ public class TablesNamesFinder<Void>
         }
         for (Join join : joins) {
             join.getFromItem().accept(this, context);
-            join.getRightItem().accept(this, context);
             for (Expression expression : join.getOnExpressions()) {
                 expression.accept(this, context);
             }


### PR DESCRIPTION
1. Mark Join.getRightItem() and setRightItem() as @Deprecated since they return the same value as getFromItem().
2. Remove the duplicate call to join.getRightItem().accept(this, context) in TablesNamesFinder.visit() method, as join.getFromItem() already processes the same FromItem object.