### PR TITLE
fix: accept VISIBLE/INVISIBLE index and column attributes in CREATE TABLE and CREATE INDEX

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -11046,6 +11046,7 @@ List<String> CreateParameter():
             | tk=<K_DESC> | tk=<K_TRUE> | tk=<K_FALSE> | tk=<K_PARALLEL> | tk=<K_BINARY> | tk=<K_START> | tk=<K_ORDER>
             | tk=<K_TIME_KEY_EXPR> | tk=<K_RAW> | tk=<K_HASH> | tk=<K_FIRST> | tk=<K_LAST> | tk = <K_SIGNED>  | tk = <K_UNSIGNED>
             | tk=<K_ENGINE> | tk=<K_IDENTITY> | tk=<K_MATERIALIZED> | tk=<K_SAMPLE> | tk=<K_ALWAYS>
+            | tk=<K_VISIBLE> | tk=<K_INVISIBLE>
             | tk="="
         )
         { param.add(tk.image); }

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
@@ -168,4 +168,10 @@ public class CreateIndexTest {
 
         assertSqlCanBeParsedAndDeparsed(statement);
     }
+
+    @Test
+    public void testCreateIndexVisibility() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("CREATE INDEX idx_a ON t1 (a) INVISIBLE", true);
+        assertSqlCanBeParsedAndDeparsed("CREATE INDEX idx_a ON t1 (a) VISIBLE", true);
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
@@ -1162,4 +1162,48 @@ public class CreateTableTest {
         assertEquals("session1", t.getSchemaName());
         assertEquals("a", t.getUnquotedName());
     }
+
+    @Test
+    void testCreateTableIndexVisibility() throws JSQLParserException {
+        String sqlStr = "CREATE TABLE `orders` (" +
+                "`id` bigint NOT NULL AUTO_INCREMENT" +
+                ", `status` varchar (32) NOT NULL" +
+                ", `quote_id` varchar (191) NOT NULL" +
+                ", PRIMARY KEY (`id`)" +
+                ", KEY `idx_status` (`status`) INVISIBLE" +
+                ", UNIQUE KEY `idx_quote_id` (`quote_id`) VISIBLE" +
+                ") ENGINE = InnoDB";
+        CreateTable createTable = (CreateTable) assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+
+        assertEquals(Arrays.asList("INVISIBLE"), createTable.getIndexes().get(1).getIndexSpec());
+        assertEquals(Arrays.asList("VISIBLE"), createTable.getIndexes().get(2).getIndexSpec());
+    }
+
+    @Test
+    void testCreateTableColumnVisibility() throws JSQLParserException {
+        String sqlStr =
+                "CREATE TABLE t1 (id bigint NOT NULL VISIBLE, secret varchar (10) INVISIBLE)";
+        CreateTable createTable = (CreateTable) assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+
+        assertEquals(Arrays.asList("NOT", "NULL", "VISIBLE"),
+                createTable.getColumnDefinitions().get(0).getColumnSpecs());
+        assertEquals(Arrays.asList("INVISIBLE"),
+                createTable.getColumnDefinitions().get(1).getColumnSpecs());
+    }
+
+    @Test
+    void testCreateTableIndexVisibilityWithOtherIndexOptions() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "CREATE TABLE t1 (a int, KEY idx_a (a) INVISIBLE COMMENT 'retiring')", true);
+        assertSqlCanBeParsedAndDeparsed(
+                "CREATE TABLE t1 (a int, KEY idx_a (a) COMMENT 'retiring' INVISIBLE)", true);
+        assertSqlCanBeParsedAndDeparsed(
+                "CREATE TABLE t1 (a int, KEY idx_a (a) USING BTREE INVISIBLE)", true);
+    }
+
+    @Test
+    void testCreateTableQuotedColumnNamedVisible() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "CREATE TABLE t1 (`visible` int, `invisible` varchar (10))", true);
+    }
 }


### PR DESCRIPTION
Related to #2076

### Problem

MySQL 8.0 index and column visibility attributes are valid syntax in CREATE TABLE and CREATE INDEX:

```sql
CREATE TABLE t1 (
  id bigint NOT NULL,
  secret varchar(10) INVISIBLE,
  KEY idx_id (id) INVISIBLE
);

CREATE INDEX idx_a ON t1 (a) INVISIBLE;
```

but both fail with `ParseException: Encountered unexpected token: "INVISIBLE"`. #2076 reported the same problem for ALTER TABLE and was fixed in #2234, but that fix covered the ALTER productions only — the CREATE statements parse their options through `CreateParameter()`, which did not accept the two tokens.

Making an index invisible is the usual first step before dropping it, so table definitions carrying a bare `INVISIBLE` are common; today the only spelling that gets through the parser is the conditional comment `/*!80000 INVISIBLE */`, which is skipped as a comment.

### Fix

Adds `K_VISIBLE` and `K_INVISIBLE` to the `CreateParameter()` alternation, following the same approach as the other MySQL index/column attributes there. The attributes are collected into the index spec / column specs like any other option and round-trip through the deparser. Both tokens already exist and stay supported in the ALTER productions from #2234, which use separate paths (`IndexOption()`, `AlterExpressionColumnSetVisibility()`).

### Tests

- `testCreateTableIndexVisibility` — `KEY ... INVISIBLE` and `UNIQUE KEY ... VISIBLE`, asserting the index spec
- `testCreateTableColumnVisibility` — column-level `VISIBLE`/`INVISIBLE`, asserting the column specs
- `testCreateTableIndexVisibilityWithOtherIndexOptions` — visibility combined with `COMMENT` and `USING BTREE` in either order
- `testCreateTableQuotedColumnNamedVisible` — backtick-quoted columns named `visible`/`invisible` still parse as identifiers
- `testCreateIndexVisibility` — `CREATE INDEX ... VISIBLE/INVISIBLE`

Full test suite passes (4653 tests, 0 failures). JavaCC parser generation reports the same pre-existing warnings as master with no new choice conflicts.
