### PR TITLE
fix: support PostgreSQL GROUPS window frames

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/WindowElement.java
+++ b/src/main/java/net/sf/jsqlparser/expression/WindowElement.java
@@ -17,6 +17,7 @@ public class WindowElement implements Serializable {
     private Type type;
     private WindowOffset offset;
     private WindowRange range;
+    private Exclusion exclusion;
 
     public Type getType() {
         return type;
@@ -42,6 +43,14 @@ public class WindowElement implements Serializable {
         this.range = range;
     }
 
+    public Exclusion getExclusion() {
+        return exclusion;
+    }
+
+    public void setExclusion(Exclusion exclusion) {
+        this.exclusion = exclusion;
+    }
+
     @Override
     public String toString() {
         StringBuilder buffer = new StringBuilder(type.toString());
@@ -50,6 +59,10 @@ public class WindowElement implements Serializable {
             buffer.append(offset.toString());
         } else if (range != null) {
             buffer.append(range.toString());
+        }
+
+        if (exclusion != null) {
+            buffer.append(" EXCLUDE ").append(exclusion);
         }
 
         return buffer.toString();
@@ -70,11 +83,31 @@ public class WindowElement implements Serializable {
         return this;
     }
 
+    public WindowElement withExclusion(Exclusion exclusion) {
+        this.setExclusion(exclusion);
+        return this;
+    }
+
     public enum Type {
         ROWS, RANGE, GROUPS;
 
         public static Type from(String type) {
             return Enum.valueOf(Type.class, type.toUpperCase(Locale.ROOT));
+        }
+    }
+
+    public enum Exclusion {
+        CURRENT_ROW("CURRENT ROW"), GROUP("GROUP"), TIES("TIES"), NO_OTHERS("NO OTHERS");
+
+        private final String keyword;
+
+        Exclusion(String keyword) {
+            this.keyword = keyword;
+        }
+
+        @Override
+        public String toString() {
+            return keyword;
         }
     }
 

--- a/src/main/java/net/sf/jsqlparser/expression/WindowElement.java
+++ b/src/main/java/net/sf/jsqlparser/expression/WindowElement.java
@@ -71,7 +71,7 @@ public class WindowElement implements Serializable {
     }
 
     public enum Type {
-        ROWS, RANGE;
+        ROWS, RANGE, GROUPS;
 
         public static Type from(String type) {
             return Enum.valueOf(Type.class, type.toUpperCase(Locale.ROOT));

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1157,6 +1157,7 @@ String NonReservedWord() :
       | tk=<K_FUNCTION:"FUNCTION">
       | tk=<K_GRANT:"GRANT">
       | tk=<K_GROUP_CONCAT:"GROUP_CONCAT">
+      | tk=<K_GROUPS:"GROUPS">
       | tk=<K_GUARD:"GUARD">
       | tk=<K_HASH:"HASH">
       | tk=<K_HIGH : "HIGH">
@@ -9205,7 +9206,9 @@ WindowElement WindowElement():
     WindowOffset offset = null;
 }
 {
-    (<K_ROWS> { windowElement.setType(WindowElement.Type.ROWS); }  |  <K_RANGE> { windowElement.setType(WindowElement.Type.RANGE); } )
+    (<K_ROWS> { windowElement.setType(WindowElement.Type.ROWS); }
+     | <K_RANGE> { windowElement.setType(WindowElement.Type.RANGE); }
+     | <K_GROUPS> { windowElement.setType(WindowElement.Type.GROUPS); })
     ( (
       <K_BETWEEN> { windowElement.setRange(range); }
       offset = WindowOffset() { range.setStart(offset); }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1157,7 +1157,6 @@ String NonReservedWord() :
       | tk=<K_FUNCTION:"FUNCTION">
       | tk=<K_GRANT:"GRANT">
       | tk=<K_GROUP_CONCAT:"GROUP_CONCAT">
-      | tk=<K_GROUPS:"GROUPS">
       | tk=<K_GUARD:"GUARD">
       | tk=<K_HASH:"HASH">
       | tk=<K_HIGH : "HIGH">
@@ -1444,6 +1443,7 @@ TOKEN: /* Reserved SQL Keywords and structural tokens */
 |   <K_GLOBAL:"GLOBAL">
 |   <K_GROUP:"GROUP">
 |   <K_GROUPING:"GROUPING">
+|   <K_GROUPS:"GROUPS">
 |   <K_HAVING:"HAVING">
 |   <K_IF:"IF">
 |   <K_IIF:"IIF">
@@ -9204,6 +9204,7 @@ WindowElement WindowElement():
     WindowElement windowElement = new WindowElement();
     WindowRange range = new WindowRange();
     WindowOffset offset = null;
+    WindowElement.Exclusion exclusion = null;
 }
 {
     (<K_ROWS> { windowElement.setType(WindowElement.Type.ROWS); }
@@ -9217,10 +9218,42 @@ WindowElement WindowElement():
     |
       offset = WindowOffset() { windowElement.setOffset(offset); }
     )
+    [ exclusion = FrameExclusion() { windowElement.setExclusion(exclusion); } ]
 
     {
         return windowElement;
     }
+}
+
+WindowElement.Exclusion FrameExclusion():
+{
+    WindowElement.Exclusion exclusion = null;
+}
+{
+    <K_EXCLUDE>
+    (
+        <K_CURRENT> <K_ROW>
+        { exclusion = WindowElement.Exclusion.CURRENT_ROW; }
+        |
+        <K_GROUP>
+        { exclusion = WindowElement.Exclusion.GROUP; }
+        |
+        LOOKAHEAD({
+            getToken(1).kind == S_IDENTIFIER
+                && getToken(1).image.equalsIgnoreCase("TIES")
+        })
+        <S_IDENTIFIER>
+        { exclusion = WindowElement.Exclusion.TIES; }
+        |
+        <K_NO>
+        LOOKAHEAD({
+            getToken(1).kind == S_IDENTIFIER
+                && getToken(1).image.equalsIgnoreCase("OTHERS")
+        })
+        <S_IDENTIFIER>
+        { exclusion = WindowElement.Exclusion.NO_OTHERS; }
+    )
+    { return exclusion; }
 }
 
 WindowOffset WindowOffset():

--- a/src/test/java/net/sf/jsqlparser/statement/select/WindowFunctionTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/WindowFunctionTest.java
@@ -10,9 +10,12 @@
 package net.sf.jsqlparser.statement.select;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.AnalyticExpression;
+import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.WindowElement;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.test.TestUtils;
@@ -50,12 +53,41 @@ public class WindowFunctionTest {
                 "SELECT SUM(value) OVER (ORDER BY ts "
                         + "GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM events";
 
-        PlainSelect plainSelect = (PlainSelect) CCJSqlParserUtil.parse(sqlString);
-        AnalyticExpression analyticExpression =
-                plainSelect.getSelectItem(0).getExpression(AnalyticExpression.class);
-
-        assertEquals(WindowElement.Type.GROUPS, analyticExpression.getWindowElement().getType());
+        WindowElement windowElement = parseWindowElement(sqlString, 0);
+        assertEquals(WindowElement.Type.GROUPS, windowElement.getType());
         TestUtils.assertSqlCanBeParsedAndDeparsed(sqlString, true);
+    }
+
+    @Test
+    public void testWindowFrameGroupsExcludeTiesIssue2431() throws JSQLParserException {
+        String sqlString =
+                "SELECT id, ts, value, SUM(value) OVER (ORDER BY ts "
+                        + "GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW EXCLUDE TIES) AS sum_excl_ties "
+                        + "FROM events ORDER BY ts, id";
+
+        WindowElement windowElement = parseWindowElement(sqlString, 3);
+        assertEquals(WindowElement.Exclusion.TIES, windowElement.getExclusion());
+        TestUtils.assertSqlCanBeParsedAndDeparsed(sqlString, true);
+    }
+
+    @Test
+    public void testWindowFrameExclusionsIssue2431() throws JSQLParserException {
+        String[] sqlStrings = {
+                "SELECT SUM(value) OVER (ORDER BY ts ROWS UNBOUNDED PRECEDING EXCLUDE CURRENT ROW) FROM events",
+                "SELECT SUM(value) OVER (ORDER BY ts RANGE CURRENT ROW EXCLUDE GROUP) FROM events",
+                "SELECT SUM(value) OVER (ORDER BY ts GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW EXCLUDE TIES) FROM events",
+                "SELECT SUM(value) OVER (ORDER BY ts GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW EXCLUDE NO OTHERS) FROM events"
+        };
+
+        for (String sqlString : sqlStrings) {
+            TestUtils.assertSqlCanBeParsedAndDeparsed(sqlString, true);
+        }
+    }
+
+    @Test
+    public void testFrameExclusionIdentifierCompatibilityIssue2431() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT ties FROM ties", true);
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT others FROM others", true);
     }
 
     @Test
@@ -68,5 +100,17 @@ public class WindowFunctionTest {
 
         TestUtils.assertSqlCanBeParsedAndDeparsed(singleSidedSqlString, true);
         TestUtils.assertSqlCanBeParsedAndDeparsed(namedWindowSqlString, true);
+    }
+
+    private WindowElement parseWindowElement(String sqlString, int selectItemIndex)
+            throws JSQLParserException {
+        PlainSelect plainSelect = (PlainSelect) CCJSqlParserUtil.parse(sqlString);
+        Expression expression = plainSelect.getSelectItem(selectItemIndex).getExpression();
+        assertInstanceOf(AnalyticExpression.class, expression);
+        AnalyticExpression analyticExpression = (AnalyticExpression) expression;
+        WindowElement windowElement = analyticExpression.getWindowElement();
+
+        assertNotNull(windowElement);
+        return windowElement;
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/WindowFunctionTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/WindowFunctionTest.java
@@ -9,7 +9,12 @@
  */
 package net.sf.jsqlparser.statement.select;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.AnalyticExpression;
+import net.sf.jsqlparser.expression.WindowElement;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.test.TestUtils;
 import org.junit.jupiter.api.Test;
 
@@ -37,5 +42,31 @@ public class WindowFunctionTest {
                         + "order by venuestate;";
 
         TestUtils.assertSqlCanBeParsedAndDeparsed(sqlString, true);
+    }
+
+    @Test
+    public void testWindowFrameGroupsIssue2431() throws JSQLParserException {
+        String sqlString =
+                "SELECT SUM(value) OVER (ORDER BY ts "
+                        + "GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW) FROM events";
+
+        PlainSelect plainSelect = (PlainSelect) CCJSqlParserUtil.parse(sqlString);
+        AnalyticExpression analyticExpression =
+                plainSelect.getSelectItem(0).getExpression(AnalyticExpression.class);
+
+        assertEquals(WindowElement.Type.GROUPS, analyticExpression.getWindowElement().getType());
+        TestUtils.assertSqlCanBeParsedAndDeparsed(sqlString, true);
+    }
+
+    @Test
+    public void testWindowFrameGroupsVariantsIssue2431() throws JSQLParserException {
+        String singleSidedSqlString =
+                "SELECT SUM(value) OVER (ORDER BY ts GROUPS UNBOUNDED PRECEDING) FROM events";
+        String namedWindowSqlString =
+                "SELECT SUM(value) OVER w FROM events "
+                        + "WINDOW w AS (ORDER BY ts GROUPS BETWEEN 1 PRECEDING AND CURRENT ROW)";
+
+        TestUtils.assertSqlCanBeParsedAndDeparsed(singleSidedSqlString, true);
+        TestUtils.assertSqlCanBeParsedAndDeparsed(namedWindowSqlString, true);
     }
 }


### PR DESCRIPTION
Fixes #2431

## What

Add support for PostgreSQL `GROUPS` window frames and all four window frame exclusions.

## How

- Add `WindowElement.Type.GROUPS`.
- Treat `GROUPS` as a reserved structural keyword.
- Add `WindowElement.Exclusion` for:
  - `EXCLUDE CURRENT ROW`
  - `EXCLUDE GROUP`
  - `EXCLUDE TIES`
  - `EXCLUDE NO OTHERS`
- Keep `TIES` and `OTHERS` contextual so they remain usable as unquoted identifiers outside the frame-exclusion grammar.
- Keep deparsing centralized in `WindowElement.toString()`.

## Tests

- Assert the parsed analytic expression, non-null window element, frame type, and exclusion type.
- Cover `BETWEEN ... AND ...`, a single-sided frame, a named `WINDOW`, and all four frame exclusions.
- Verify `ties` and `others` remain usable as identifiers.
- `./gradlew clean check`
- `mvn clean verify`