### PR TITLE
fix: stop 0x hex literal from swallowing trailing whitespace (#2435)

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1601,8 +1601,9 @@ TOKEN : /* Numeric Constants */
             )>
   |     < S_LONG: ( <DIGIT> )+ >
   |     < #DIGIT: ["0" - "9"] >
-  |     < S_HEX: ("X" ("'" ( <HEX_VALUE> )* "'" (" ")*)+ | "0x" ( <HEX_VALUE> )+ ) >
+  |     < S_HEX: ("X" ("'" ( <HEX_VALUE> )* "'" (" ")*)+ | "0x" ( <HEX_DIGIT> )+ ) >
   |     < #HEX_VALUE: ["0"-"9","A"-"F", " "]  >
+  |     < #HEX_DIGIT: ["0"-"9","A"-"F"]  >
 }
 
 SPECIAL_TOKEN:

--- a/src/test/java/net/sf/jsqlparser/expression/HexValueTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/HexValueTest.java
@@ -9,6 +9,8 @@
  */
 package net.sf.jsqlparser.expression;
 
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.select.PlainSelect;
@@ -53,7 +55,7 @@ class HexValueTest {
 
     private static void assertHexSelectItem(String sql, String expectedDigits)
             throws JSQLParserException {
-        PlainSelect select = (PlainSelect) CCJSqlParserUtil.parse(sql);
+        PlainSelect select = (PlainSelect) assertSqlCanBeParsedAndDeparsed(sql, true);
         Expression expr = select.getSelectItem(0).getExpression();
         Assertions.assertTrue(expr instanceof HexValue, () -> "Expected HexValue for: " + sql);
         Assertions.assertEquals(expectedDigits, ((HexValue) expr).getDigits());

--- a/src/test/java/net/sf/jsqlparser/expression/HexValueTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/HexValueTest.java
@@ -39,4 +39,23 @@ class HexValueTest {
 
         Assertions.assertEquals("'\\xC3\\xBC'", hex3.getBlob().toString());
     }
+
+    @Test
+    void testHexLiteralFollowedByPrimaryKeyword() throws JSQLParserException {
+        // Issue #2435: a "0x"-prefixed hex literal must not greedily consume the
+        // following whitespace nor adjacent hex letters (e.g. the "F" of FROM),
+        // which previously made "SELECT 0xFF FROM t" fail to parse.
+        assertHexSelectItem("SELECT 0xFF FROM t", "FF");
+        assertHexSelectItem("SELECT 0xff FROM t", "ff");
+        assertHexSelectItem("SELECT 0xDEADBEEF FROM t", "DEADBEEF");
+        assertHexSelectItem("SELECT 0xab FROM dual", "ab");
+    }
+
+    private static void assertHexSelectItem(String sql, String expectedDigits)
+            throws JSQLParserException {
+        PlainSelect select = (PlainSelect) CCJSqlParserUtil.parse(sql);
+        Expression expr = select.getSelectItem(0).getExpression();
+        Assertions.assertTrue(expr instanceof HexValue, () -> "Expected HexValue for: " + sql);
+        Assertions.assertEquals(expectedDigits, ((HexValue) expr).getDigits());
+    }
 }


### PR DESCRIPTION
## What

`SELECT 0xFF FROM t` (any `0x`-hex literal followed by whitespace/a keyword) failed to parse, while `SELECT 0xFF,1 FROM t` parsed fine. This makes the `0x` hex literal form stop greedily consuming trailing whitespace.

## Why

MySQL and other dialects accept `0x`-prefixed hex literals as values/select items (#2435). Today such a literal followed by `FROM` or a keyword fails:

```
SELECT 0xFF FROM t
  -> ParseException: Encountered: <S_IDENTIFIER> / "t", at line 1, column 18
```

while the same literal followed by a comma parses fine — a confusing inconsistency.

## Root cause

`HEX_VALUE` was defined as `["0"-"9","A"-"F", " "]` and shared by **both** hex literal forms in `S_HEX`:

```
<S_HEX: ("X" ("'" ( <HEX_VALUE> )* "'" (" ")*)+ | "0x" ( <HEX_VALUE> )+ )>
```

The space is intentional for the `X'..'` form, which allows internal whitespace (e.g. `X'01 bc 2a'`, exercised by `StringValueTest#testParseInput_BYTEA`). But for the `0x` form, `<HEX_VALUE>+` then greedily matched the trailing space **and** any following hex letter — so `0xFF FROM` was tokenised as a single `S_HEX` (`0xFF F`), leaving `ROM t`, and the parser choked on `t` at column 18.

## How

Split the shared token so each form gets the character class it needs:

- `X'..'` keeps `HEX_VALUE` (with space — preserves `X'01 bc 2a'`).
- `0x..` uses a new `HEX_DIGIT` token (`["0"-"9","A"-"F"]`, no space).

`IGNORE_CASE = true` already makes both forms match upper/lower case, so `0xff` works too. `HexValue` itself is unchanged.

## Testing

- New `HexValueTest#testHexLiteralFollowedByPrimaryKeyword`: `SELECT 0xFF FROM t`, `SELECT 0xff FROM t`, `SELECT 0xDEADBEEF FROM t`, `SELECT 0xab FROM dual` — all parse to a `HexValue` select item.
- Full suite: `mvn test` → **4647 tests, 0 failures, 0 errors** (26 pre-existing skipped), including the `X'01 bc 2a'` regression in `StringValueTest` and existing `InsertTest#testHexValues*`.
- `checkstyle:check` / `pmd:check` / `license:check-file-header` clean.

Fixes #2435
