### PR TITLE
fix: support nested parametric data types as CAST target

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -10707,6 +10707,7 @@ ColDataType ColDataType():
     List<Integer> array = new ArrayList<Integer>();
     List<String> name;
     ColDataType arrayType;
+    ColDataType nestedType = null;
 
     int precision = -1;
     int scale = -1;
@@ -10756,6 +10757,9 @@ ColDataType ColDataType():
         LOOKAHEAD(2) "(" {tk2 =null;}
         (
             (
+            LOOKAHEAD((<DATA_TYPE> | <S_IDENTIFIER>) "(") nestedType=ColDataType()
+            |
+            (
                 (
                     ( tk=<S_LONG> | tk=<K_MAX> ) [ LOOKAHEAD(2) (tk2=<K_BYTE> | tk2=<K_CHAR>) ]
                 )
@@ -10766,8 +10770,14 @@ ColDataType ColDataType():
                 |
                 tk=<K_CHAR>
             )
+            )
 		    {
-		        argumentsStringList.add(tk.image + (tk2!=null?" " + tk2.image:""));
+            if (nestedType != null) {
+                argumentsStringList.add(nestedType.toString());
+                nestedType = null;
+            } else {
+                argumentsStringList.add(tk.image + (tk2!=null?" " + tk2.image:""));
+            }
             }
 
             [ "," ]

--- a/src/test/java/net/sf/jsqlparser/statement/select/ClickHouseTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/ClickHouseTest.java
@@ -140,4 +140,16 @@ public class ClickHouseTest {
         Assertions.assertNotNull(select.getSettings());
         Assertions.assertEquals(2, select.getSettings().size());
     }
+
+    @Test
+    public void testCastToNestedParametricTypeIssue2441() throws JSQLParserException {
+        // ClickHouse allows parametric (constructor-style) data types as a CAST target,
+        // including nested ones such as Nullable(Decimal(p, s)).
+        String sql = "SELECT CAST(x AS Nullable(Decimal(10, 2))) FROM cast_demo";
+        assertSqlCanBeParsedAndDeparsed(sql, true);
+
+        // The inner parametric type may itself be wrapped by another parametric type.
+        sql = "SELECT CAST(x AS LowCardinality(Decimal(10, 2))) FROM cast_demo";
+        assertSqlCanBeParsedAndDeparsed(sql, true);
+    }
 }


### PR DESCRIPTION
## What
Allow a parametric (constructor-style) data type — including a nested one such as `Nullable(Decimal(10, 2))` — to be used as the target type of a `CAST`.

## Why
ClickHouse supports parametric data types as a `CAST` target, and they can be nested:

```sql
SELECT CAST(x AS Nullable(Decimal(10, 2))) FROM cast_demo;
```

JSQLParser failed on the inner opening bracket:

```
ParseException: Encountered: <OPENING_BRACKET> / "(", ... Was expecting ... <CLOSING_BRACKET>
```

Reported in #2441.

## How
The argument production of `ColDataType` only accepted atomic tokens (`S_LONG`/`K_MAX` with optional `BYTE`/`CHAR`, `S_CHAR_LITERAL`, `S_IDENTIFIER`, `K_CHAR`), so a nested parametric type was unreachable.

This adds one alternative to the argument loop: when the next token is a `DATA_TYPE` or identifier immediately followed by `(`, parse the argument as a nested `ColDataType` (recursing through the existing production) and store its `toString()` rendering in the arguments string list. The new alternative is gated by an explicit `LOOKAHEAD`, so the existing atomic arguments are unaffected.

Kept intentionally narrow: only parametric arguments (a type immediately followed by its own argument list) are handled. A bare type-keyword argument (e.g. `String` in `Nullable(String)`) is a separate concern and out of scope for this issue.

## Testing
- New regression test `ClickHouseTest#testCastToNestedParametricTypeIssue2441` covering `Nullable(Decimal(10, 2))` (the reported case) and `LowCardinality(Decimal(10, 2))` (another ClickHouse parametric type wrapping a precision type). Both parse and round-trip.
- `mvn clean test`: 4647 tests, 0 failures, 0 errors (26 skipped) — no regressions on the shared `ColDataType` production.
- `mvn spotless:check`: clean.

Fixes #2441
