### PR TITLE
fix(parser): keep parenthesized multi-param lambda as first function arg

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -7885,22 +7885,22 @@ Expression PrimaryExpression() #PrimaryExpression:
             list=ParenthesedExpressionList()
              // Mutli-Variable Lambda Expression, e. g.
             // SELECT map_filter(my_column, (k,v) -> v.my_inner_column = 'some_value')
-            [ LOOKAHEAD(2) "->"
-                  retval = Expression()
-                  {
-                      retval = LambdaExpression.from(list, retval);
-                  }
-            ]
-
-
-            {
-                if (list.size() == 1) {
-                    retval = new ParenthesedExpressionList( (Expression) list.getExpressions().get(0));
-                } else {
-                    retval = list;
+            // First-arg form (issue #2195): array_map((x,y,z) -> x + y, ...)
+            (
+                LOOKAHEAD(2) "->"
+                      retval = Expression()
+                      {
+                          retval = LambdaExpression.from(list, retval);
+                      }
+                |
+                {
+                    if (list.size() == 1) {
+                        retval = new ParenthesedExpressionList( (Expression) list.getExpressions().get(0));
+                    } else {
+                        retval = list;
+                    }
                 }
-            }
-
+            )
 
             // RowGet Expressions
             ( LOOKAHEAD(2) "." tmp=RelObjectName() { retval = new RowGetExpression(retval, tmp); } )*

--- a/src/test/java/net/sf/jsqlparser/expression/LambdaExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/LambdaExpressionTest.java
@@ -45,4 +45,10 @@ class LambdaExpressionTest {
         TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
     }
 
+    @Test
+    void testLambdaFirstArgumentIssue2195() throws JSQLParserException {
+        String sqlStr = "select array_map((x,y,z) -> x + y, [1], [2], [4]) FROM table_name";
+        TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+    }
+
 }

--- a/src/test/java/net/sf/jsqlparser/expression/LambdaExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/LambdaExpressionTest.java
@@ -41,7 +41,8 @@ class LambdaExpressionTest {
 
     @Test
     void testLambdaMultiParameterIssue2032() throws JSQLParserException {
-        String sqlStr = "SELECT  array_sort(array_agg(named_struct('depth', events_union.depth, 'eventtime',events_union.eventtime)), (left, right) -> case when(left.eventtime, left.depth) <(right.eventtime, right.depth) then -1 when(left.eventtime, left.depth) >(right.eventtime, right.depth) then 1 else 0 end) as col1 FROM your_table;";
+        String sqlStr =
+                "SELECT  array_sort(array_agg(named_struct('depth', events_union.depth, 'eventtime',events_union.eventtime)), (left, right) -> case when(left.eventtime, left.depth) <(right.eventtime, right.depth) then -1 when(left.eventtime, left.depth) >(right.eventtime, right.depth) then 1 else 0 end) as col1 FROM your_table;";
         TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
     }
 


### PR DESCRIPTION
## Summary
`array_map((x,y,z) -> x + y, …)` incorrectly kept only the parameter list `(x, y, z)` as the first argument. Tokens for `-> body` were consumed, then discarded by an unconditional reassignment after `ParenthesedExpressionList()`.

## Changes
- In `PrimaryExpression()`, make the lambda branch and the plain-list assignment mutually exclusive.
- Add regression test `testLambdaFirstArgumentIssue2195`.

## Test plan
- [ ] `mvn -Dtest=LambdaExpressionTest test`

Fixes #2195
