### PR TITLE
Add support for multiple Trino JSON functions

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -652,6 +652,14 @@ public interface ExpressionVisitor<T> {
         this.visit(jsonFunction, null);
     }
 
+    default <S> T visit(JsonTableFunction jsonTableFunction, S context) {
+        return visit((Function) jsonTableFunction, context);
+    }
+
+    default void visit(JsonTableFunction jsonTableFunction) {
+        this.visit(jsonTableFunction, null);
+    }
+
     <S> T visit(ConnectByRootOperator connectByRootOperator, S context);
 
     default void visit(ConnectByRootOperator connectByRootOperator) {

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -722,10 +722,38 @@ public class ExpressionVisitorAdapter<T>
     @Override
     public <S> T visit(JsonFunction jsonFunction, S context) {
         ArrayList<Expression> subExpressions = new ArrayList<>();
+        for (JsonKeyValuePair keyValuePair : jsonFunction.getKeyValuePairs()) {
+            if (keyValuePair.getKey() instanceof Expression) {
+                subExpressions.add((Expression) keyValuePair.getKey());
+            }
+            if (keyValuePair.getValue() instanceof Expression) {
+                subExpressions.add((Expression) keyValuePair.getValue());
+            }
+        }
         for (JsonFunctionExpression expr : jsonFunction.getExpressions()) {
             subExpressions.add(expr.getExpression());
         }
+        if (jsonFunction.getInputExpression() != null) {
+            subExpressions.add(jsonFunction.getInputExpression().getExpression());
+        }
+        if (jsonFunction.getJsonPathExpression() != null) {
+            subExpressions.add(jsonFunction.getJsonPathExpression());
+        }
+        subExpressions.addAll(jsonFunction.getPassingExpressions());
+        if (jsonFunction.getOnEmptyBehavior() != null
+                && jsonFunction.getOnEmptyBehavior().getExpression() != null) {
+            subExpressions.add(jsonFunction.getOnEmptyBehavior().getExpression());
+        }
+        if (jsonFunction.getOnErrorBehavior() != null
+                && jsonFunction.getOnErrorBehavior().getExpression() != null) {
+            subExpressions.add(jsonFunction.getOnErrorBehavior().getExpression());
+        }
         return visitExpressions(jsonFunction, context, subExpressions);
+    }
+
+    @Override
+    public <S> T visit(JsonTableFunction jsonTableFunction, S context) {
+        return visitExpressions(jsonTableFunction, context, jsonTableFunction.getAllExpressions());
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/expression/JsonFunctionExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/JsonFunctionExpression.java
@@ -21,6 +21,7 @@ public class JsonFunctionExpression implements Serializable {
     private final Expression expression;
 
     private boolean usingFormatJson = false;
+    private String encoding;
 
     public JsonFunctionExpression(Expression expression) {
         this.expression = Objects.requireNonNull(expression, "The EXPRESSION must not be null");
@@ -43,8 +44,28 @@ public class JsonFunctionExpression implements Serializable {
         return this;
     }
 
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
+    }
+
+    public JsonFunctionExpression withEncoding(String encoding) {
+        this.setEncoding(encoding);
+        return this;
+    }
+
     public StringBuilder append(StringBuilder builder) {
-        return builder.append(getExpression()).append(isUsingFormatJson() ? " FORMAT JSON" : "");
+        builder.append(getExpression());
+        if (isUsingFormatJson()) {
+            builder.append(" FORMAT JSON");
+            if (encoding != null) {
+                builder.append(" ENCODING ").append(encoding);
+            }
+        }
+        return builder;
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/expression/JsonFunctionType.java
+++ b/src/main/java/net/sf/jsqlparser/expression/JsonFunctionType.java
@@ -14,7 +14,7 @@ package net.sf.jsqlparser.expression;
  * @author <a href="mailto:andreas@manticore-projects.com">Andreas Reichel</a>
  */
 public enum JsonFunctionType {
-    OBJECT, ARRAY,
+    OBJECT, ARRAY, VALUE, QUERY, EXISTS,
 
     /**
      * Not used anymore

--- a/src/main/java/net/sf/jsqlparser/expression/JsonKeyValuePair.java
+++ b/src/main/java/net/sf/jsqlparser/expression/JsonKeyValuePair.java
@@ -23,6 +23,7 @@ public class JsonKeyValuePair implements Serializable {
     private boolean usingKeyKeyword;
     private JsonKeyValuePairSeparator separator;
     private boolean usingFormatJson = false;
+    private String encoding;
 
     /**
      * Please use the Constructor with {@link JsonKeyValuePairSeparator} parameter.
@@ -108,6 +109,19 @@ public class JsonKeyValuePair implements Serializable {
         return this;
     }
 
+    public String getEncoding() {
+        return encoding;
+    }
+
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
+    }
+
+    public JsonKeyValuePair withEncoding(String encoding) {
+        this.setEncoding(encoding);
+        return this;
+    }
+
     @Override
     public int hashCode() {
         int hash = 7;
@@ -151,6 +165,9 @@ public class JsonKeyValuePair implements Serializable {
 
         if (isUsingFormatJson()) {
             builder.append(" FORMAT JSON");
+            if (encoding != null) {
+                builder.append(" ENCODING ").append(encoding);
+            }
         }
 
         return builder;

--- a/src/main/java/net/sf/jsqlparser/expression/JsonTableFunction.java
+++ b/src/main/java/net/sf/jsqlparser/expression/JsonTableFunction.java
@@ -1,0 +1,704 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+import net.sf.jsqlparser.statement.create.table.ColDataType;
+
+public class JsonTableFunction extends Function {
+    public enum JsonTablePlanOperator {
+        COMMA(", "), INNER(" INNER "), OUTER(" OUTER "), CROSS(" CROSS "), UNION(" UNION ");
+
+        private final String display;
+
+        JsonTablePlanOperator(String display) {
+            this.display = display;
+        }
+
+        public String getDisplay() {
+            return display;
+        }
+    }
+
+    public enum JsonTableOnErrorType {
+        ERROR, EMPTY
+    }
+
+    public static class JsonTablePassingClause extends ASTNodeAccessImpl implements Serializable {
+        private Expression valueExpression;
+        private String parameterName;
+
+        public JsonTablePassingClause() {}
+
+        public JsonTablePassingClause(Expression valueExpression, String parameterName) {
+            this.valueExpression = valueExpression;
+            this.parameterName = parameterName;
+        }
+
+        public Expression getValueExpression() {
+            return valueExpression;
+        }
+
+        public JsonTablePassingClause setValueExpression(Expression valueExpression) {
+            this.valueExpression = valueExpression;
+            return this;
+        }
+
+        public String getParameterName() {
+            return parameterName;
+        }
+
+        public JsonTablePassingClause setParameterName(String parameterName) {
+            this.parameterName = parameterName;
+            return this;
+        }
+
+        public void collectExpressions(List<Expression> expressions) {
+            if (valueExpression != null) {
+                expressions.add(valueExpression);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return valueExpression + " AS " + parameterName;
+        }
+    }
+
+    public static class JsonTableWrapperClause extends ASTNodeAccessImpl implements Serializable {
+        private JsonFunction.JsonWrapperType wrapperType;
+        private JsonFunction.JsonWrapperMode wrapperMode;
+        private boolean array;
+
+        public JsonFunction.JsonWrapperType getWrapperType() {
+            return wrapperType;
+        }
+
+        public JsonTableWrapperClause setWrapperType(JsonFunction.JsonWrapperType wrapperType) {
+            this.wrapperType = wrapperType;
+            return this;
+        }
+
+        public JsonFunction.JsonWrapperMode getWrapperMode() {
+            return wrapperMode;
+        }
+
+        public JsonTableWrapperClause setWrapperMode(JsonFunction.JsonWrapperMode wrapperMode) {
+            this.wrapperMode = wrapperMode;
+            return this;
+        }
+
+        public boolean isArray() {
+            return array;
+        }
+
+        public JsonTableWrapperClause setArray(boolean array) {
+            this.array = array;
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append(wrapperType);
+            if (wrapperMode != null) {
+                builder.append(" ").append(wrapperMode);
+            }
+            if (array) {
+                builder.append(" ARRAY");
+            }
+            builder.append(" WRAPPER");
+            return builder.toString();
+        }
+    }
+
+    public static class JsonTableQuotesClause extends ASTNodeAccessImpl implements Serializable {
+        private JsonFunction.JsonQuotesType quotesType;
+        private boolean onScalarString;
+
+        public JsonFunction.JsonQuotesType getQuotesType() {
+            return quotesType;
+        }
+
+        public JsonTableQuotesClause setQuotesType(JsonFunction.JsonQuotesType quotesType) {
+            this.quotesType = quotesType;
+            return this;
+        }
+
+        public boolean isOnScalarString() {
+            return onScalarString;
+        }
+
+        public JsonTableQuotesClause setOnScalarString(boolean onScalarString) {
+            this.onScalarString = onScalarString;
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            builder.append(quotesType).append(" QUOTES");
+            if (onScalarString) {
+                builder.append(" ON SCALAR STRING");
+            }
+            return builder.toString();
+        }
+    }
+
+    public static class JsonTableOnErrorClause extends ASTNodeAccessImpl implements Serializable {
+        private JsonTableOnErrorType type;
+
+        public JsonTableOnErrorType getType() {
+            return type;
+        }
+
+        public JsonTableOnErrorClause setType(JsonTableOnErrorType type) {
+            this.type = type;
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return type + " ON ERROR";
+        }
+    }
+
+    public static class JsonTablePlanTerm extends ASTNodeAccessImpl implements Serializable {
+        private JsonTablePlanExpression nestedPlanExpression;
+        private String name;
+        private Expression expression;
+
+        public JsonTablePlanExpression getNestedPlanExpression() {
+            return nestedPlanExpression;
+        }
+
+        public JsonTablePlanTerm setNestedPlanExpression(
+                JsonTablePlanExpression nestedPlanExpression) {
+            this.nestedPlanExpression = nestedPlanExpression;
+            return this;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public JsonTablePlanTerm setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Expression getExpression() {
+            return expression;
+        }
+
+        public JsonTablePlanTerm setExpression(Expression expression) {
+            this.expression = expression;
+            return this;
+        }
+
+        public void collectExpressions(List<Expression> expressions) {
+            if (expression != null) {
+                expressions.add(expression);
+            }
+            if (nestedPlanExpression != null) {
+                nestedPlanExpression.collectExpressions(expressions);
+            }
+        }
+
+        @Override
+        public String toString() {
+            if (nestedPlanExpression != null) {
+                return "(" + nestedPlanExpression + ")";
+            }
+            if (name != null) {
+                return name;
+            }
+            return expression != null ? expression.toString() : "";
+        }
+    }
+
+    public static class JsonTablePlanExpression extends ASTNodeAccessImpl implements Serializable {
+        private final List<JsonTablePlanTerm> terms = new ArrayList<>();
+        private final List<JsonTablePlanOperator> operators = new ArrayList<>();
+
+        public List<JsonTablePlanTerm> getTerms() {
+            return terms;
+        }
+
+        public JsonTablePlanExpression addTerm(JsonTablePlanTerm term) {
+            terms.add(term);
+            return this;
+        }
+
+        public List<JsonTablePlanOperator> getOperators() {
+            return operators;
+        }
+
+        public JsonTablePlanExpression addOperator(JsonTablePlanOperator operator) {
+            operators.add(operator);
+            return this;
+        }
+
+        public void collectExpressions(List<Expression> expressions) {
+            for (JsonTablePlanTerm term : terms) {
+                if (term != null) {
+                    term.collectExpressions(expressions);
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder();
+            if (!terms.isEmpty()) {
+                builder.append(terms.get(0));
+            }
+            for (int i = 0; i < operators.size() && i + 1 < terms.size(); i++) {
+                builder.append(operators.get(i).getDisplay()).append(terms.get(i + 1));
+            }
+            return builder.toString();
+        }
+    }
+
+    public static class JsonTablePlanClause extends ASTNodeAccessImpl implements Serializable {
+        private boolean defaultPlan;
+        private JsonTablePlanExpression planExpression;
+
+        public boolean isDefaultPlan() {
+            return defaultPlan;
+        }
+
+        public JsonTablePlanClause setDefaultPlan(boolean defaultPlan) {
+            this.defaultPlan = defaultPlan;
+            return this;
+        }
+
+        public JsonTablePlanExpression getPlanExpression() {
+            return planExpression;
+        }
+
+        public JsonTablePlanClause setPlanExpression(JsonTablePlanExpression planExpression) {
+            this.planExpression = planExpression;
+            return this;
+        }
+
+        public void collectExpressions(List<Expression> expressions) {
+            if (planExpression != null) {
+                planExpression.collectExpressions(expressions);
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder("PLAN");
+            if (defaultPlan) {
+                builder.append(" DEFAULT");
+            }
+            builder.append(" (").append(planExpression).append(")");
+            return builder.toString();
+        }
+    }
+
+    public abstract static class JsonTableColumnDefinition extends ASTNodeAccessImpl
+            implements Serializable {
+        public abstract void collectExpressions(List<Expression> expressions);
+    }
+
+    public static class JsonTableNestedColumnDefinition extends JsonTableColumnDefinition {
+        private boolean pathKeyword;
+        private Expression pathExpression;
+        private String pathName;
+        private JsonTableColumnsClause columnsClause;
+
+        public boolean isPathKeyword() {
+            return pathKeyword;
+        }
+
+        public JsonTableNestedColumnDefinition setPathKeyword(boolean pathKeyword) {
+            this.pathKeyword = pathKeyword;
+            return this;
+        }
+
+        public Expression getPathExpression() {
+            return pathExpression;
+        }
+
+        public JsonTableNestedColumnDefinition setPathExpression(Expression pathExpression) {
+            this.pathExpression = pathExpression;
+            return this;
+        }
+
+        public String getPathName() {
+            return pathName;
+        }
+
+        public JsonTableNestedColumnDefinition setPathName(String pathName) {
+            this.pathName = pathName;
+            return this;
+        }
+
+        public JsonTableColumnsClause getColumnsClause() {
+            return columnsClause;
+        }
+
+        public JsonTableNestedColumnDefinition setColumnsClause(
+                JsonTableColumnsClause columnsClause) {
+            this.columnsClause = columnsClause;
+            return this;
+        }
+
+        @Override
+        public void collectExpressions(List<Expression> expressions) {
+            if (pathExpression != null) {
+                expressions.add(pathExpression);
+            }
+            if (columnsClause != null) {
+                columnsClause.collectExpressions(expressions);
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder("NESTED");
+            if (pathKeyword) {
+                builder.append(" PATH");
+            }
+            builder.append(" ").append(pathExpression);
+            if (pathName != null) {
+                builder.append(" AS ").append(pathName);
+            }
+            builder.append(" ").append(columnsClause);
+            return builder.toString();
+        }
+    }
+
+    public static class JsonTableValueColumnDefinition extends JsonTableColumnDefinition {
+        private String columnName;
+        private boolean forOrdinality;
+        private ColDataType dataType;
+        private boolean formatJson;
+        private String encoding;
+        private Expression pathExpression;
+        private JsonTableWrapperClause wrapperClause;
+        private JsonTableQuotesClause quotesClause;
+        private JsonFunction.JsonOnResponseBehavior onEmptyBehavior;
+        private JsonFunction.JsonOnResponseBehavior onErrorBehavior;
+
+        public String getColumnName() {
+            return columnName;
+        }
+
+        public JsonTableValueColumnDefinition setColumnName(String columnName) {
+            this.columnName = columnName;
+            return this;
+        }
+
+        public boolean isForOrdinality() {
+            return forOrdinality;
+        }
+
+        public JsonTableValueColumnDefinition setForOrdinality(boolean forOrdinality) {
+            this.forOrdinality = forOrdinality;
+            return this;
+        }
+
+        public ColDataType getDataType() {
+            return dataType;
+        }
+
+        public JsonTableValueColumnDefinition setDataType(ColDataType dataType) {
+            this.dataType = dataType;
+            return this;
+        }
+
+        public boolean isFormatJson() {
+            return formatJson;
+        }
+
+        public JsonTableValueColumnDefinition setFormatJson(boolean formatJson) {
+            this.formatJson = formatJson;
+            return this;
+        }
+
+        public String getEncoding() {
+            return encoding;
+        }
+
+        public JsonTableValueColumnDefinition setEncoding(String encoding) {
+            this.encoding = encoding;
+            return this;
+        }
+
+        public Expression getPathExpression() {
+            return pathExpression;
+        }
+
+        public JsonTableValueColumnDefinition setPathExpression(Expression pathExpression) {
+            this.pathExpression = pathExpression;
+            return this;
+        }
+
+        public JsonTableWrapperClause getWrapperClause() {
+            return wrapperClause;
+        }
+
+        public JsonTableValueColumnDefinition setWrapperClause(
+                JsonTableWrapperClause wrapperClause) {
+            this.wrapperClause = wrapperClause;
+            return this;
+        }
+
+        public JsonTableQuotesClause getQuotesClause() {
+            return quotesClause;
+        }
+
+        public JsonTableValueColumnDefinition setQuotesClause(JsonTableQuotesClause quotesClause) {
+            this.quotesClause = quotesClause;
+            return this;
+        }
+
+        public JsonFunction.JsonOnResponseBehavior getOnEmptyBehavior() {
+            return onEmptyBehavior;
+        }
+
+        public JsonTableValueColumnDefinition setOnEmptyBehavior(
+                JsonFunction.JsonOnResponseBehavior onEmptyBehavior) {
+            this.onEmptyBehavior = onEmptyBehavior;
+            return this;
+        }
+
+        public JsonFunction.JsonOnResponseBehavior getOnErrorBehavior() {
+            return onErrorBehavior;
+        }
+
+        public JsonTableValueColumnDefinition setOnErrorBehavior(
+                JsonFunction.JsonOnResponseBehavior onErrorBehavior) {
+            this.onErrorBehavior = onErrorBehavior;
+            return this;
+        }
+
+        @Override
+        public void collectExpressions(List<Expression> expressions) {
+            if (pathExpression != null) {
+                expressions.add(pathExpression);
+            }
+            if (onEmptyBehavior != null && onEmptyBehavior.getExpression() != null) {
+                expressions.add(onEmptyBehavior.getExpression());
+            }
+            if (onErrorBehavior != null && onErrorBehavior.getExpression() != null) {
+                expressions.add(onErrorBehavior.getExpression());
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder(columnName);
+            if (forOrdinality) {
+                builder.append(" FOR ORDINALITY");
+                return builder.toString();
+            }
+
+            builder.append(" ").append(dataType);
+            if (formatJson) {
+                builder.append(" FORMAT JSON");
+                if (encoding != null) {
+                    builder.append(" ENCODING ").append(encoding);
+                }
+            }
+            if (pathExpression != null) {
+                builder.append(" PATH ").append(pathExpression);
+            }
+            if (wrapperClause != null) {
+                builder.append(" ").append(wrapperClause);
+            }
+            if (quotesClause != null) {
+                builder.append(" ").append(quotesClause);
+            }
+            if (onEmptyBehavior != null) {
+                builder.append(" ").append(onEmptyBehavior).append(" ON EMPTY");
+            }
+            if (onErrorBehavior != null) {
+                builder.append(" ").append(onErrorBehavior).append(" ON ERROR");
+            }
+            return builder.toString();
+        }
+    }
+
+    public static class JsonTableColumnsClause extends ASTNodeAccessImpl implements Serializable {
+        private final List<JsonTableColumnDefinition> columnDefinitions = new ArrayList<>();
+
+        public List<JsonTableColumnDefinition> getColumnDefinitions() {
+            return columnDefinitions;
+        }
+
+        public JsonTableColumnsClause addColumnDefinition(
+                JsonTableColumnDefinition columnDefinition) {
+            columnDefinitions.add(columnDefinition);
+            return this;
+        }
+
+        public void collectExpressions(List<Expression> expressions) {
+            for (JsonTableColumnDefinition columnDefinition : columnDefinitions) {
+                if (columnDefinition != null) {
+                    columnDefinition.collectExpressions(expressions);
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder("COLUMNS (");
+            boolean first = true;
+            for (JsonTableColumnDefinition columnDefinition : columnDefinitions) {
+                if (!first) {
+                    builder.append(", ");
+                }
+                builder.append(columnDefinition);
+                first = false;
+            }
+            builder.append(")");
+            return builder.toString();
+        }
+    }
+
+    private Expression jsonInputExpression;
+    private Expression jsonPathExpression;
+    private String pathName;
+    private final List<JsonTablePassingClause> passingClauses = new ArrayList<>();
+    private JsonTableColumnsClause columnsClause;
+    private JsonTablePlanClause planClause;
+    private JsonTableOnErrorClause onErrorClause;
+
+    public JsonTableFunction() {
+        setName("JSON_TABLE");
+    }
+
+    public Expression getJsonInputExpression() {
+        return jsonInputExpression;
+    }
+
+    public JsonTableFunction setJsonInputExpression(Expression jsonInputExpression) {
+        this.jsonInputExpression = jsonInputExpression;
+        return this;
+    }
+
+    public Expression getJsonPathExpression() {
+        return jsonPathExpression;
+    }
+
+    public JsonTableFunction setJsonPathExpression(Expression jsonPathExpression) {
+        this.jsonPathExpression = jsonPathExpression;
+        return this;
+    }
+
+    public String getPathName() {
+        return pathName;
+    }
+
+    public JsonTableFunction setPathName(String pathName) {
+        this.pathName = pathName;
+        return this;
+    }
+
+    public List<JsonTablePassingClause> getPassingClauses() {
+        return passingClauses;
+    }
+
+    public JsonTableFunction addPassingClause(JsonTablePassingClause passingClause) {
+        passingClauses.add(Objects.requireNonNull(passingClause, "passingClause"));
+        return this;
+    }
+
+    public JsonTableColumnsClause getColumnsClause() {
+        return columnsClause;
+    }
+
+    public JsonTableFunction setColumnsClause(JsonTableColumnsClause columnsClause) {
+        this.columnsClause = columnsClause;
+        return this;
+    }
+
+    public JsonTablePlanClause getPlanClause() {
+        return planClause;
+    }
+
+    public JsonTableFunction setPlanClause(JsonTablePlanClause planClause) {
+        this.planClause = planClause;
+        return this;
+    }
+
+    public JsonTableOnErrorClause getOnErrorClause() {
+        return onErrorClause;
+    }
+
+    public JsonTableFunction setOnErrorClause(JsonTableOnErrorClause onErrorClause) {
+        this.onErrorClause = onErrorClause;
+        return this;
+    }
+
+    public List<Expression> getAllExpressions() {
+        List<Expression> expressions = new ArrayList<>();
+        if (jsonInputExpression != null) {
+            expressions.add(jsonInputExpression);
+        }
+        if (jsonPathExpression != null) {
+            expressions.add(jsonPathExpression);
+        }
+        for (JsonTablePassingClause passingClause : passingClauses) {
+            passingClause.collectExpressions(expressions);
+        }
+        if (columnsClause != null) {
+            columnsClause.collectExpressions(expressions);
+        }
+        if (planClause != null) {
+            planClause.collectExpressions(expressions);
+        }
+        return expressions;
+    }
+
+    @Override
+    public <T, S> T accept(ExpressionVisitor<T> expressionVisitor, S context) {
+        return expressionVisitor.visit(this, context);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("JSON_TABLE(");
+        builder.append(jsonInputExpression).append(", ").append(jsonPathExpression);
+        if (pathName != null) {
+            builder.append(" AS ").append(pathName);
+        }
+        if (!passingClauses.isEmpty()) {
+            builder.append(" PASSING ");
+            boolean first = true;
+            for (JsonTablePassingClause passingClause : passingClauses) {
+                if (!first) {
+                    builder.append(", ");
+                }
+                builder.append(passingClause);
+                first = false;
+            }
+        }
+        builder.append(" ").append(columnsClause);
+        if (planClause != null) {
+            builder.append(" ").append(planClause);
+        }
+        if (onErrorClause != null) {
+            builder.append(" ").append(onErrorClause);
+        }
+        builder.append(")");
+        return builder.toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/expression/RawFunction.java
+++ b/src/main/java/net/sf/jsqlparser/expression/RawFunction.java
@@ -1,0 +1,41 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+/**
+ * Function with a raw argument body preserved as-is for deparsing.
+ */
+public class RawFunction extends Function {
+    private String rawArguments;
+
+    public RawFunction() {}
+
+    public RawFunction(String name, String rawArguments) {
+        setName(name);
+        this.rawArguments = rawArguments;
+    }
+
+    public String getRawArguments() {
+        return rawArguments;
+    }
+
+    public void setRawArguments(String rawArguments) {
+        this.rawArguments = rawArguments;
+    }
+
+    @Override
+    public String toString() {
+        String name = getName();
+        if (rawArguments == null) {
+            return name + "()";
+        }
+        return name + "(" + rawArguments + ")";
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -1726,6 +1726,38 @@ public class TablesNamesFinder<Void>
         for (JsonFunctionExpression expr : expression.getExpressions()) {
             expr.getExpression().accept(this, context);
         }
+
+        if (expression.getInputExpression() != null) {
+            expression.getInputExpression().getExpression().accept(this, context);
+        }
+
+        if (expression.getJsonPathExpression() != null) {
+            expression.getJsonPathExpression().accept(this, context);
+        }
+
+        for (Expression passingExpression : expression.getPassingExpressions()) {
+            passingExpression.accept(this, context);
+        }
+
+        if (expression.getOnEmptyBehavior() != null
+                && expression.getOnEmptyBehavior().getExpression() != null) {
+            expression.getOnEmptyBehavior().getExpression().accept(this, context);
+        }
+
+        if (expression.getOnErrorBehavior() != null
+                && expression.getOnErrorBehavior().getExpression() != null) {
+            expression.getOnErrorBehavior().getExpression().accept(this, context);
+        }
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(JsonTableFunction expression, S context) {
+        for (Expression jsonExpression : expression.getAllExpressions()) {
+            if (jsonExpression != null) {
+                jsonExpression.accept(this, context);
+            }
+        }
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -39,6 +39,7 @@ import net.sf.jsqlparser.expression.JdbcParameter;
 import net.sf.jsqlparser.expression.JsonAggregateFunction;
 import net.sf.jsqlparser.expression.JsonExpression;
 import net.sf.jsqlparser.expression.JsonFunction;
+import net.sf.jsqlparser.expression.JsonTableFunction;
 import net.sf.jsqlparser.expression.KeepExpression;
 import net.sf.jsqlparser.expression.LambdaExpression;
 import net.sf.jsqlparser.expression.LongValue;
@@ -1627,6 +1628,12 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
     @Override
     public <S> StringBuilder visit(JsonFunction expression, S context) {
         expression.append(builder);
+        return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(JsonTableFunction expression, S context) {
+        builder.append(expression);
         return builder;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
@@ -38,6 +38,7 @@ import net.sf.jsqlparser.expression.JdbcParameter;
 import net.sf.jsqlparser.expression.JsonAggregateFunction;
 import net.sf.jsqlparser.expression.JsonExpression;
 import net.sf.jsqlparser.expression.JsonFunction;
+import net.sf.jsqlparser.expression.JsonTableFunction;
 import net.sf.jsqlparser.expression.KeepExpression;
 import net.sf.jsqlparser.expression.LambdaExpression;
 import net.sf.jsqlparser.expression.LongValue;
@@ -1032,6 +1033,14 @@ public class ExpressionValidator extends AbstractValidator<Expression>
     @Override
     public <S> Void visit(JsonFunction expression, S context) {
         // no idea what this is good for
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(JsonTableFunction expression, S context) {
+        for (Expression jsonExpression : expression.getAllExpressions()) {
+            validateOptionalExpression(jsonExpression, this);
+        }
         return null;
     }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4864,6 +4864,19 @@ FromItem FromItem() #FromItem:
     (
         LOOKAHEAD(3, { !getAsBoolean(Feature.allowUnparenthesizedSubSelects) }) fromItem = Values()
         |
+        LOOKAHEAD({
+            getToken(1).kind == S_IDENTIFIER
+                && getToken(1).image.equalsIgnoreCase("JSON_TABLE")
+                && getToken(2).kind == OPENING_BRACKET
+        }) fromItem=TableFunction()
+        |
+        LOOKAHEAD({
+            getToken(1).kind == K_LATERAL
+                && getToken(2).kind == S_IDENTIFIER
+                && getToken(2).image.equalsIgnoreCase("JSON_TABLE")
+                && getToken(3).kind == OPENING_BRACKET
+        }) fromItem=TableFunction()
+        |
         LOOKAHEAD(16) fromItem=TableFunction()
         |
         LOOKAHEAD(3) fromItem=Table()
@@ -7045,6 +7058,7 @@ JsonKeyValuePair JsonKeyValuePair(boolean isFirstEntry) : {
 
     boolean usingKeyKeyword = false;
     boolean usingFormatJason = false;
+    String encoding = null;
     boolean isWildcard = false;
 
     Object key = null;
@@ -7087,11 +7101,15 @@ JsonKeyValuePair JsonKeyValuePair(boolean isFirstEntry) : {
        expression = Expression()
     ]
 
-    // Optional: FORMAT JSON - Is not allowed with * or t1.*
-    [ LOOKAHEAD(1, { !isWildcard } ) <K_FORMAT> <K_JSON> { usingFormatJason = true; } ]
+    // Optional: FORMAT JSON [ ENCODING ... ] - Is not allowed with * or t1.*
+    [
+        LOOKAHEAD(1, { !isWildcard } ) <K_FORMAT> <K_JSON> { usingFormatJason = true; }
+        [ <K_ENCODING> encoding = JsonEncoding() ]
+    ]
     {
         final JsonKeyValuePair keyValuePair = new JsonKeyValuePair( key, expression, usingKeyKeyword, kvSeparator );
         keyValuePair.setUsingFormatJson( usingFormatJason );
+        keyValuePair.setEncoding(encoding);
         return keyValuePair;
    }
 }
@@ -7100,6 +7118,8 @@ JsonFunction JsonObjectBody() : {
     JsonFunction result = new JsonFunction(JsonFunctionType.OBJECT);
 
     JsonKeyValuePair keyValuePair;
+    ColDataType dataType;
+    String encoding;
 }
 {
     ( "("
@@ -7123,6 +7143,13 @@ JsonFunction JsonObjectBody() : {
           |
           ( <K_WITHOUT> <K_UNIQUE> <K_KEYS> { result.setUniqueKeysType( JsonAggregateUniqueKeysType.WITHOUT ); } )
         ]
+        [
+            <K_RETURNING> dataType = ColDataType() { result.setReturningType(dataType); }
+            [
+                <K_FORMAT> <K_JSON> { result.setReturningFormatJson(true); }
+                [ <K_ENCODING> encoding = JsonEncoding() { result.setReturningEncoding(encoding); } ]
+            ]
+        ]
     ")" )
     {
         return result;
@@ -7134,6 +7161,8 @@ JsonFunction JsonArrayBody() : {
 
     Expression expression = null;
     JsonFunctionExpression functionExpression;
+    ColDataType dataType;
+    String encoding;
 }
 {
     ( "("
@@ -7144,18 +7173,478 @@ JsonFunction JsonArrayBody() : {
             |
             expression=Expression() { functionExpression = new JsonFunctionExpression( expression ); result.add( functionExpression ); }
 
-            [ LOOKAHEAD(2) <K_FORMAT> <K_JSON> { functionExpression.setUsingFormatJson( true ); } ]
+            [
+                LOOKAHEAD(2) <K_FORMAT> <K_JSON> { functionExpression.setUsingFormatJson( true ); }
+                [ <K_ENCODING> encoding = JsonEncoding() { functionExpression.setEncoding(encoding); } ]
+            ]
             (
                 ","
                 expression=Expression() { functionExpression = new JsonFunctionExpression( expression ); result.add( functionExpression ); }
-                [ LOOKAHEAD(2) <K_FORMAT> <K_JSON> { functionExpression.setUsingFormatJson( true ); } ]
+                [
+                    LOOKAHEAD(2) <K_FORMAT> <K_JSON> { functionExpression.setUsingFormatJson( true ); }
+                    [ <K_ENCODING> encoding = JsonEncoding() { functionExpression.setEncoding(encoding); } ]
+                ]
             )*
         )*
 
         [
           <K_ABSENT> <K_ON> <K_NULL> { result.setOnNullType(  JsonAggregateOnNullType.ABSENT ); }
         ]
+        [
+            <K_RETURNING> dataType = ColDataType() { result.setReturningType(dataType); }
+            [
+                <K_FORMAT> <K_JSON> { result.setReturningFormatJson(true); }
+                [ <K_ENCODING> encoding = JsonEncoding() { result.setReturningEncoding(encoding); } ]
+            ]
+        ]
     ")" )
+    {
+        return result;
+    }
+}
+
+void JsonKeyword(String expectedKeyword) : {
+    Token token;
+}
+{
+    token = <S_IDENTIFIER>
+    {
+        if (!token.image.equalsIgnoreCase(expectedKeyword)) {
+            throw new ParseException(
+                    "Expected keyword " + expectedKeyword + " but found " + token.image);
+        }
+    }
+}
+
+String JsonEncoding() : {
+    Token token;
+}
+{
+    token = <S_IDENTIFIER>
+    {
+        if (token.image.equalsIgnoreCase("UTF8")) {
+            return "UTF8";
+        } else if (token.image.equalsIgnoreCase("UTF16")) {
+            return "UTF16";
+        } else if (token.image.equalsIgnoreCase("UTF32")) {
+            return "UTF32";
+        }
+        throw new ParseException(
+                "Expected ENCODING value UTF8, UTF16 or UTF32 but found " + token.image);
+    }
+}
+
+JsonFunctionExpression JsonValueOrQueryInputExpression() : {
+    Expression expression;
+    JsonFunctionExpression functionExpression;
+    String encoding;
+}
+{
+    expression = Expression() { functionExpression = new JsonFunctionExpression(expression); }
+    [
+        <K_FORMAT> <K_JSON> { functionExpression.setUsingFormatJson(true); }
+        [ <K_ENCODING> encoding = JsonEncoding() { functionExpression.setEncoding(encoding); } ]
+    ]
+    {
+        return functionExpression;
+    }
+}
+
+JsonFunction.JsonOnResponseBehavior JsonValueOnResponseBehavior() : {
+    JsonFunction.JsonOnResponseBehavior behavior;
+    Expression expression;
+}
+{
+    (
+        <K_ERROR>
+        {
+            behavior = new JsonFunction.JsonOnResponseBehavior(
+                    JsonFunction.JsonOnResponseBehaviorType.ERROR);
+        }
+        |
+        <K_NULL>
+        {
+            behavior = new JsonFunction.JsonOnResponseBehavior(
+                    JsonFunction.JsonOnResponseBehaviorType.NULL);
+        }
+        |
+        <K_DEFAULT> expression = Expression()
+        {
+            behavior = new JsonFunction.JsonOnResponseBehavior(
+                    JsonFunction.JsonOnResponseBehaviorType.DEFAULT, expression);
+        }
+    )
+    {
+        return behavior;
+    }
+}
+
+JsonFunction.JsonOnResponseBehavior JsonQueryOnResponseBehavior() : {
+    JsonFunction.JsonOnResponseBehavior behavior = null;
+    Token token;
+}
+{
+    (
+        <K_ERROR>
+        {
+            behavior = new JsonFunction.JsonOnResponseBehavior(
+                    JsonFunction.JsonOnResponseBehaviorType.ERROR);
+        }
+        |
+        <K_NULL>
+        {
+            behavior = new JsonFunction.JsonOnResponseBehavior(
+                    JsonFunction.JsonOnResponseBehaviorType.NULL);
+        }
+        |
+        token = <S_IDENTIFIER>
+        {
+            if (!token.image.equalsIgnoreCase("EMPTY")) {
+                throw new ParseException(
+                        "Expected EMPTY, ERROR or NULL but found " + token.image);
+            }
+        }
+        (
+            <K_ARRAY_LITERAL>
+            {
+                behavior = new JsonFunction.JsonOnResponseBehavior(
+                        JsonFunction.JsonOnResponseBehaviorType.EMPTY_ARRAY);
+            }
+            |
+            JsonKeyword("OBJECT")
+            {
+                behavior = new JsonFunction.JsonOnResponseBehavior(
+                        JsonFunction.JsonOnResponseBehaviorType.EMPTY_OBJECT);
+            }
+        )
+    )
+    {
+        if (behavior != null) {
+            return behavior;
+        }
+    }
+}
+
+JsonFunction.JsonOnResponseBehavior JsonExistsOnResponseBehavior() : {
+    JsonFunction.JsonOnResponseBehavior behavior = null;
+}
+{
+    (
+        <K_TRUE>
+        {
+            behavior = new JsonFunction.JsonOnResponseBehavior(
+                    JsonFunction.JsonOnResponseBehaviorType.TRUE);
+        }
+        |
+        <K_FALSE>
+        {
+            behavior = new JsonFunction.JsonOnResponseBehavior(
+                    JsonFunction.JsonOnResponseBehaviorType.FALSE);
+        }
+        |
+        <K_UNKNOWN>
+        {
+            behavior = new JsonFunction.JsonOnResponseBehavior(
+                    JsonFunction.JsonOnResponseBehaviorType.UNKNOWN);
+        }
+        |
+        <K_ERROR>
+        {
+            behavior = new JsonFunction.JsonOnResponseBehavior(
+                    JsonFunction.JsonOnResponseBehaviorType.ERROR);
+        }
+    )
+    {
+        return behavior;
+    }
+}
+
+JsonFunction JsonExistsBody() : {
+    JsonFunction result = new JsonFunction(JsonFunctionType.EXISTS);
+    JsonFunctionExpression inputExpression;
+    Expression expression;
+    JsonFunction.JsonOnResponseBehavior behavior;
+}
+{
+    "("
+    inputExpression = JsonValueOrQueryInputExpression() { result.setInputExpression(inputExpression); }
+    ","
+    expression = Expression() { result.setJsonPathExpression(expression); }
+
+    [
+        LOOKAHEAD({ getToken(1).kind == S_IDENTIFIER && getToken(1).image.equalsIgnoreCase("PASSING") })
+        JsonKeyword("PASSING")
+        expression = Expression() { result.addPassingExpression(expression); }
+        ( "," expression = Expression() { result.addPassingExpression(expression); } )*
+    ]
+
+    [
+        LOOKAHEAD( JsonExistsOnResponseBehavior() <K_ON> <K_ERROR> )
+        behavior = JsonExistsOnResponseBehavior()
+        <K_ON> <K_ERROR>
+        { result.setOnErrorBehavior(behavior); }
+    ]
+    ")"
+    {
+        return result;
+    }
+}
+
+JsonFunction JsonValueBody() : {
+    JsonFunction result = new JsonFunction(JsonFunctionType.VALUE);
+    JsonFunctionExpression inputExpression;
+    Expression expression;
+    ColDataType dataType;
+    JsonFunction.JsonOnResponseBehavior behavior;
+}
+{
+    "("
+    inputExpression = JsonValueOrQueryInputExpression() { result.setInputExpression(inputExpression); }
+    ","
+    expression = Expression() { result.setJsonPathExpression(expression); }
+
+    [
+        LOOKAHEAD({ getToken(1).kind == S_IDENTIFIER && getToken(1).image.equalsIgnoreCase("PASSING") })
+        JsonKeyword("PASSING")
+        expression = Expression() { result.addPassingExpression(expression); }
+        ( "," expression = Expression() { result.addPassingExpression(expression); } )*
+    ]
+
+    [ <K_RETURNING> dataType = ColDataType() { result.setReturningType(dataType); } ]
+
+    [
+        LOOKAHEAD( JsonValueOnResponseBehavior() <K_ON> <S_IDENTIFIER> )
+        behavior = JsonValueOnResponseBehavior()
+        <K_ON> JsonKeyword("EMPTY")
+        { result.setOnEmptyBehavior(behavior); }
+    ]
+
+    [
+        LOOKAHEAD( JsonValueOnResponseBehavior() <K_ON> <K_ERROR> )
+        behavior = JsonValueOnResponseBehavior()
+        <K_ON> <K_ERROR>
+        { result.setOnErrorBehavior(behavior); }
+    ]
+    ")"
+    {
+        return result;
+    }
+}
+
+JsonFunction JsonQueryBody() : {
+    JsonFunction result = new JsonFunction(JsonFunctionType.QUERY);
+    JsonFunctionExpression inputExpression;
+    Expression expression;
+    ColDataType dataType;
+    JsonFunction.JsonOnResponseBehavior behavior;
+    Token token;
+    String encoding;
+    ColDataType additionalReturningType;
+    boolean additionalReturningFormatJson;
+    String additionalReturningEncoding;
+    JsonFunction.JsonWrapperType additionalWrapperType;
+    JsonFunction.JsonWrapperMode additionalWrapperMode;
+    boolean additionalWrapperArray;
+    JsonFunction.JsonQuotesType additionalQuotesType;
+    boolean additionalQuotesOnScalarString;
+    JsonFunction.JsonOnResponseBehavior additionalOnEmptyBehavior;
+    JsonFunction.JsonOnResponseBehavior additionalOnErrorBehavior;
+    StringBuilder additionalBuilder;
+}
+{
+    "("
+    inputExpression = JsonValueOrQueryInputExpression() { result.setInputExpression(inputExpression); }
+    ","
+    expression = Expression() { result.setJsonPathExpression(expression); }
+
+    [
+        LOOKAHEAD({ getToken(1).kind == S_IDENTIFIER && getToken(1).image.equalsIgnoreCase("PASSING") })
+        JsonKeyword("PASSING")
+        expression = Expression() { result.addPassingExpression(expression); }
+        ( "," expression = Expression() { result.addPassingExpression(expression); } )*
+    ]
+
+    [
+        <K_RETURNING> dataType = ColDataType() { result.setReturningType(dataType); }
+        [
+            <K_FORMAT> <K_JSON> { result.setReturningFormatJson(true); }
+            [ <K_ENCODING> encoding = JsonEncoding() { result.setReturningEncoding(encoding); } ]
+        ]
+    ]
+
+    [
+        (
+            <K_WITHOUT> { result.setWrapperType(JsonFunction.JsonWrapperType.WITHOUT); }
+            [ <K_ARRAY_LITERAL> { result.setWrapperArray(true); } ]
+            JsonKeyword("WRAPPER")
+            |
+            <K_WITH> { result.setWrapperType(JsonFunction.JsonWrapperType.WITH); }
+            [
+                LOOKAHEAD({
+                    getToken(1).kind == S_IDENTIFIER
+                        && (getToken(1).image.equalsIgnoreCase("CONDITIONAL")
+                            || getToken(1).image.equalsIgnoreCase("UNCONDITIONAL"))
+                })
+                token = <S_IDENTIFIER>
+                {
+                    if (token.image.equalsIgnoreCase("CONDITIONAL")) {
+                        result.setWrapperMode(JsonFunction.JsonWrapperMode.CONDITIONAL);
+                    } else {
+                        result.setWrapperMode(JsonFunction.JsonWrapperMode.UNCONDITIONAL);
+                    }
+                }
+            ]
+            [ <K_ARRAY_LITERAL> { result.setWrapperArray(true); } ]
+            JsonKeyword("WRAPPER")
+        )
+    ]
+
+    [
+        LOOKAHEAD({
+            getToken(1).kind == K_KEEP
+                || (getToken(1).kind == S_IDENTIFIER
+                    && getToken(1).image.equalsIgnoreCase("OMIT"))
+        })
+        (
+            <K_KEEP> { result.setQuotesType(JsonFunction.JsonQuotesType.KEEP); }
+            |
+            JsonKeyword("OMIT") { result.setQuotesType(JsonFunction.JsonQuotesType.OMIT); }
+        )
+        JsonKeyword("QUOTES")
+        [
+            <K_ON> JsonKeyword("SCALAR") <K_STRING>
+            { result.setQuotesOnScalarString(true); }
+        ]
+    ]
+
+    [
+        LOOKAHEAD( JsonQueryOnResponseBehavior() <K_ON> <S_IDENTIFIER> )
+        behavior = JsonQueryOnResponseBehavior()
+        <K_ON> JsonKeyword("EMPTY")
+        { result.setOnEmptyBehavior(behavior); }
+    ]
+
+    [
+        LOOKAHEAD( JsonQueryOnResponseBehavior() <K_ON> <K_ERROR> )
+        behavior = JsonQueryOnResponseBehavior()
+        <K_ON> <K_ERROR>
+        { result.setOnErrorBehavior(behavior); }
+    ]
+
+    (
+        ","
+        {
+            additionalReturningType = null;
+            additionalReturningFormatJson = false;
+            additionalReturningEncoding = null;
+            additionalWrapperType = null;
+            additionalWrapperMode = null;
+            additionalWrapperArray = false;
+            additionalQuotesType = null;
+            additionalQuotesOnScalarString = false;
+            additionalOnEmptyBehavior = null;
+            additionalOnErrorBehavior = null;
+        }
+        expression = Expression()
+        [
+            <K_RETURNING> additionalReturningType = ColDataType()
+            [
+                <K_FORMAT> <K_JSON> { additionalReturningFormatJson = true; }
+                [ <K_ENCODING> additionalReturningEncoding = JsonEncoding() ]
+            ]
+        ]
+        [
+            (
+                <K_WITHOUT>
+                { additionalWrapperType = JsonFunction.JsonWrapperType.WITHOUT; }
+                [ <K_ARRAY_LITERAL> { additionalWrapperArray = true; } ]
+                JsonKeyword("WRAPPER")
+                |
+                <K_WITH>
+                { additionalWrapperType = JsonFunction.JsonWrapperType.WITH; }
+                [
+                    LOOKAHEAD({
+                        getToken(1).kind == S_IDENTIFIER
+                            && (getToken(1).image.equalsIgnoreCase("CONDITIONAL")
+                                || getToken(1).image.equalsIgnoreCase("UNCONDITIONAL"))
+                    })
+                    token = <S_IDENTIFIER>
+                    {
+                        if (token.image.equalsIgnoreCase("CONDITIONAL")) {
+                            additionalWrapperMode = JsonFunction.JsonWrapperMode.CONDITIONAL;
+                        } else {
+                            additionalWrapperMode = JsonFunction.JsonWrapperMode.UNCONDITIONAL;
+                        }
+                    }
+                ]
+                [ <K_ARRAY_LITERAL> { additionalWrapperArray = true; } ]
+                JsonKeyword("WRAPPER")
+            )
+        ]
+        [
+            LOOKAHEAD({
+                getToken(1).kind == K_KEEP
+                    || (getToken(1).kind == S_IDENTIFIER
+                        && getToken(1).image.equalsIgnoreCase("OMIT"))
+            })
+            (
+                <K_KEEP> { additionalQuotesType = JsonFunction.JsonQuotesType.KEEP; }
+                |
+                JsonKeyword("OMIT") { additionalQuotesType = JsonFunction.JsonQuotesType.OMIT; }
+            )
+            JsonKeyword("QUOTES")
+            [
+                <K_ON> JsonKeyword("SCALAR") <K_STRING> { additionalQuotesOnScalarString = true; }
+            ]
+        ]
+        [
+            LOOKAHEAD( JsonQueryOnResponseBehavior() <K_ON> <S_IDENTIFIER> )
+            additionalOnEmptyBehavior = JsonQueryOnResponseBehavior()
+            <K_ON> JsonKeyword("EMPTY")
+        ]
+        [
+            LOOKAHEAD( JsonQueryOnResponseBehavior() <K_ON> <K_ERROR> )
+            additionalOnErrorBehavior = JsonQueryOnResponseBehavior()
+            <K_ON> <K_ERROR>
+        ]
+        {
+            additionalBuilder = new StringBuilder();
+            additionalBuilder.append(expression);
+            if (additionalReturningType != null) {
+                additionalBuilder.append(" RETURNING ").append(additionalReturningType);
+                if (additionalReturningFormatJson) {
+                    additionalBuilder.append(" FORMAT JSON");
+                    if (additionalReturningEncoding != null) {
+                        additionalBuilder.append(" ENCODING ").append(additionalReturningEncoding);
+                    }
+                }
+            }
+            if (additionalWrapperType != null) {
+                additionalBuilder.append(" ").append(additionalWrapperType);
+                if (additionalWrapperMode != null) {
+                    additionalBuilder.append(" ").append(additionalWrapperMode);
+                }
+                if (additionalWrapperArray) {
+                    additionalBuilder.append(" ARRAY");
+                }
+                additionalBuilder.append(" WRAPPER");
+            }
+            if (additionalQuotesType != null) {
+                additionalBuilder.append(" ").append(additionalQuotesType).append(" QUOTES");
+                if (additionalQuotesOnScalarString) {
+                    additionalBuilder.append(" ON SCALAR STRING");
+                }
+            }
+            if (additionalOnEmptyBehavior != null) {
+                additionalBuilder.append(" ").append(additionalOnEmptyBehavior).append(" ON EMPTY");
+            }
+            if (additionalOnErrorBehavior != null) {
+                additionalBuilder.append(" ").append(additionalOnErrorBehavior).append(" ON ERROR");
+            }
+            result.addAdditionalQueryPathArgument(additionalBuilder.toString());
+        }
+    )*
+    ")"
     {
         return result;
     }
@@ -7169,6 +7658,33 @@ JsonFunction JsonFunction() : {
       ( <K_JSON_OBJECT> result = JsonObjectBody() )
       |
       ( <K_JSON_ARRAY> result = JsonArrayBody() )
+      |
+      (
+          LOOKAHEAD({
+              getToken(1).kind == S_IDENTIFIER
+                  && getToken(1).image.equalsIgnoreCase("JSON_VALUE")
+          })
+          JsonKeyword("JSON_VALUE")
+          result = JsonValueBody()
+      )
+      |
+      (
+          LOOKAHEAD({
+              getToken(1).kind == S_IDENTIFIER
+                  && getToken(1).image.equalsIgnoreCase("JSON_QUERY")
+          })
+          JsonKeyword("JSON_QUERY")
+          result = JsonQueryBody()
+      )
+      |
+      (
+          LOOKAHEAD({
+              getToken(1).kind == S_IDENTIFIER
+                  && getToken(1).image.equalsIgnoreCase("JSON_EXISTS")
+          })
+          JsonKeyword("JSON_EXISTS")
+          result = JsonExistsBody()
+      )
     )
     {
         return result;
@@ -7927,16 +8443,386 @@ MySQLGroupConcat MySQLGroupConcat():{
     }
 }
 
+JsonTableFunction.JsonTablePassingClause JsonTablePassingClause() : {
+    Expression valueExpression;
+    String parameterName;
+}
+{
+    valueExpression = Expression()
+    <K_AS>
+    parameterName = RelObjectName()
+    {
+        return new JsonTableFunction.JsonTablePassingClause(valueExpression, parameterName);
+    }
+}
+
+JsonFunction.JsonOnResponseBehavior JsonTableOnEmptyBehavior() : {
+    JsonFunction.JsonOnResponseBehavior behavior = null;
+    Expression expression;
+    Token token;
+}
+{
+    (
+        <K_ERROR>
+        {
+            behavior = new JsonFunction.JsonOnResponseBehavior(
+                    JsonFunction.JsonOnResponseBehaviorType.ERROR);
+        }
+        |
+        <K_NULL>
+        {
+            behavior = new JsonFunction.JsonOnResponseBehavior(
+                    JsonFunction.JsonOnResponseBehaviorType.NULL);
+        }
+        |
+        <K_DEFAULT> expression = Expression()
+        {
+            behavior = new JsonFunction.JsonOnResponseBehavior(
+                    JsonFunction.JsonOnResponseBehaviorType.DEFAULT, expression);
+        }
+        |
+        token = <S_IDENTIFIER>
+        {
+            if (!token.image.equalsIgnoreCase("EMPTY")) {
+                throw new ParseException(
+                        "Expected EMPTY, ERROR, NULL or DEFAULT but found " + token.image);
+            }
+        }
+        (
+            LOOKAHEAD({ getToken(1).kind == S_IDENTIFIER && getToken(1).image.equalsIgnoreCase("OBJECT") })
+            JsonKeyword("OBJECT")
+            {
+                behavior = new JsonFunction.JsonOnResponseBehavior(
+                        JsonFunction.JsonOnResponseBehaviorType.EMPTY_OBJECT);
+            }
+            |
+            [ <K_ARRAY_LITERAL> ]
+            {
+                behavior = new JsonFunction.JsonOnResponseBehavior(
+                        JsonFunction.JsonOnResponseBehaviorType.EMPTY_ARRAY);
+            }
+        )
+    )
+    {
+        if (behavior != null) {
+            return behavior;
+        }
+    }
+}
+
+JsonTableFunction.JsonTableWrapperClause JsonTableWrapperClause() : {
+    JsonTableFunction.JsonTableWrapperClause wrapperClause =
+            new JsonTableFunction.JsonTableWrapperClause();
+    Token token;
+}
+{
+    (
+        <K_WITHOUT> {
+            wrapperClause.setWrapperType(JsonFunction.JsonWrapperType.WITHOUT);
+        }
+        |
+        <K_WITH> {
+            wrapperClause.setWrapperType(JsonFunction.JsonWrapperType.WITH);
+        }
+        [
+            LOOKAHEAD({
+                getToken(1).kind == S_IDENTIFIER
+                    && (getToken(1).image.equalsIgnoreCase("CONDITIONAL")
+                        || getToken(1).image.equalsIgnoreCase("UNCONDITIONAL"))
+            })
+            token = <S_IDENTIFIER>
+            {
+                if (token.image.equalsIgnoreCase("CONDITIONAL")) {
+                    wrapperClause.setWrapperMode(JsonFunction.JsonWrapperMode.CONDITIONAL);
+                } else {
+                    wrapperClause.setWrapperMode(JsonFunction.JsonWrapperMode.UNCONDITIONAL);
+                }
+            }
+        ]
+    )
+    [ <K_ARRAY_LITERAL> { wrapperClause.setArray(true); } ]
+    JsonKeyword("WRAPPER")
+    {
+        return wrapperClause;
+    }
+}
+
+JsonTableFunction.JsonTableQuotesClause JsonTableQuotesClause() : {
+    JsonTableFunction.JsonTableQuotesClause quotesClause =
+            new JsonTableFunction.JsonTableQuotesClause();
+}
+{
+    (
+        <K_KEEP> { quotesClause.setQuotesType(JsonFunction.JsonQuotesType.KEEP); }
+        |
+        JsonKeyword("OMIT") { quotesClause.setQuotesType(JsonFunction.JsonQuotesType.OMIT); }
+    )
+    JsonKeyword("QUOTES")
+    [
+        <K_ON> JsonKeyword("SCALAR") <K_STRING> { quotesClause.setOnScalarString(true); }
+    ]
+    {
+        return quotesClause;
+    }
+}
+
+JsonTableFunction.JsonTableColumnDefinition JsonTableColumnDefinition() : {
+    JsonTableFunction.JsonTableColumnDefinition columnDefinition = null;
+    JsonTableFunction.JsonTableNestedColumnDefinition nestedColumnDefinition;
+    JsonTableFunction.JsonTableValueColumnDefinition valueColumnDefinition;
+    String columnName;
+    ColDataType dataType;
+    Expression expression;
+    String pathName = null;
+    JsonTableFunction.JsonTableColumnsClause columnsClause;
+    JsonFunction.JsonOnResponseBehavior behavior;
+    JsonTableFunction.JsonTableWrapperClause wrapperClause;
+    JsonTableFunction.JsonTableQuotesClause quotesClause;
+    String encoding;
+}
+{
+    (
+        LOOKAHEAD({ getToken(1).kind == S_IDENTIFIER && getToken(1).image.equalsIgnoreCase("NESTED") })
+        JsonKeyword("NESTED")
+        { nestedColumnDefinition = new JsonTableFunction.JsonTableNestedColumnDefinition(); }
+        [ <K_PATH> { nestedColumnDefinition.setPathKeyword(true); } ]
+        expression = Expression() { nestedColumnDefinition.setPathExpression(expression); }
+        [ <K_AS> pathName = RelObjectName() { nestedColumnDefinition.setPathName(pathName); } ]
+        columnsClause = JsonTableColumnsClause() {
+            nestedColumnDefinition.setColumnsClause(columnsClause);
+            columnDefinition = nestedColumnDefinition;
+        }
+        |
+        columnName = RelObjectName() {
+            valueColumnDefinition = new JsonTableFunction.JsonTableValueColumnDefinition();
+            valueColumnDefinition.setColumnName(columnName);
+            columnDefinition = valueColumnDefinition;
+        }
+        (
+            <K_FOR> JsonKeyword("ORDINALITY")
+            { valueColumnDefinition.setForOrdinality(true); }
+            |
+            dataType = ColDataType() { valueColumnDefinition.setDataType(dataType); }
+            [
+                <K_FORMAT> <K_JSON> { valueColumnDefinition.setFormatJson(true); }
+                [ <K_ENCODING> encoding = JsonEncoding() { valueColumnDefinition.setEncoding(encoding); } ]
+            ]
+            [ <K_PATH> expression = Expression() { valueColumnDefinition.setPathExpression(expression); } ]
+            [ wrapperClause = JsonTableWrapperClause() { valueColumnDefinition.setWrapperClause(wrapperClause); } ]
+            [
+                LOOKAHEAD({
+                    getToken(1).kind == K_KEEP
+                        || (getToken(1).kind == S_IDENTIFIER
+                            && getToken(1).image.equalsIgnoreCase("OMIT"))
+                })
+                quotesClause = JsonTableQuotesClause() { valueColumnDefinition.setQuotesClause(quotesClause); }
+            ]
+            [
+                LOOKAHEAD( JsonTableOnEmptyBehavior() <K_ON> <S_IDENTIFIER> )
+                behavior = JsonTableOnEmptyBehavior()
+                <K_ON> JsonKeyword("EMPTY")
+                { valueColumnDefinition.setOnEmptyBehavior(behavior); }
+            ]
+            [
+                LOOKAHEAD( JsonValueOnResponseBehavior() <K_ON> <K_ERROR> )
+                behavior = JsonValueOnResponseBehavior()
+                <K_ON> <K_ERROR>
+                { valueColumnDefinition.setOnErrorBehavior(behavior); }
+            ]
+        )
+    )
+    {
+        return columnDefinition;
+    }
+}
+
+JsonTableFunction.JsonTableColumnsClause JsonTableColumnsClause() : {
+    JsonTableFunction.JsonTableColumnsClause columnsClause =
+            new JsonTableFunction.JsonTableColumnsClause();
+    JsonTableFunction.JsonTableColumnDefinition columnDefinition;
+}
+{
+    <K_COLUMNS> "("
+    [
+        columnDefinition = JsonTableColumnDefinition() {
+            columnsClause.addColumnDefinition(columnDefinition);
+        }
+        (
+            ","
+            columnDefinition = JsonTableColumnDefinition() {
+                columnsClause.addColumnDefinition(columnDefinition);
+            }
+        )*
+    ]
+    ")"
+    {
+        return columnsClause;
+    }
+}
+
+JsonTableFunction.JsonTablePlanTerm JsonTablePlanTerm() : {
+    JsonTableFunction.JsonTablePlanTerm term = null;
+    String value;
+    Expression expression;
+    JsonTableFunction.JsonTablePlanExpression nestedPlanExpression;
+}
+{
+    (
+        LOOKAHEAD(2)
+        "(" nestedPlanExpression = JsonTablePlanExpression() ")" {
+            term = new JsonTableFunction.JsonTablePlanTerm();
+            term.setNestedPlanExpression(nestedPlanExpression);
+        }
+        |
+        value = RelObjectName() {
+            term = new JsonTableFunction.JsonTablePlanTerm();
+            term.setName(value);
+        }
+        |
+        expression = Expression() {
+            term = new JsonTableFunction.JsonTablePlanTerm();
+            term.setExpression(expression);
+        }
+    )
+    {
+        return term;
+    }
+}
+
+JsonTableFunction.JsonTablePlanExpression JsonTablePlanExpression() : {
+    JsonTableFunction.JsonTablePlanExpression planExpression =
+            new JsonTableFunction.JsonTablePlanExpression();
+    JsonTableFunction.JsonTablePlanTerm term;
+    Token operator = null;
+}
+{
+    term = JsonTablePlanTerm() { planExpression.addTerm(term); }
+    (
+        (
+            operator = <K_COMMA> {
+                planExpression.addOperator(JsonTableFunction.JsonTablePlanOperator.COMMA);
+            }
+            |
+            operator = <K_INNER> {
+                planExpression.addOperator(JsonTableFunction.JsonTablePlanOperator.INNER);
+            }
+            |
+            operator = <K_OUTER> {
+                planExpression.addOperator(JsonTableFunction.JsonTablePlanOperator.OUTER);
+            }
+            |
+            operator = <K_CROSS> {
+                planExpression.addOperator(JsonTableFunction.JsonTablePlanOperator.CROSS);
+            }
+            |
+            operator = <K_UNION> {
+                planExpression.addOperator(JsonTableFunction.JsonTablePlanOperator.UNION);
+            }
+        )
+        term = JsonTablePlanTerm() { planExpression.addTerm(term); }
+    )*
+    {
+        return planExpression;
+    }
+}
+
+JsonTableFunction.JsonTablePlanClause JsonTablePlanClause() : {
+    JsonTableFunction.JsonTablePlanClause planClause =
+            new JsonTableFunction.JsonTablePlanClause();
+    JsonTableFunction.JsonTablePlanExpression planExpression;
+}
+{
+    <K_PLAN>
+    [ <K_DEFAULT> { planClause.setDefaultPlan(true); } ]
+    "(" planExpression = JsonTablePlanExpression() ")" { planClause.setPlanExpression(planExpression); }
+    {
+        return planClause;
+    }
+}
+
+JsonTableFunction.JsonTableOnErrorClause JsonTableOnErrorClause() : {
+    JsonTableFunction.JsonTableOnErrorClause onErrorClause =
+            new JsonTableFunction.JsonTableOnErrorClause();
+    Token token;
+}
+{
+    (
+        <K_ERROR> { onErrorClause.setType(JsonTableFunction.JsonTableOnErrorType.ERROR); }
+        |
+        token = <S_IDENTIFIER>
+        {
+            if (!token.image.equalsIgnoreCase("EMPTY")) {
+                throw new ParseException(
+                        "Expected EMPTY or ERROR but found " + token.image);
+            }
+            onErrorClause.setType(JsonTableFunction.JsonTableOnErrorType.EMPTY);
+        }
+    )
+    <K_ON> <K_ERROR>
+    {
+        if (onErrorClause.getType() != null) {
+            return onErrorClause;
+        }
+    }
+}
+
+JsonTableFunction JsonTableBody() : {
+    JsonTableFunction function = new JsonTableFunction();
+    Expression jsonInput;
+    Expression jsonPath;
+    JsonTableFunction.JsonTablePassingClause passingClause;
+    String pathName = null;
+    JsonTableFunction.JsonTableColumnsClause columnsClause;
+    JsonTableFunction.JsonTablePlanClause planClause = null;
+    JsonTableFunction.JsonTableOnErrorClause onErrorClause = null;
+}
+{
+    "("
+    jsonInput = Expression() {
+        function.setJsonInputExpression(jsonInput);
+    }
+    ","
+    jsonPath = Expression() {
+        function.setJsonPathExpression(jsonPath);
+        function.setParameters(new ExpressionList(jsonInput, jsonPath));
+    }
+    [ <K_AS> pathName = RelObjectName() { function.setPathName(pathName); } ]
+    [
+        LOOKAHEAD({ getToken(1).kind == S_IDENTIFIER && getToken(1).image.equalsIgnoreCase("PASSING") })
+        JsonKeyword("PASSING")
+        passingClause = JsonTablePassingClause() { function.addPassingClause(passingClause); }
+        (
+            ","
+            passingClause = JsonTablePassingClause() { function.addPassingClause(passingClause); }
+        )*
+    ]
+    columnsClause = JsonTableColumnsClause() { function.setColumnsClause(columnsClause); }
+    [ planClause = JsonTablePlanClause() { function.setPlanClause(planClause); } ]
+    [ onErrorClause = JsonTableOnErrorClause() { function.setOnErrorClause(onErrorClause); } ]
+    ")"
+    {
+        return function;
+    }
+}
+
 TableFunction TableFunction():
 {
     Token prefix = null;
     Function function;
-    TableFunction functionItem;
     Token withClause = null;
 }
 {
     [ prefix = <K_LATERAL> ]
-    function=Function()
+    (
+        LOOKAHEAD({
+            getToken(1).kind == S_IDENTIFIER
+                && getToken(1).image.equalsIgnoreCase("JSON_TABLE")
+        })
+        JsonKeyword("JSON_TABLE")
+        function = JsonTableBody()
+        |
+        function=Function()
+    )
     [ LOOKAHEAD(2) <K_WITH> ( withClause = <K_OFFSET> | withClause = <K_ORDINALITY> ) ]
     {
         return  prefix!=null

--- a/src/test/resources/simple_parsing.txt
+++ b/src/test/resources/simple_parsing.txt
@@ -249,3 +249,236 @@ WITH
     RETURNS double
     RETURN x[1] + x[2] + x[3]
 SELECT takesArray(array[1.0, 2.0, 3.0]);
+
+SELECT
+      id,
+      json_exists(
+                  description,
+                  'lax $.children[*]?(@ > 10)'
+                 ) AS children_above_ten
+FROM customers;
+
+SELECT
+      id,
+      json_exists(
+                  description,
+                  'strict $.children[2]?(@ > 10)'
+                  UNKNOWN ON ERROR
+                 ) AS child_3_above_ten
+FROM customers;
+
+SELECT
+      id,
+      json_query(
+                 description,
+                 'lax $.children'
+                ) AS children
+FROM customers;
+
+SELECT
+      id,
+      json_query(
+                 description,
+                 'lax $.children[*]'
+                 WITHOUT ARRAY WRAPPER
+                 NULL ON ERROR
+                ) AS children
+FROM customers;
+
+SELECT
+      id,
+      json_query(
+                 description,
+                 'lax $.children[last]'
+                 WITH ARRAY WRAPPER
+                ) AS last_child
+FROM customers;
+
+SELECT
+      id,
+      json_query(
+                 description,
+                 'strict $.children[*]?(@ > 12)'
+                 WITH ARRAY WRAPPER
+                 EMPTY ARRAY ON EMPTY
+                ) AS children
+FROM customers;
+
+SELECT
+      id,
+      json_query(description, 'strict $.comment' KEEP QUOTES) AS quoted_comment,
+      json_query(description, 'strict $.comment' OMIT QUOTES) AS unquoted_comment
+FROM customers;
+
+SELECT id, json_value(
+                      description,
+                      'lax $.comment'
+                      RETURNING char(12)
+                     ) AS comment
+FROM customers;
+
+SELECT id, json_value(
+                      description,
+                      'lax $.children[0]'
+                      RETURNING tinyint
+                     ) AS child
+FROM customers;
+
+SELECT id, json_value(
+                      description,
+                      'strict $.children[2]'
+                      DEFAULT 'err' ON ERROR
+                     ) AS child
+FROM customers;
+
+SELECT id, json_value(
+                      description,
+                      'lax $.children[2]'
+                      DEFAULT 'missing' ON EMPTY
+                     ) AS child
+FROM customers;
+
+SELECT
+      *
+FROM
+      json_table(
+                '[
+                  {"id":1,"name":"Africa","wikiDataId":"Q15"},
+                  {"id":2,"name":"Americas","wikiDataId":"Q828"},
+                  {"id":3,"name":"Asia","wikiDataId":"Q48"},
+                  {"id":4,"name":"Europe","wikiDataId":"Q51"}
+                ]',
+                'strict $' COLUMNS (
+                  NESTED PATH 'strict $[*]' COLUMNS (
+                    id integer PATH 'strict $.id',
+                    name varchar PATH 'strict $.name',
+                    wiki_data_id varchar PATH 'strict $."wikiDataId"'
+                  )
+                )
+              );
+
+SELECT
+      *
+FROM
+      json_table(
+                '[
+                    {"continent": "Asia", "countries": [
+                        {"name": "Japan", "population": 125.7},
+                        {"name": "Thailand", "population": 71.6}
+                    ]},
+                    {"continent": "Europe", "countries": [
+                        {"name": "France", "population": 67.4},
+                        {"name": "Germany", "population": 83.2}
+                    ]}
+                ]',
+                'lax $' COLUMNS (
+                    NESTED PATH 'lax $[*]' COLUMNS (
+                        continent varchar PATH 'lax $.continent',
+                        NESTED PATH 'lax $.countries[*]' COLUMNS (
+                            country varchar PATH 'lax $.name',
+                            population double PATH 'lax $.population'
+                        )
+                    )
+                ));
+
+SELECT
+      *
+FROM
+      JSON_TABLE(
+                '[]',
+                'lax $' AS "root_path"
+                COLUMNS(
+                    a varchar(1) PATH 'lax "A"',
+                    NESTED PATH 'lax $[*]' AS "nested_path"
+                            COLUMNS (b varchar(1) PATH 'lax "B"'))
+                PLAN ("root_path" OUTER "nested_path")
+                );
+
+SELECT
+      *
+FROM
+      JSON_TABLE(
+                '[]',
+                'lax $' AS "root_path"
+                COLUMNS(
+                    a varchar(1) PATH 'lax "A"',
+                    NESTED PATH 'lax $[*]' AS "nested_path"
+                            COLUMNS (b varchar(1) PATH 'lax "B"'))
+                PLAN ("root_path" INNER "nested_path")
+                );
+
+SELECT json_array(true, 12e-1, 'text');
+
+SELECT json_array(
+                  '[  "text"  ] ' FORMAT JSON,
+                  X'5B0035005D00' FORMAT JSON ENCODING UTF16
+                 );
+
+SELECT json_array(
+                  json_query('{"key" : [  "value"  ]}', 'lax $.key')
+                 );
+
+SELECT json_array(
+                  DATE '2001-01-31',
+                  UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59'
+                 );
+
+SELECT json_array();
+
+SELECT json_array(true, null, 1);
+
+SELECT json_array(true, null, 1 ABSENT ON NULL);
+
+SELECT json_array(true, null, 1 NULL ON NULL);
+
+SELECT json_array(true, 1 RETURNING VARCHAR(100));
+
+SELECT json_array(true, 1 RETURNING VARBINARY);
+
+SELECT json_array(true, 1 RETURNING VARBINARY FORMAT JSON ENCODING UTF8);
+
+SELECT json_array(true, 1 RETURNING VARBINARY FORMAT JSON ENCODING UTF16);
+
+SELECT json_array(true, 1 RETURNING VARBINARY FORMAT JSON ENCODING UTF32);
+
+SELECT json_object('key1' : 1, 'key2' : true);
+
+SELECT json_object(KEY 'key1' VALUE 1, KEY 'key2' VALUE true);
+
+SELECT json_object('key1' VALUE 1, 'key2' VALUE true);
+
+SELECT json_object('x' : true, 'y' : 12e-1, 'z' : 'text');
+
+SELECT json_object(
+                   'x' : '[  "text"  ] ' FORMAT JSON,
+                   'y' : X'5B0035005D00' FORMAT JSON ENCODING UTF16
+                  );
+
+SELECT json_object(
+                   'x' : json_query('{"key" : [  "value"  ]}', 'lax $.key')
+                  );
+
+SELECT json_object(
+                   'x' : DATE '2001-01-31',
+                   'y' : UUID '12151fd2-7586-11e9-8f9e-2a86e4085a59'
+                  );
+
+SELECT json_object();
+
+SELECT json_object('x' : null, 'y' : 1);
+
+SELECT json_object('x' : null, 'y' : 1 NULL ON NULL);
+
+SELECT json_object('x' : null, 'y' : 1 ABSENT ON NULL);
+
+SELECT json_object('x' : null, 'x' : 1 WITH UNIQUE KEYS);
+
+SELECT json_object('x' : 1 RETURNING VARCHAR(100));
+
+SELECT json_object('x' : 1 RETURNING VARBINARY);
+
+SELECT json_object('x' : 1 RETURNING VARBINARY FORMAT JSON ENCODING UTF8);
+
+SELECT json_object('x' : 1 RETURNING VARBINARY FORMAT JSON ENCODING UTF16);
+
+SELECT json_object('x' : 1 RETURNING VARBINARY FORMAT JSON ENCODING UTF32);


### PR DESCRIPTION
Adding support for clauses in JSON Functions. Fixes #2368

Adds support for the extra clauses found in Trino's JSON functions https://trino.io/docs/current/functions/json.html#json-exists, and includes test cases for these extra functions directly taken from the documentations.

Before:
Result "net.sf.jsqlparser.benchmark.JSQLParserBenchmark.parseSQLStatements":
  34.858 ±(99.9%) 1.724 ms/op [Average]
  (min, avg, max) = (32.578, 34.858, 38.383), stdev = 2.302
  CI (99.9%): [33.133, 36.582] (assumes normal distribution)

After:
Result "net.sf.jsqlparser.benchmark.JSQLParserBenchmark.parseSQLStatements":
  36.154 ±(99.9%) 1.701 ms/op [Average]
  (min, avg, max) = (33.100, 36.154, 38.353), stdev = 2.271
  CI (99.9%): [34.453, 37.855] (assumes normal distribution)