### PR TITLE
Add support for ClickHouse MATERIALIZED column in CREATE TABLE

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -8619,9 +8619,9 @@ List<String> CreateParameter():
             | tk=<K_CONSTRAINT> | tk=<K_WITH> | tk=<K_EXCLUDE> | tk=<K_WHERE>
             | tk=<K_TEMP> | tk=<K_TEMPORARY> | tk=<K_PARTITION> | tk=<K_BY> | tk=<K_IN>
             | tk=<K_TYPE> | tk=<K_COMMENT> | tk=<K_USING> | tk=<K_COLLATE> | tk=<K_ASC>
-            | tk=<K_DESC> | tk=<K_TRUE> | tk=<K_FALSE> | tk=<K_PARALLEL> | tk=<K_BINARY> | tk=<K_START>
+            | tk=<K_DESC> | tk=<K_TRUE> | tk=<K_FALSE> | tk=<K_PARALLEL> | tk=<K_BINARY> | tk=<K_START> | tk=<K_ORDER>
             | tk=<K_TIME_KEY_EXPR> | tk=<K_RAW> | tk=<K_HASH> | tk=<K_FIRST> | tk=<K_LAST> | tk = <K_SIGNED>  | tk = <K_UNSIGNED>
-            | tk=<K_ENGINE> | tk=<K_IDENTITY>
+            | tk=<K_ENGINE> | tk=<K_IDENTITY> | tk=<K_MATERIALIZED>
             | tk="="
         )
         { param.add(tk.image); }

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
@@ -220,6 +220,17 @@ public class CreateTableTest {
     }
 
     @Test
+    public void testCreateTableClickHouseMaterializedColumn() throws JSQLParserException {
+        String statement = "CREATE TABLE t (\n"
+                + "    url String,\n"
+                + "    domain String MATERIALIZED regexpExtract(url, '^(?:https?://)?([^/]+)', 1)\n"
+                + ")\n"
+                + "ENGINE = MergeTree()\n"
+                + "ORDER BY tuple()";
+        assertSqlCanBeParsedAndDeparsed(statement, true);
+    }
+
+    @Test
     public void testCreateTableIfNotExists() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("CREATE TABLE IF NOT EXISTS animals (id INT NOT NULL)");
     }
@@ -1076,7 +1087,7 @@ public class CreateTableTest {
 
     @Test
     void testWithCatalog() throws JSQLParserException {
-        String sqlStr="CREATE TABLE UNNAMED.session1.a (b VARCHAR (1))";
+        String sqlStr = "CREATE TABLE UNNAMED.session1.a (b VARCHAR (1))";
         CreateTable st = (CreateTable) assertSqlCanBeParsedAndDeparsed(sqlStr, true);
 
         Table t = st.getTable();


### PR DESCRIPTION
- allow `MATERIALIZED` in column specs
- allow `ORDER BY` in table options
- add regression test for `ENGINE = MergeTree() ORDER BY tuple()`

fixes [https://github.com/JSQLParser/JSqlParser/issues/2354](https://github.com/JSQLParser/JSqlParser/issues/2354)、[https://github.com/JSQLParser/JSqlParser/issues/2353](https://github.com/JSQLParser/JSqlParser/issues/2353)