### PR TITLE
Enhance FOR UPDATE support

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/ForUpdateClause.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/ForUpdateClause.java
@@ -1,0 +1,135 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2024 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.select;
+
+import java.util.List;
+import net.sf.jsqlparser.schema.Table;
+
+/**
+ * Represents a FOR UPDATE / FOR SHARE locking clause in a SELECT statement.
+ *
+ * <p>
+ * Supports all common SQL dialects:
+ * <ul>
+ * <li>{@code FOR UPDATE} – standard row locking</li>
+ * <li>{@code FOR UPDATE OF t1, t2} – table-specific locking (Oracle, PostgreSQL)</li>
+ * <li>{@code FOR UPDATE NOWAIT} – fail immediately if rows are locked (Oracle, PostgreSQL)</li>
+ * <li>{@code FOR UPDATE WAIT n} – wait up to n seconds (Oracle)</li>
+ * <li>{@code FOR UPDATE SKIP LOCKED} – skip locked rows (Oracle, PostgreSQL)</li>
+ * <li>{@code FOR SHARE} – shared row lock (PostgreSQL)</li>
+ * <li>{@code FOR KEY SHARE} – key-level shared lock (PostgreSQL)</li>
+ * <li>{@code FOR NO KEY UPDATE} – non-key exclusive lock (PostgreSQL)</li>
+ * </ul>
+ * </p>
+ */
+public class ForUpdateClause {
+
+    private ForMode mode;
+    private List<Table> tables;
+    private Wait wait;
+    private boolean noWait;
+    private boolean skipLocked;
+
+    public ForMode getMode() {
+        return mode;
+    }
+
+    public ForUpdateClause setMode(ForMode mode) {
+        this.mode = mode;
+        return this;
+    }
+
+    public List<Table> getTables() {
+        return tables;
+    }
+
+    public ForUpdateClause setTables(List<Table> tables) {
+        this.tables = tables;
+        return this;
+    }
+
+    /**
+     * Returns the first table from the OF clause, or {@code null} if none was specified.
+     *
+     * @return the first table, or {@code null}
+     */
+    public Table getFirstTable() {
+        return (tables != null && !tables.isEmpty()) ? tables.get(0) : null;
+    }
+
+    public Wait getWait() {
+        return wait;
+    }
+
+    public ForUpdateClause setWait(Wait wait) {
+        this.wait = wait;
+        return this;
+    }
+
+    public boolean isNoWait() {
+        return noWait;
+    }
+
+    public ForUpdateClause setNoWait(boolean noWait) {
+        this.noWait = noWait;
+        return this;
+    }
+
+    public boolean isSkipLocked() {
+        return skipLocked;
+    }
+
+    public ForUpdateClause setSkipLocked(boolean skipLocked) {
+        this.skipLocked = skipLocked;
+        return this;
+    }
+
+    /** Returns {@code true} when the mode is {@link ForMode#UPDATE}. */
+    public boolean isForUpdate() {
+        return mode == ForMode.UPDATE;
+    }
+
+    /** Returns {@code true} when the mode is {@link ForMode#SHARE}. */
+    public boolean isForShare() {
+        return mode == ForMode.SHARE;
+    }
+
+    /** Returns {@code true} when at least one table was listed in the OF clause. */
+    public boolean hasTableList() {
+        return tables != null && !tables.isEmpty();
+    }
+
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append(" FOR ").append(mode.getValue());
+        if (tables != null && !tables.isEmpty()) {
+            builder.append(" OF ");
+            for (int i = 0; i < tables.size(); i++) {
+                if (i > 0) {
+                    builder.append(", ");
+                }
+                builder.append(tables.get(i));
+            }
+        }
+        if (wait != null) {
+            builder.append(wait);
+        }
+        if (noWait) {
+            builder.append(" NOWAIT");
+        } else if (skipLocked) {
+            builder.append(" SKIP LOCKED");
+        }
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return appendTo(new StringBuilder()).toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/select/Select.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/Select.java
@@ -24,7 +24,7 @@ import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 
 public abstract class Select extends ASTNodeAccessImpl implements Statement, Expression, FromItem {
-    protected Table forUpdateTable = null;
+    protected List<Table> forUpdateTables = null;
     protected List<WithItem<?>> withItemsList;
     Limit limitBy;
     Limit limit;
@@ -40,6 +40,7 @@ public abstract class Select extends ASTNodeAccessImpl implements Statement, Exp
     private boolean skipLocked;
     private Wait wait;
     private boolean noWait = false;
+    private boolean forUpdateBeforeOrderBy = false;
     Alias alias;
     Pivot pivot;
     UnPivot unPivot;
@@ -291,12 +292,92 @@ public abstract class Select extends ASTNodeAccessImpl implements Statement, Exp
         this.forMode = forMode;
     }
 
+    /**
+     * Returns the first table from the {@code FOR UPDATE OF} clause, or {@code null} if no table
+     * was specified. Use {@link #getForUpdateTables()} to retrieve all tables.
+     *
+     * @return the first table, or {@code null}
+     */
     public Table getForUpdateTable() {
-        return this.forUpdateTable;
+        return (forUpdateTables != null && !forUpdateTables.isEmpty()) ? forUpdateTables.get(0)
+                : null;
     }
 
+    /**
+     * Sets a single table for the {@code FOR UPDATE OF} clause.
+     *
+     * @param forUpdateTable the table, or {@code null} to clear
+     */
     public void setForUpdateTable(Table forUpdateTable) {
-        this.forUpdateTable = forUpdateTable;
+        if (forUpdateTable == null) {
+            this.forUpdateTables = null;
+        } else {
+            this.forUpdateTables = new ArrayList<>();
+            this.forUpdateTables.add(forUpdateTable);
+        }
+    }
+
+    /**
+     * Returns the list of tables named in the {@code FOR UPDATE OF t1, t2, ...} clause, or
+     * {@code null} if no OF clause was present.
+     *
+     * @return list of tables, or {@code null}
+     */
+    public List<Table> getForUpdateTables() {
+        return forUpdateTables;
+    }
+
+    /**
+     * Sets the list of tables for the {@code FOR UPDATE OF t1, t2, ...} clause.
+     *
+     * @param forUpdateTables list of tables
+     */
+    public void setForUpdateTables(List<Table> forUpdateTables) {
+        this.forUpdateTables = forUpdateTables;
+    }
+
+    public Select withForUpdateTables(List<Table> forUpdateTables) {
+        this.setForUpdateTables(forUpdateTables);
+        return this;
+    }
+
+    /**
+     * Builds and returns a {@link ForUpdateClause} representing the current FOR UPDATE / FOR SHARE
+     * state of this SELECT, or {@code null} if no FOR clause is present.
+     *
+     * @return a {@link ForUpdateClause} view, or {@code null}
+     */
+    public ForUpdateClause getForUpdate() {
+        if (forMode == null) {
+            return null;
+        }
+        ForUpdateClause clause = new ForUpdateClause();
+        clause.setMode(forMode);
+        clause.setTables(forUpdateTables);
+        clause.setWait(wait);
+        clause.setNoWait(noWait);
+        clause.setSkipLocked(skipLocked);
+        return clause;
+    }
+
+    /**
+     * Returns {@code true} when the {@code FOR UPDATE} clause appears before the {@code ORDER BY}
+     * clause in the original SQL (non-standard ordering supported by some databases).
+     *
+     * @return {@code true} if FOR UPDATE precedes ORDER BY
+     */
+    public boolean isForUpdateBeforeOrderBy() {
+        return forUpdateBeforeOrderBy;
+    }
+
+    /**
+     * Indicates whether the {@code FOR UPDATE} clause precedes the {@code ORDER BY} clause in the
+     * SQL output.
+     *
+     * @param forUpdateBeforeOrderBy {@code true} to emit FOR UPDATE before ORDER BY
+     */
+    public void setForUpdateBeforeOrderBy(boolean forUpdateBeforeOrderBy) {
+        this.forUpdateBeforeOrderBy = forUpdateBeforeOrderBy;
     }
 
     /**
@@ -380,7 +461,9 @@ public abstract class Select extends ASTNodeAccessImpl implements Statement, Exp
 
         appendTo(builder, alias, null, pivot, unPivot);
 
-        builder.append(orderByToString(oracleSiblings, orderByElements));
+        if (!forUpdateBeforeOrderBy) {
+            builder.append(orderByToString(oracleSiblings, orderByElements));
+        }
 
         if (forClause != null) {
             forClause.appendTo(builder);
@@ -405,8 +488,14 @@ public abstract class Select extends ASTNodeAccessImpl implements Statement, Exp
             builder.append(" FOR ");
             builder.append(forMode.getValue());
 
-            if (getForUpdateTable() != null) {
-                builder.append(" OF ").append(forUpdateTable);
+            if (forUpdateTables != null && !forUpdateTables.isEmpty()) {
+                builder.append(" OF ");
+                for (int i = 0; i < forUpdateTables.size(); i++) {
+                    if (i > 0) {
+                        builder.append(", ");
+                    }
+                    builder.append(forUpdateTables.get(i));
+                }
             }
 
             if (wait != null) {
@@ -419,6 +508,10 @@ public abstract class Select extends ASTNodeAccessImpl implements Statement, Exp
             } else if (isSkipLocked()) {
                 builder.append(" SKIP LOCKED");
             }
+        }
+
+        if (forUpdateBeforeOrderBy) {
+            builder.append(orderByToString(oracleSiblings, orderByElements));
         }
 
         return builder;

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -335,7 +335,9 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
             unpivot.accept(this, context);
         }
 
-        deparseOrderByElementsClause(plainSelect, plainSelect.getOrderByElements());
+        if (!plainSelect.isForUpdateBeforeOrderBy()) {
+            deparseOrderByElementsClause(plainSelect, plainSelect.getOrderByElements());
+        }
 
         if (plainSelect.getForClause() != null) {
             plainSelect.getForClause().appendTo(builder);
@@ -363,8 +365,15 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
             builder.append(" FOR ");
             builder.append(plainSelect.getForMode().getValue());
 
-            if (plainSelect.getForUpdateTable() != null) {
-                builder.append(" OF ").append(plainSelect.getForUpdateTable());
+            List<Table> forUpdateTables = plainSelect.getForUpdateTables();
+            if (forUpdateTables != null && !forUpdateTables.isEmpty()) {
+                builder.append(" OF ");
+                for (int i = 0; i < forUpdateTables.size(); i++) {
+                    if (i > 0) {
+                        builder.append(", ");
+                    }
+                    builder.append(forUpdateTables.get(i));
+                }
             }
             if (plainSelect.getWait() != null) {
                 // wait's toString will do the formatting for us
@@ -375,6 +384,10 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
             } else if (plainSelect.isSkipLocked()) {
                 builder.append(" SKIP LOCKED");
             }
+        }
+
+        if (plainSelect.isForUpdateBeforeOrderBy()) {
+            deparseOrderByElementsClause(plainSelect, plainSelect.getOrderByElements());
         }
         if (plainSelect.getMySqlSelectIntoClause() != null
                 && plainSelect.getMySqlSelectIntoClause()

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/SelectValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/SelectValidator.java
@@ -101,6 +101,11 @@ public class SelectValidator extends AbstractValidator<SelectItem<?>>
 
                 validateOptionalFeature(c, plainSelect.getForUpdateTable(),
                         Feature.selectForUpdateOfTable);
+                if (plainSelect.getForUpdateTables() != null) {
+                    plainSelect.getForUpdateTables()
+                            .forEach(t -> validateOptionalFeature(c, t,
+                                    Feature.selectForUpdateOfTable));
+                }
                 validateOptionalFeature(c, plainSelect.getWait(), Feature.selectForUpdateWait);
                 validateFeature(c, plainSelect.isNoWait(), Feature.selectForUpdateNoWait);
                 validateFeature(c, plainSelect.isSkipLocked(), Feature.selectForUpdateSkipLocked);

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4958,6 +4958,7 @@ PlainSelect PlainSelect() #PlainSelect:
     List<Table> intoTables = null;
     MySqlSelectIntoClause mySqlSelectIntoClause = null;
     Table updateTable = null;
+    List<Table> updateTables = new ArrayList<Table>();
     Wait wait = null;
     boolean mySqlSqlCalcFoundRows = false;
     Token token;
@@ -5084,10 +5085,17 @@ PlainSelect PlainSelect() #PlainSelect:
             | (<K_READ> <K_ONLY> { plainSelect.setForMode(ForMode.READ_ONLY); })
             | (<K_FETCH> <K_ONLY> { plainSelect.setForMode(ForMode.FETCH_ONLY); })
             )
-        [ LOOKAHEAD(2) <K_OF> updateTable = Table() { plainSelect.setForUpdateTable(updateTable); } ]
+        [ LOOKAHEAD(2) <K_OF>
+            updateTable = Table() { updateTables.add(updateTable); }
+            ( LOOKAHEAD(2) "," updateTable = Table() { updateTables.add(updateTable); } )*
+            { plainSelect.setForUpdateTables(updateTables); }
+        ]
         [ LOOKAHEAD(<K_WAIT>) wait = Wait() { plainSelect.setWait(wait); } ]
         [ LOOKAHEAD(2) (<K_NOWAIT> { plainSelect.setNoWait(true); }
                | <K_SKIP> <K_LOCKED> { plainSelect.setSkipLocked(true); }) ]
+        [ LOOKAHEAD(<K_ORDER> <K_BY>) orderByElements = OrderByElements()
+            { plainSelect.setOrderByElements(orderByElements); plainSelect.setForUpdateBeforeOrderBy(true); }
+        ]
     ]
     [ LOOKAHEAD(<K_INTO> (<K_OUTFILE> | <K_DUMPFILE>))
         mySqlSelectIntoClause = MySqlSelectIntoClause(MySqlSelectIntoClause.Position.TRAILING)

--- a/src/test/java/net/sf/jsqlparser/statement/select/ForUpdateTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/ForUpdateTest.java
@@ -10,8 +10,12 @@
 package net.sf.jsqlparser.statement.select;
 
 import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.test.TestUtils;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ForUpdateTest {
 
@@ -43,5 +47,102 @@ public class ForUpdateTest {
         String sqlStr = "select * from t_demo where a = 1 order by b asc limit 1 for update";
 
         TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+    }
+
+    @Test
+    void testForUpdateMultipleTables() throws JSQLParserException {
+        String sqlStr =
+                "select employee_id from (select employee_id+1 as employee_id from employees)"
+                        + " for update of a, b.c, d skip locked";
+
+        Statement stmt = TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        PlainSelect plainSelect = (PlainSelect) stmt;
+
+        assertThat(plainSelect.getForMode()).isEqualTo(ForMode.UPDATE);
+        assertThat(plainSelect.getForUpdateTables()).hasSize(3);
+        assertThat(plainSelect.isSkipLocked()).isTrue();
+
+        ForUpdateClause forUpdate = plainSelect.getForUpdate();
+        assertThat(forUpdate).isNotNull();
+        assertThat(forUpdate.isForUpdate()).isTrue();
+        assertThat(forUpdate.getTables()).hasSize(3);
+        assertThat(forUpdate.isSkipLocked()).isTrue();
+    }
+
+    @Test
+    void testForUpdateOrderByAfter() throws JSQLParserException {
+        String sqlStr =
+                "select su.ttype, su.cid, su.s_id, sessiontimezone from sku su"
+                        + " where (nvl(su.up, 'n') = 'n' and su.ttype = :b0)"
+                        + " for update of su.up order by su.d";
+
+        Statement stmt = TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        PlainSelect plainSelect = (PlainSelect) stmt;
+
+        assertThat(plainSelect.getForMode()).isEqualTo(ForMode.UPDATE);
+        assertThat(plainSelect.getForUpdateTables()).hasSize(1);
+        assertThat(plainSelect.getOrderByElements()).hasSize(1);
+        assertThat(plainSelect.isForUpdateBeforeOrderBy()).isTrue();
+    }
+
+    @Test
+    void testForUpdateDetection() throws JSQLParserException {
+        Statement stmt = CCJSqlParserUtil.parse("SELECT * FROM users FOR UPDATE");
+        PlainSelect plainSelect = (PlainSelect) stmt;
+
+        // ForMode is set for FOR UPDATE
+        assertThat(plainSelect.getForMode()).isEqualTo(ForMode.UPDATE);
+
+        // getForUpdate() returns a ForUpdateClause
+        ForUpdateClause forUpdate = plainSelect.getForUpdate();
+        assertThat(forUpdate).isNotNull();
+        assertThat(forUpdate.isForUpdate()).isTrue();
+        assertThat(forUpdate.isForShare()).isFalse();
+        assertThat(forUpdate.getTables()).isNull();
+    }
+
+    @Test
+    void testForShare() throws JSQLParserException {
+        Statement stmt = CCJSqlParserUtil.parse("SELECT * FROM users FOR SHARE");
+        PlainSelect plainSelect = (PlainSelect) stmt;
+
+        assertThat(plainSelect.getForMode()).isEqualTo(ForMode.SHARE);
+
+        ForUpdateClause forUpdate = plainSelect.getForUpdate();
+        assertThat(forUpdate).isNotNull();
+        assertThat(forUpdate.isForShare()).isTrue();
+        assertThat(forUpdate.isForUpdate()).isFalse();
+    }
+
+    @Test
+    void testForUpdateNowait() throws JSQLParserException {
+        String sqlStr =
+                "select employee_id from (select employee_id+1 as employee_id from employees)"
+                        + " for update of employee_id nowait";
+        Statement stmt = TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        PlainSelect plainSelect = (PlainSelect) stmt;
+
+        assertThat(plainSelect.getForMode()).isEqualTo(ForMode.UPDATE);
+        assertThat(plainSelect.isNoWait()).isTrue();
+
+        ForUpdateClause forUpdate = plainSelect.getForUpdate();
+        assertThat(forUpdate.isNoWait()).isTrue();
+        assertThat(forUpdate.isSkipLocked()).isFalse();
+    }
+
+    @Test
+    void testForUpdateWait() throws JSQLParserException {
+        String sqlStr =
+                "select employee_id from (select employee_id+1 as employee_id from employees)"
+                        + " for update of employee_id wait 10";
+        Statement stmt = TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        PlainSelect plainSelect = (PlainSelect) stmt;
+
+        assertThat(plainSelect.getWait()).isNotNull();
+        assertThat(plainSelect.getWait().getTimeout()).isEqualTo(10L);
+
+        ForUpdateClause forUpdate = plainSelect.getForUpdate();
+        assertThat(forUpdate.getWait()).isNotNull();
+        assertThat(forUpdate.getWait().getTimeout()).isEqualTo(10L);
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/SpecialOracleTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SpecialOracleTest.java
@@ -89,6 +89,7 @@ public class SpecialOracleTest {
             "datetime02.sql", "datetime04.sql", "datetime05.sql", "datetime06.sql", "dblink01.sql",
             "for_update01.sql", "for_update02.sql", "for_update03.sql", "function04.sql",
             "function05.sql", "for_update04.sql", "for_update05.sql", "for_update06.sql",
+            "for_update07.sql", "for_update08.sql",
             "function01.sql", "function02.sql", "function03.sql",
             "function06.sql", "function07.sql",
             "groupby01.sql",

--- a/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/for_update07.sql
+++ b/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/for_update07.sql
@@ -13,3 +13,4 @@ select employee_id from (select employee_id+1 as employee_id from employees)
 
 --@FAILURE: Encountered unexpected token: "," "," recorded first on Aug 3, 2021, 7:20:08 AM
 --@FAILURE: Encountered: <K_COMMA> / ",", at line 11, column 19, in lexical state DEFAULT. recorded first on 15 May 2025, 16:24:08
+--@SUCCESSFULLY_PARSED_AND_DEPARSED first on Apr 11, 2026, 4:05:21 PM

--- a/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/for_update08.sql
+++ b/src/test/resources/net/sf/jsqlparser/statement/select/oracle-tests/for_update08.sql
@@ -15,3 +15,4 @@ order by su.d
 
 --@FAILURE: select su.ttype,su.cid,su.s_id,sessiontimezone from sku su where(nvl(su.up,'n')='n' and su.ttype=:b0)order by su.d for update of su.up recorded first on 20 Apr 2024, 15:59:32
 --@FAILURE: Encountered unexpected token: "order" "ORDER" recorded first on Feb 13, 2025, 10:16:06 AM
+--@SUCCESSFULLY_PARSED_AND_DEPARSED first on Apr 11, 2026, 4:05:22 PM


### PR DESCRIPTION
During tests for integration of the JSqlParser into the https://github.com/Open-J-Proxy/ojp we found some limitations on how FOR UPDATE is interpreted.
This PR adds three things:

Grammar fix — multi-table OF clause: FOR UPDATE OF t1, t2, t3 was previously broken (only a single table was accepted), causing a ParseException. This affected any SELECT, not just subselect scenarios — the for_update07.sql oracle test just happens to use a subquery in FROM.

Grammar fix — ORDER BY after FOR UPDATE: Some Oracle SQL puts ORDER BY after FOR UPDATE (non-standard ordering). This also caused a ParseException before (for_update08.sql).

ForUpdateClause API class: A convenience object returned by getForUpdate() that aggregates all lock state (mode, table list, wait options) into a single object, useful for programmatic inspection in read/write routing scenarios as described in the problem statement. It's additive — all the pre-existing getForMode(), getWait(), isNoWait(), isSkipLocked() methods still work unchanged.