### PR TITLE
fix: support SQL Server CREATE INDEX INCLUDE columns

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -10507,6 +10507,7 @@ CreateIndex CreateIndex():
     CreateIndex createIndex = new CreateIndex();
     Table table = null;
     List<Index.ColumnParams> colNames;
+    List<String> includeColumns;
     String indexType;
     Index index = null;
     List<String> parameter = new ArrayList<String>();
@@ -10535,6 +10536,9 @@ CreateIndex CreateIndex():
         )
     )
     colNames = IndexColumnsWithParamsList()
+    [ <K_INCLUDE> includeColumns=ColumnsNamesList()
+        { tailParameters.add("INCLUDE (" + String.join(", ", includeColumns) + ")"); }
+    ]
     ( LOOKAHEAD(2)  parameter=CreateParameter() { tailParameters.addAll(parameter); } )*
     {
         index.setColumns(colNames);

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
@@ -174,4 +174,9 @@ public class CreateIndexTest {
         assertSqlCanBeParsedAndDeparsed("CREATE INDEX idx_a ON t1 (a) INVISIBLE", true);
         assertSqlCanBeParsedAndDeparsed("CREATE INDEX idx_a ON t1 (a) VISIBLE", true);
     }
+
+    @Test
+    public void testCreateIndexIncludeIssue2459() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("CREATE INDEX idx_a ON t1 (a) INCLUDE (b, c)");
+    }
 }


### PR DESCRIPTION
## What changed

Added support for SQL Server `CREATE INDEX ... INCLUDE (...)` clauses.

`CreateIndex()` now consumes the `INCLUDE` column list directly after the index key columns and preserves the clause through the existing create-index tail parameters.

## Why

`K_INCLUDE` was already tokenized, but the create-index grammar did not accept it after the index key columns. As a result, statements such as:

```sql
CREATE INDEX idx_a ON t1 (a) INCLUDE (b, c)
```

failed with a `ParseException` at `K_INCLUDE`.

## Tests

- Added a regression test covering parsing and deparsing of `CREATE INDEX ... INCLUDE (b, c)`.
- Verified that the regression test fails before the grammar change and passes afterward.
- Ran:

```text
./gradlew.bat test --tests net.sf.jsqlparser.statement.create.CreateIndexTest
./gradlew.bat spotlessApply
```

Fixes #2459