### PR TITLE
[Fix] #2443 - NPE In TableNamesFinder with AnalyticExpression

### DIFF
--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -766,17 +766,20 @@ public class TablesNamesFinder<Void>
         }
 
         if (analytic.getWindowElement() != null) {
-            if (analytic.getWindowElement().getRange().getStart().getExpression() != null) {
-                analytic.getWindowElement().getRange().getStart().getExpression().accept(this,
-                        context);
+            if (analytic.getWindowElement().getRange() != null) {
+                if (analytic.getWindowElement().getRange().getStart().getExpression() != null) {
+                    analytic.getWindowElement().getRange().getStart().getExpression().accept(this,
+                            context);
+                }
+                if (analytic.getWindowElement().getRange().getEnd().getExpression() != null) {
+                    analytic.getWindowElement().getRange().getEnd().getExpression().accept(this,
+                            context);
+                }
             }
-            if (analytic.getWindowElement().getRange().getEnd().getExpression() != null) {
-                analytic.getWindowElement().getRange().getEnd().getExpression().accept(this,
-                        context);
-            }
-            if (analytic.getWindowElement().getOffset() != null) {
+            if (analytic.getWindowElement().getOffset() != null && analytic.getWindowElement().getOffset().getExpression() != null) {
                 analytic.getWindowElement().getOffset().getExpression().accept(this, context);
             }
+
         }
         return null;
     }

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -767,11 +767,13 @@ public class TablesNamesFinder<Void>
 
         if (analytic.getWindowElement() != null) {
             if (analytic.getWindowElement().getRange() != null) {
-                if (analytic.getWindowElement().getRange().getStart().getExpression() != null) {
+                if (analytic.getWindowElement().getRange().getStart() != null
+                        && analytic.getWindowElement().getRange().getStart().getExpression() != null) {
                     analytic.getWindowElement().getRange().getStart().getExpression().accept(this,
                             context);
                 }
-                if (analytic.getWindowElement().getRange().getEnd().getExpression() != null) {
+                if (analytic.getWindowElement().getRange().getEnd() != null
+                        && analytic.getWindowElement().getRange().getEnd().getExpression() != null) {
                     analytic.getWindowElement().getRange().getEnd().getExpression().accept(this,
                             context);
                 }

--- a/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
@@ -771,4 +771,12 @@ public class TablesNamesFinderTest {
 
     }
 
+    @Test
+    void testWindowExpressionWithNoRangeAndNoOffsetDoesNotThrowException() {
+        String sqlStr = "SELECT c, SUM(COUNT(*)) OVER (ORDER BY c ASC ROWS UNBOUNDED PRECEDING) FROM tbl GROUP BY c";
+
+        assertThatCode(() -> TablesNamesFinder.findTables(sqlStr))
+                .doesNotThrowAnyException();
+    }
+
 }


### PR DESCRIPTION
If you attempt to tree walk an AnalyticExpression in TableNamesFinder with an SQL that has a window function without a range and without an offset, such as `SELECT c, SUM(COUNT(*)) OVER (ORDER BY c ASC ROWS UNBOUNDED PRECEDING) FROM tbl GROUP BY c`, an NPE is thrown. This adds defensive checks around the range and offset expressions being null.

Fixes #2443 