### PR TITLE
fix: support ClickHouse tuple positional access

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -9559,6 +9559,7 @@ Function InternalFunction(boolean escaped):
     Expression expr = null;
     Expression attributeExpression = null;
     Column attributeColumn = null;
+    Token attributeToken = null;
     Limit limit;
     List<Function.KeywordArgument> keywordArgs = null;
 }
@@ -9624,14 +9625,24 @@ Function InternalFunction(boolean escaped):
     ]
 
 
-    [ LOOKAHEAD(2) "." (
-            // tricky lookahead since we do need to support the following constructs
-            // schema.f1().f2() - Function with Function Column
-            // schema.f1().f2.f3 - Function with Attribute Column
-            LOOKAHEAD( 6 ) attributeExpression=Function() { retval.setAttribute(attributeExpression); }
+    [
+        LOOKAHEAD(2)
+        (
+            LOOKAHEAD({ getToken(1).kind == S_DOUBLE
+                    && getToken(1).image.matches("\\.[0-9]+") })
+            attributeToken=<S_DOUBLE> {
+                retval.setAttribute(new LongValue(attributeToken.image.substring(1)));
+            }
             |
-            attributeColumn=Column() { retval.setAttribute(attributeColumn); }
-          )
+            "." (
+                    // tricky lookahead since we do need to support the following constructs
+                    // schema.f1().f2() - Function with Function Column
+                    // schema.f1().f2.f3 - Function with Attribute Column
+                    LOOKAHEAD( 6 ) attributeExpression=Function() { retval.setAttribute(attributeExpression); }
+                    |
+                    attributeColumn=Column() { retval.setAttribute(attributeColumn); }
+                )
+        )
     ]
 
     [ LOOKAHEAD(2) (

--- a/src/test/java/net/sf/jsqlparser/statement/select/ClickHouseTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/ClickHouseTest.java
@@ -79,6 +79,12 @@ public class ClickHouseTest {
     }
 
     @Test
+    public void testTuplePositionalAccessIssue2442() throws JSQLParserException {
+        String sql = "SELECT tuple(1, 2, 3).2 FROM tuple_demo";
+        assertSqlCanBeParsedAndDeparsed(sql, true);
+    }
+
+    @Test
     public void testGlobalIn() throws JSQLParserException {
         String sql =
                 "SELECT lo_linenumber,lo_orderkey from lo_linenumber where lo_linenumber global in (1,2,3)";


### PR DESCRIPTION
Fixes #2442

## Problem

ClickHouse supports tuple positional access using `tuple(...).N`.
JSQLParser tokenizes `.2` as `S_DOUBLE`, so the existing function postfix grammar does not see a standalone `.` token and parsing fails.

## Fix

Keep the global numeric lexer unchanged. Recognize only strict `.[0-9]+` `S_DOUBLE` tokens locally in the `InternalFunction` postfix and represent the position with the existing `Function` attribute and `LongValue` AST support.

The existing `.` + `Function()` / `Column()` postfix paths remain unchanged.

## Tests

Added a parse/deparse regression test for:

```sql
SELECT tuple(1, 2, 3).2 FROM tuple_demo
```

The full Gradle test suite and check pass, and JavaCC generation introduces no new warnings.
