### PR TITLE
fix: add 'K_TYPE' to KeywordOrIdentifier to allow 'type' as a column name

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1756,7 +1756,7 @@ TOKEN:
  * Supported tokens:
  *  - <S_IDENTIFIER>: Standard unquoted SQL identifier
  *  - <S_QUOTED_IDENTIFIER>: Quoted identifier (e.g., `identifier` or "identifier")
- *  - <K_NAME>, <K_NEXT>, <K_VALUE>, <K_PUBLIC>, <K_STRING>, <K_DATA>: Specific keywords treated as identifiers
+ *  - <K_NAME>, <K_NEXT>, <K_VALUE>, <K_PUBLIC>, <K_STRING>, <K_DATA>, <K_TYPE>: Specific keywords treated as identifiers
  *
  * @return Token representing the identifier or keyword used as identifier
  */
@@ -1774,6 +1774,7 @@ Token KeywordOrIdentifier():
       | tk = <K_PUBLIC>
       | tk = <K_STRING>
       | tk = <K_DATA>
+      | tk = <K_TYPE>
     )
     { return tk; }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -260,6 +260,11 @@ public class AlterTest {
     }
 
     @Test
+    public void testAlterTableDropColumnIssue2447() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE test DROP COLUMN type");
+    }
+
+    @Test
     public void testAlterTableDropConstraint() throws JSQLParserException {
         final String sql = "ALTER TABLE test DROP CONSTRAINT YYY";
         Statement stmt = CCJSqlParserUtil.parse(sql);
@@ -470,6 +475,11 @@ public class AlterTest {
     }
 
     @Test
+    public void testAlterTableChangeColumnIssue2447() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE tb_test CHANGE type INT (10)");
+    }
+
+    @Test
     public void testAlterTableAddColumnWithZone() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed(
                 "ALTER TABLE mytable ADD COLUMN col1 timestamp with time zone");
@@ -666,6 +676,18 @@ public class AlterTest {
         assertEquals(expression.getOperation(), AlterOperation.RENAME);
         assertEquals(expression.getColOldName(), "name");
         assertEquals(expression.getColumnName(), "full_name");
+    }
+
+    @Test
+    public void testAlterTableRenameColumnIssue2447() throws JSQLParserException {
+        String sql = "ALTER TABLE test_table RENAME COLUMN type TO type2";
+        assertSqlCanBeParsedAndDeparsed(sql);
+
+        Alter alter = (Alter) CCJSqlParserUtil.parse(sql);
+        AlterExpression expression = alter.getAlterExpressions().get(0);
+        assertEquals(expression.getOperation(), AlterOperation.RENAME);
+        assertEquals(expression.getColOldName(), "type");
+        assertEquals(expression.getColumnName(), "type2");
     }
 
     @Test


### PR DESCRIPTION
Fixes #2447

### Problem

`TYPE` is a non-reserved keyword in MySQL 8.0, so this is valid MySQL syntax without quoting:

```sql
ALTER TABLE nullable_tbl DROP COLUMN type;
```

but it fails with `ParseException: Encountered unexpected token: "type" "TYPE"`, while the same identifier parses fine in a `SELECT` (via `RelObjectName()`, since `K_TYPE` is inside the non-reserved word range).

### Fix

Adds `K_TYPE` to `KeywordOrIdentifier()`, following the exact same approach as #2340 (which added `K_DATA` for the same class of bug, see #2339).

This covers all `KeywordOrIdentifier()` call sites: `DROP [COLUMN]`, `RENAME [COLUMN]`, and `CHANGE [COLUMN]`.

### Tests

- `testAlterTableDropColumnIssue2447` — `ALTER TABLE test DROP COLUMN type`
- `testAlterTableChangeColumnIssue2447` — `ALTER TABLE tb_test CHANGE type INT (10)`
- `testAlterTableRenameColumnIssue2447` — `ALTER TABLE test_table RENAME COLUMN type TO type2`

Full test suite passes (4646 tests, 0 failures). JavaCC parser generation reports the same pre-existing warnings as master (#2403) with no new choice conflicts.
