### PR TITLE
feat: add support for the XMLTABLE table function

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -659,6 +659,14 @@ public interface ExpressionVisitor<T> {
         this.visit(jsonTableFunction, null);
     }
 
+    default <S> T visit(XmlTableFunction xmlTableFunction, S context) {
+        return visit((Function) xmlTableFunction, context);
+    }
+
+    default void visit(XmlTableFunction xmlTableFunction) {
+        this.visit(xmlTableFunction, null);
+    }
+
     <S> T visit(ConnectByRootOperator connectByRootOperator, S context);
 
     default void visit(ConnectByRootOperator connectByRootOperator) {

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -759,6 +759,11 @@ public class ExpressionVisitorAdapter<T>
     }
 
     @Override
+    public <S> T visit(XmlTableFunction xmlTableFunction, S context) {
+        return visitExpressions(xmlTableFunction, context, xmlTableFunction.getAllExpressions());
+    }
+
+    @Override
     public <S> T visit(ConnectByRootOperator connectByRootOperator, S context) {
         return connectByRootOperator.getColumn().accept(this, context);
     }

--- a/src/main/java/net/sf/jsqlparser/expression/XmlTableFunction.java
+++ b/src/main/java/net/sf/jsqlparser/expression/XmlTableFunction.java
@@ -1,0 +1,235 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+import net.sf.jsqlparser.statement.create.table.ColDataType;
+
+/**
+ * Represents an {@code XMLTABLE} table function (SQL/XML standard, supported by PostgreSQL and
+ * Oracle), which turns an XML document into a relational row set, e.g.:
+ *
+ * <pre>
+ * XMLTABLE('//ROWS/ROW'
+ *          PASSING data
+ *          COLUMNS id int PATH '@id',
+ *                  ordinality FOR ORDINALITY,
+ *                  country_id text PATH 'COUNTRY_ID',
+ *                  size float PATH 'SIZE' DEFAULT 0)
+ * </pre>
+ *
+ * It is the XML counterpart of {@link JsonTableFunction} and mirrors its structure, without the
+ * JSON-specific wrapper/error/plan clauses.
+ */
+public class XmlTableFunction extends Function {
+
+    private Expression rowPathExpression;
+    private final List<XmlTablePassingClause> passingClauses = new ArrayList<>();
+    private final List<XmlTableColumnDefinition> columnDefinitions = new ArrayList<>();
+
+    public static class XmlTablePassingClause extends ASTNodeAccessImpl implements Serializable {
+        private Expression valueExpression;
+        private String name;
+
+        public XmlTablePassingClause() {}
+
+        public Expression getValueExpression() {
+            return valueExpression;
+        }
+
+        public XmlTablePassingClause setValueExpression(Expression valueExpression) {
+            this.valueExpression = valueExpression;
+            return this;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public XmlTablePassingClause setName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public void collectExpressions(List<Expression> expressions) {
+            if (valueExpression != null) {
+                expressions.add(valueExpression);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return valueExpression + (name != null ? " AS " + name : "");
+        }
+    }
+
+    public static class XmlTableColumnDefinition extends ASTNodeAccessImpl implements Serializable {
+        private String columnName;
+        private boolean forOrdinality;
+        private ColDataType dataType;
+        private Expression pathExpression;
+        private Expression defaultExpression;
+
+        public XmlTableColumnDefinition() {}
+
+        public String getColumnName() {
+            return columnName;
+        }
+
+        public XmlTableColumnDefinition setColumnName(String columnName) {
+            this.columnName = columnName;
+            return this;
+        }
+
+        public boolean isForOrdinality() {
+            return forOrdinality;
+        }
+
+        public XmlTableColumnDefinition setForOrdinality(boolean forOrdinality) {
+            this.forOrdinality = forOrdinality;
+            return this;
+        }
+
+        public ColDataType getDataType() {
+            return dataType;
+        }
+
+        public XmlTableColumnDefinition setDataType(ColDataType dataType) {
+            this.dataType = dataType;
+            return this;
+        }
+
+        public Expression getPathExpression() {
+            return pathExpression;
+        }
+
+        public XmlTableColumnDefinition setPathExpression(Expression pathExpression) {
+            this.pathExpression = pathExpression;
+            return this;
+        }
+
+        public Expression getDefaultExpression() {
+            return defaultExpression;
+        }
+
+        public XmlTableColumnDefinition setDefaultExpression(Expression defaultExpression) {
+            this.defaultExpression = defaultExpression;
+            return this;
+        }
+
+        public void collectExpressions(List<Expression> expressions) {
+            if (pathExpression != null) {
+                expressions.add(pathExpression);
+            }
+            if (defaultExpression != null) {
+                expressions.add(defaultExpression);
+            }
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder builder = new StringBuilder(columnName);
+            if (forOrdinality) {
+                builder.append(" FOR ORDINALITY");
+                return builder.toString();
+            }
+            if (dataType != null) {
+                builder.append(" ").append(dataType);
+            }
+            if (pathExpression != null) {
+                builder.append(" PATH ").append(pathExpression);
+            }
+            if (defaultExpression != null) {
+                builder.append(" DEFAULT ").append(defaultExpression);
+            }
+            return builder.toString();
+        }
+    }
+
+    public Expression getRowPathExpression() {
+        return rowPathExpression;
+    }
+
+    public XmlTableFunction setRowPathExpression(Expression rowPathExpression) {
+        this.rowPathExpression = rowPathExpression;
+        return this;
+    }
+
+    public List<XmlTablePassingClause> getPassingClauses() {
+        return passingClauses;
+    }
+
+    public XmlTableFunction addPassingClause(XmlTablePassingClause passingClause) {
+        passingClauses.add(passingClause);
+        return this;
+    }
+
+    public List<XmlTableColumnDefinition> getColumnDefinitions() {
+        return columnDefinitions;
+    }
+
+    public XmlTableFunction addColumnDefinition(XmlTableColumnDefinition columnDefinition) {
+        columnDefinitions.add(columnDefinition);
+        return this;
+    }
+
+    public List<Expression> getAllExpressions() {
+        List<Expression> expressions = new ArrayList<>();
+        if (rowPathExpression != null) {
+            expressions.add(rowPathExpression);
+        }
+        for (XmlTablePassingClause passingClause : passingClauses) {
+            passingClause.collectExpressions(expressions);
+        }
+        for (XmlTableColumnDefinition columnDefinition : columnDefinitions) {
+            columnDefinition.collectExpressions(expressions);
+        }
+        return expressions;
+    }
+
+    @Override
+    public <T, S> T accept(ExpressionVisitor<T> expressionVisitor, S context) {
+        return expressionVisitor.visit(this, context);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("XMLTABLE(");
+        builder.append(rowPathExpression);
+        if (!passingClauses.isEmpty()) {
+            builder.append(" PASSING ");
+            boolean first = true;
+            for (XmlTablePassingClause passingClause : passingClauses) {
+                if (!first) {
+                    builder.append(", ");
+                }
+                builder.append(passingClause);
+                first = false;
+            }
+        }
+        if (!columnDefinitions.isEmpty()) {
+            builder.append(" COLUMNS ");
+            boolean first = true;
+            for (XmlTableColumnDefinition columnDefinition : columnDefinitions) {
+                if (!first) {
+                    builder.append(", ");
+                }
+                builder.append(columnDefinition);
+                first = false;
+            }
+        }
+        builder.append(")");
+        return builder.toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/expression/XmlTableFunction.java
+++ b/src/main/java/net/sf/jsqlparser/expression/XmlTableFunction.java
@@ -42,8 +42,6 @@ public class XmlTableFunction extends Function {
         private Expression valueExpression;
         private String name;
 
-        public XmlTablePassingClause() {}
-
         public Expression getValueExpression() {
             return valueExpression;
         }
@@ -80,8 +78,6 @@ public class XmlTableFunction extends Function {
         private ColDataType dataType;
         private Expression pathExpression;
         private Expression defaultExpression;
-
-        public XmlTableColumnDefinition() {}
 
         public String getColumnName() {
             return columnName;

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -768,17 +768,20 @@ public class TablesNamesFinder<Void>
         if (analytic.getWindowElement() != null) {
             if (analytic.getWindowElement().getRange() != null) {
                 if (analytic.getWindowElement().getRange().getStart() != null
-                        && analytic.getWindowElement().getRange().getStart().getExpression() != null) {
+                        && analytic.getWindowElement().getRange().getStart()
+                                .getExpression() != null) {
                     analytic.getWindowElement().getRange().getStart().getExpression().accept(this,
                             context);
                 }
                 if (analytic.getWindowElement().getRange().getEnd() != null
-                        && analytic.getWindowElement().getRange().getEnd().getExpression() != null) {
+                        && analytic.getWindowElement().getRange().getEnd()
+                                .getExpression() != null) {
                     analytic.getWindowElement().getRange().getEnd().getExpression().accept(this,
                             context);
                 }
             }
-            if (analytic.getWindowElement().getOffset() != null && analytic.getWindowElement().getOffset().getExpression() != null) {
+            if (analytic.getWindowElement().getOffset() != null
+                    && analytic.getWindowElement().getOffset().getExpression() != null) {
                 analytic.getWindowElement().getOffset().getExpression().accept(this, context);
             }
 
@@ -1787,6 +1790,16 @@ public class TablesNamesFinder<Void>
         for (Expression jsonExpression : expression.getAllExpressions()) {
             if (jsonExpression != null) {
                 jsonExpression.accept(this, context);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(XmlTableFunction expression, S context) {
+        for (Expression xmlExpression : expression.getAllExpressions()) {
+            if (xmlExpression != null) {
+                xmlExpression.accept(this, context);
             }
         }
         return null;

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -45,6 +45,7 @@ import net.sf.jsqlparser.expression.JsonAggregateFunction;
 import net.sf.jsqlparser.expression.JsonExpression;
 import net.sf.jsqlparser.expression.JsonFunction;
 import net.sf.jsqlparser.expression.JsonTableFunction;
+import net.sf.jsqlparser.expression.XmlTableFunction;
 import net.sf.jsqlparser.expression.KeepExpression;
 import net.sf.jsqlparser.expression.KeyExpression;
 import net.sf.jsqlparser.expression.LambdaExpression;
@@ -1655,6 +1656,12 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
 
     @Override
     public <S> StringBuilder visit(JsonTableFunction expression, S context) {
+        builder.append(expression);
+        return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(XmlTableFunction expression, S context) {
         builder.append(expression);
         return builder;
     }

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
@@ -39,6 +39,7 @@ import net.sf.jsqlparser.expression.JsonAggregateFunction;
 import net.sf.jsqlparser.expression.JsonExpression;
 import net.sf.jsqlparser.expression.JsonFunction;
 import net.sf.jsqlparser.expression.JsonTableFunction;
+import net.sf.jsqlparser.expression.XmlTableFunction;
 import net.sf.jsqlparser.expression.KeepExpression;
 import net.sf.jsqlparser.expression.KeyExpression;
 import net.sf.jsqlparser.expression.LambdaExpression;
@@ -1047,6 +1048,14 @@ public class ExpressionValidator extends AbstractValidator<Expression>
     public <S> Void visit(JsonTableFunction expression, S context) {
         for (Expression jsonExpression : expression.getAllExpressions()) {
             validateOptionalExpression(jsonExpression, this);
+        }
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(XmlTableFunction expression, S context) {
+        for (Expression xmlExpression : expression.getAllExpressions()) {
+            validateOptionalExpression(xmlExpression, this);
         }
         return null;
     }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -10192,6 +10192,71 @@ JsonTableFunction JsonTableBody() : {
     }
 }
 
+XmlTableFunction.XmlTablePassingClause XmlTablePassingClause() : {
+    XmlTableFunction.XmlTablePassingClause passingClause = new XmlTableFunction.XmlTablePassingClause();
+    Expression valueExpression;
+    String name = null;
+}
+{
+    valueExpression = Expression() { passingClause.setValueExpression(valueExpression); }
+    [ <K_AS> name = RelObjectName() { passingClause.setName(name); } ]
+    {
+        return passingClause;
+    }
+}
+
+XmlTableFunction.XmlTableColumnDefinition XmlTableColumnDefinition() : {
+    XmlTableFunction.XmlTableColumnDefinition columnDefinition = new XmlTableFunction.XmlTableColumnDefinition();
+    String columnName;
+    ColDataType dataType;
+    Expression expression;
+}
+{
+    columnName = RelObjectName() { columnDefinition.setColumnName(columnName); }
+    (
+        <K_FOR> <K_ORDINALITY> { columnDefinition.setForOrdinality(true); }
+        |
+        dataType = ColDataType() { columnDefinition.setDataType(dataType); }
+        [ <K_PATH> expression = Expression() { columnDefinition.setPathExpression(expression); } ]
+        [ <K_DEFAULT> expression = Expression() { columnDefinition.setDefaultExpression(expression); } ]
+    )
+    {
+        return columnDefinition;
+    }
+}
+
+XmlTableFunction XmlTableBody() : {
+    XmlTableFunction function = new XmlTableFunction();
+    Expression rowPath;
+    XmlTableFunction.XmlTablePassingClause passingClause;
+    XmlTableFunction.XmlTableColumnDefinition columnDefinition;
+}
+{
+    "("
+    rowPath = Expression() { function.setRowPathExpression(rowPath); }
+    [
+        LOOKAHEAD({ getToken(1).kind == S_IDENTIFIER && getToken(1).image.equalsIgnoreCase("PASSING") })
+        <S_IDENTIFIER>
+        passingClause = XmlTablePassingClause() { function.addPassingClause(passingClause); }
+        (
+            ","
+            passingClause = XmlTablePassingClause() { function.addPassingClause(passingClause); }
+        )*
+    ]
+    [
+        <K_COLUMNS>
+        columnDefinition = XmlTableColumnDefinition() { function.addColumnDefinition(columnDefinition); }
+        (
+            ","
+            columnDefinition = XmlTableColumnDefinition() { function.addColumnDefinition(columnDefinition); }
+        )*
+    ]
+    ")"
+    {
+        return function;
+    }
+}
+
 TableFunction TableFunction():
 {
     Token prefix = null;
@@ -10210,6 +10275,13 @@ TableFunction TableFunction():
         })
         JsonKeyword("JSON_TABLE")
         function = JsonTableBody()
+        |
+        LOOKAHEAD({
+            getToken(1).kind == S_IDENTIFIER
+                && getToken(1).image.equalsIgnoreCase("XMLTABLE")
+        })
+        <S_IDENTIFIER>
+        function = XmlTableBody()
         |
         function=Function()
     )

--- a/src/test/java/net/sf/jsqlparser/expression/XmlTableTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/XmlTableTest.java
@@ -1,0 +1,101 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.create.table.ColDataType;
+import net.sf.jsqlparser.statement.select.FromItem;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.TableFunction;
+import net.sf.jsqlparser.test.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XmlTableTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // Issue #2326: full PostgreSQL XMLTABLE example
+            "SELECT x.* FROM xmldata, XMLTABLE('//ROWS/ROW' PASSING data COLUMNS\n"
+                    + "id int PATH '@id',\n"
+                    + "ordinality FOR ORDINALITY,\n"
+                    + "\"COUNTRY_NAME\" text,\n"
+                    + "country_id text PATH 'COUNTRY_ID',\n"
+                    + "size_sq_km float PATH 'SIZE[@unit = \"sq_km\"]') x",
+            // Minimal forms
+            "SELECT * FROM XMLTABLE('//ROWS/ROW') x",
+            "SELECT * FROM XMLTABLE('//ROWS/ROW' COLUMNS id int) x",
+            "SELECT * FROM XMLTABLE('//ROWS/ROW' PASSING data) x",
+            "SELECT * FROM XMLTABLE('//ROWS/ROW' PASSING data COLUMNS id int) x",
+            // Passing alias, PATH and DEFAULT
+            "SELECT * FROM XMLTABLE('/a' PASSING data AS d COLUMNS c1 int PATH 'b' DEFAULT 0) x",
+            // DEFAULT without PATH
+            "SELECT * FROM XMLTABLE('/a' COLUMNS c1 int DEFAULT 5) x",
+            // Multiple passing arguments
+            "SELECT * FROM XMLTABLE('/a' PASSING data AS d, doc AS x COLUMNS c1 int) x"
+    })
+    void testXmlTableRoundTrip(String sqlStr) throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+    }
+
+    @Test
+    void testXmlTableStructure() throws JSQLParserException {
+        XmlTableFunction table = parseXmlTable(
+                "XMLTABLE('//ROWS/ROW' PASSING data AS d COLUMNS\n"
+                        + "id int PATH '@id', ordinality FOR ORDINALITY, country text PATH 'COUNTRY_ID')");
+
+        assertThat(table.getRowPathExpression().toString()).isEqualTo("'//ROWS/ROW'");
+        assertThat(table.getPassingClauses()).hasSize(1);
+        assertThat(table.getPassingClauses().get(0).getName()).isEqualTo("d");
+
+        assertThat(table.getColumnDefinitions()).hasSize(3);
+
+        XmlTableFunction.XmlTableColumnDefinition ordinality = table.getColumnDefinitions().get(1);
+        assertThat(ordinality.getColumnName()).isEqualTo("ordinality");
+        assertThat(ordinality.isForOrdinality()).isTrue();
+        assertThat(ordinality.getDataType()).isNull();
+
+        XmlTableFunction.XmlTableColumnDefinition valueColumn = table.getColumnDefinitions().get(2);
+        assertThat(valueColumn.getColumnName()).isEqualTo("country");
+        assertThat(valueColumn.isForOrdinality()).isFalse();
+        assertThat(valueColumn.getDataType()).isInstanceOf(ColDataType.class);
+        assertThat(valueColumn.getDataType().getDataType()).isEqualTo("text");
+        assertThat(valueColumn.getPathExpression().toString()).isEqualTo("'COUNTRY_ID'");
+    }
+
+    @Test
+    void testXmlTableDefaultExpression() throws JSQLParserException {
+        XmlTableFunction table = parseXmlTable(
+                "XMLTABLE('/a' COLUMNS c1 int PATH 'b' DEFAULT 0)");
+
+        XmlTableFunction.XmlTableColumnDefinition column = table.getColumnDefinitions().get(0);
+        assertThat(column.getPathExpression().toString()).isEqualTo("'b'");
+        assertThat(column.getDefaultExpression().toString()).isEqualTo("0");
+    }
+
+    private XmlTableFunction parseXmlTable(String xmlTableStr) throws JSQLParserException {
+        String sql = "SELECT * FROM " + xmlTableStr;
+        Statement stmt = CCJSqlParserUtil.parse(sql);
+
+        TestUtils.assertSqlCanBeParsedAndDeparsed(sql, true);
+
+        FromItem fromItem = ((PlainSelect) stmt).getFromItem();
+        assertThat(fromItem).isInstanceOf(TableFunction.class);
+        Function function = ((TableFunction) fromItem).getFunction();
+        assertThat(function).isInstanceOf(XmlTableFunction.class);
+
+        return (XmlTableFunction) function;
+    }
+}


### PR DESCRIPTION
Fixes #2326.

`XMLTABLE` (SQL/XML standard, supported by PostgreSQL and Oracle) projects an XML document into a relational row set. JSQLParser currently fails to parse it, e.g. the [PostgreSQL manual example](https://www.postgresql.org/docs/current/functions-xml.html#FUNCTIONS-XML-PROCESSING-XMLTABLE):

```sql
SELECT x.*
  FROM xmldata,
       XMLTABLE('//ROWS/ROW'
                PASSING data
                COLUMNS id int PATH '@id',
                        ordinality FOR ORDINALITY,
                        country_id text PATH 'COUNTRY_ID',
                        size_sq_km float PATH 'SIZE[@unit = "sq_km"]') x
```

It is the XML counterpart of `JSON_TABLE` and shares its `PASSING`/`COLUMNS` structure, so this mirrors the existing `JsonTableFunction`:

- a new `XmlTableFunction` AST node: a row XPath expression, an optional `PASSING value [AS name], ...` clause, and an optional `COLUMNS` clause with `name FOR ORDINALITY` or `name <type> [PATH expr] [DEFAULT expr]` per column;
- an `XmlTableBody` branch in the `TableFunction` dispatch;
- wired into `ExpressionVisitor`, `ExpressionDeParser`, `ExpressionVisitorAdapter`, `TablesNamesFinder` and `ExpressionValidator`.

The JSON-specific clauses (wrapper, error/empty handling, plan, NESTED) are intentionally out of scope, and `XMLNAMESPACES` would be a natural follow-up.

### Testing
- New `XmlTableTest` with parameterised parse/deparse round-trips (incl. the issue example, quoted column names, bracket XPath, `DEFAULT`, multiple `PASSING` arguments) plus AST assertions on the column structure.
- `./gradlew test --tests net.sf.jsqlparser.expression.XmlTableTest` is green; the full suite shows no new failures vs. `master`.
- `./gradlew spotlessCheck` passes.
