### PR TITLE
fix: allow arbitrary column aliases in LATERAL VIEW

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -5053,6 +5053,9 @@ LateralView LateralView() #LateralView:
     [
         LOOKAHEAD(2) ","  { columnAlias.setName(null);  columnAlias.addAliasColumns( columnName); }
         columnName = RelObjectName() { columnAlias.addAliasColumns( columnName); }
+        (
+            LOOKAHEAD(2) "," columnName = RelObjectName() { columnAlias.addAliasColumns( columnName); }
+        )*
     ]
     {
         return new LateralView(

--- a/src/test/java/net/sf/jsqlparser/statement/select/HiveTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/HiveTest.java
@@ -9,12 +9,16 @@
  */
 package net.sf.jsqlparser.statement.select;
 
-import net.sf.jsqlparser.schema.Table;
-import org.junit.jupiter.api.Test;
-
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.sf.jsqlparser.expression.Alias;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Table;
+import org.junit.jupiter.api.Test;
 
 public class HiveTest {
 
@@ -53,5 +57,31 @@ public class HiveTest {
                 + "    Sometable\n"
                 + "GROUP BY GROUPING SETS (())";
         assertSqlCanBeParsedAndDeparsed(sql, true);
+    }
+
+    @Test
+    public void testLateralViewManyColumnAliasesIssue2433() throws Exception {
+        // Hive/Spark LATERAL VIEW allows an arbitrary number of column aliases
+        // (e.g. json_tuple yielding many columns). Only the first two were absorbed;
+        // any further aliases leaked into the FROM clause as implicit cross-join
+        // tables, so the failure was silent and even round-tripped identically.
+        String sql = "SELECT a FROM t"
+                + " LATERAL VIEW json_tuple(j, 'a', 'b', 'c', 'd', 'e', 'f', 'g')"
+                + " x AS c1, c2, c3, c4, c5, c6, c7";
+
+        Select select = (Select) CCJSqlParserUtil.parse(sql);
+        PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
+
+        // The extra aliases must not leak as cross-join tables.
+        assertNull(plainSelect.getJoins());
+
+        java.util.List<LateralView> lateralViews = plainSelect.getLateralViews();
+        assertNotNull(lateralViews);
+        assertEquals(1, lateralViews.size());
+
+        Alias columnAlias = lateralViews.get(0).getColumnAlias();
+        assertNotNull(columnAlias);
+        assertNotNull(columnAlias.getAliasColumns());
+        assertEquals(7, columnAlias.getAliasColumns().size());
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/HiveTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/HiveTest.java
@@ -16,7 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import net.sf.jsqlparser.expression.Alias;
-import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Table;
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +68,7 @@ public class HiveTest {
                 + " LATERAL VIEW json_tuple(j, 'a', 'b', 'c', 'd', 'e', 'f', 'g')"
                 + " x AS c1, c2, c3, c4, c5, c6, c7";
 
-        Select select = (Select) CCJSqlParserUtil.parse(sql);
+        Select select = (Select) assertSqlCanBeParsedAndDeparsed(sql, true);
         PlainSelect plainSelect = (PlainSelect) select.getSelectBody();
 
         // The extra aliases must not leak as cross-join tables.


### PR DESCRIPTION
## What
Allow a Hive/Spark `LATERAL VIEW` to declare an arbitrary number of column aliases, not just two.

## Why
`LATERAL VIEW ... x AS c1, c2, c3, ..., cN` is valid Hive/Spark SQL — `json_tuple` and similar UDTFs commonly yield many output columns. The grammar only absorbed the first two aliases (#2088); from the third onward the aliases were silently parsed as comma-separated tables in the `FROM` clause (implicit cross joins):

- `PlainSelect.joins` incorrectly contained `Join(Table("c3")) ... Join(Table("cN"))`
- `LateralView.columnAlias.aliasColumns` stopped at 2

Because `toString()` re-emits the leaked aliases as the join list, the broken AST round-trips to textually identical SQL, so the bug is invisible to round-trip checks.

Reported in #2433.

## How
The column-alias production (`LateralView`) handled the second alias with an optional `[ "," name ]` block. This adds a `("," name)*` loop immediately after it, so the 3rd…Nth aliases are consumed by the lateral view instead of leaking to the `FROM` clause. The existing single- and two-alias behaviour is unchanged (the loop simply runs zero times).

## Testing
- New `HiveTest#testLateralViewManyColumnAliasesIssue2433` parses `LATERAL VIEW json_tuple(...) x AS c1, c2, c3, c4, c5, c6, c7` and asserts at the AST level (a round-trip assertion would be vacuous here): `PlainSelect.joins` is `null` and `LateralView.columnAlias.aliasColumns` has size 7.
- Verified the test fails on `master` (`expected: <null> but was: <[c3, c4, c5, c6, c7]>`) and passes with this change.
- `mvn clean test`: 4648 tests, 0 failures, 0 errors (26 skipped) — the existing two-alias case (#2088) and all other tests unchanged.
- `mvn spotless:check`: clean.

Fixes #2433
