### PR TITLE
fix: support PostgreSQL composite row expansion (function()).*

### DIFF
--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -925,7 +925,7 @@ public class TablesNamesFinder<Void>
 
     @Override
     public <S> Void visit(FunctionAllColumns functionAllColumns, S context) {
-
+        functionAllColumns.getFunction().accept(this, context);
         return null;
     }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -595,6 +595,55 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
     }
 
     /**
+     * Detects PostgreSQL composite row expansion {@code (function()).*} (and any
+     * number of surrounding parentheses), where a parenthesised expression wrapping
+     * a single {@link Function} is immediately followed by {@code .*}.
+     *
+     * <p>This is a constant-time follower check (unwraps the already-parsed
+     * {@code retval} and peeks the next two tokens). It deliberately avoids the
+     * speculative syntactic lookahead that previously degraded performance, see
+     * issue #2207.
+     *
+     * @param retval the expression parsed so far within the
+     *        {@code ParenthesedExpressionList} branch of {@code PrimaryExpression}
+     */
+    protected boolean isFunctionAllColumnsAhead(Expression retval) {
+        // Fast follower gate: the overwhelming majority of parenthesised
+        // expressions are not followed by ".*", so reject on the token stream
+        // before ever touching the already-parsed expression.
+        if (!getToken(1).image.equals(".") || !getToken(2).image.equals("*")) {
+            return false;
+        }
+        if (retval == null) {
+            return false;
+        }
+
+        Expression inner = retval;
+        while (inner instanceof ParenthesedExpressionList) {
+            ParenthesedExpressionList<?> parenthesed = (ParenthesedExpressionList<?>) inner;
+            if (parenthesed.size() != 1) {
+                return false;
+            }
+            inner = parenthesed.get(0);
+        }
+
+        return inner instanceof Function;
+    }
+
+    /**
+     * Unwraps any number of surrounding parentheses from a parenthesised
+     * {@link Function} and returns the inner function. Only call this after
+     * {@link #isFunctionAllColumnsAhead(Expression)} has confirmed the shape.
+     */
+    protected Function unwrapParenthesedFunction(Expression retval) {
+        Expression inner = retval;
+        while (inner instanceof ParenthesedExpressionList) {
+            inner = ((ParenthesedExpressionList<?>) inner).get(0);
+        }
+        return (Function) inner;
+    }
+
+    /**
      * Follower-based disambiguation for reserved keywords in ambiguous
      * positions (implicit alias, clause boundary, after parenthesised
      * expression, etc.).
@@ -7902,6 +7951,15 @@ Expression PrimaryExpression() #PrimaryExpression:
                     }
                 }
             )
+
+            // PostgreSQL composite row expansion: (function()).*
+            // Re-enables FunctionAllColumns, which was disabled in #2207 due to the
+            // performance toll of a speculative syntactic lookahead. A bounded
+            // semantic follower check instead reads the already-parsed retval and
+            // peeks the next two tokens, avoiding any speculative production.
+            [ LOOKAHEAD( { isFunctionAllColumnsAhead(retval) } )
+                "." "*"
+                { retval = new FunctionAllColumns(unwrapParenthesedFunction(retval)); } ]
 
             // RowGet Expressions
             ( LOOKAHEAD(2) "." tmp=RelObjectName() { retval = new RowGetExpression(retval, tmp); } )*

--- a/src/test/java/net/sf/jsqlparser/statement/select/CompositeRowExpansionTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/CompositeRowExpansionTest.java
@@ -1,0 +1,97 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.select;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * PostgreSQL composite row expansion {@code (function_returning_composite).*}.
+ *
+ * <p>
+ * This feature was merged via #2207 and afterwards disabled, because the speculative syntactic
+ * lookahead used back then caused a severe performance regression. It is re-enabled here through a
+ * bounded semantic follower check, see {@code FunctionAllColumns} in the grammar.
+ */
+public class CompositeRowExpansionTest {
+
+    private static FunctionAllColumns assertFunctionAllColumns(String sql)
+            throws JSQLParserException {
+        PlainSelect select = (PlainSelect) assertSqlCanBeParsedAndDeparsed(sql, true);
+        Expression expression = select.getSelectItems().get(0).getExpression();
+        Assertions.assertTrue(expression instanceof FunctionAllColumns,
+                "Expected a FunctionAllColumns select item but got " + expression.getClass());
+        return (FunctionAllColumns) expression;
+    }
+
+    @Test
+    public void testIssue2412JsonPopulateRecord() throws JSQLParserException {
+        FunctionAllColumns result = assertFunctionAllColumns(
+                "SELECT (json_populate_record(NULL::users, data)).* FROM staging_users");
+        Assertions.assertEquals("json_populate_record", result.getFunction().getName());
+    }
+
+    @Test
+    public void testSimpleFunctionAllColumns() throws JSQLParserException {
+        FunctionAllColumns result = assertFunctionAllColumns("SELECT (foo(a, b)).* FROM t");
+        Assertions.assertEquals("foo", result.getFunction().getName());
+    }
+
+    @Test
+    public void testPgStatFileExampleFrom2207() throws JSQLParserException {
+        FunctionAllColumns result = assertFunctionAllColumns(
+                "SELECT (pg_stat_file('postgresql.conf')).*");
+        Assertions.assertEquals("pg_stat_file", result.getFunction().getName());
+    }
+
+    @Test
+    public void testIssue2412InsertSelectUseCase() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO users SELECT (json_populate_record(NULL::users, data)).* FROM staging_users",
+                true);
+    }
+
+    @Test
+    public void testMultipleSurroundingParensAreUnwrapped() throws JSQLParserException {
+        // Redundant parentheses around a single value are semantically transparent in
+        // PostgreSQL, so they are unwrapped to the inner function. The round-trip
+        // therefore normalises to a single surrounding pair.
+        PlainSelect select = (PlainSelect) CCJSqlParserUtil.parse("SELECT ((((foo(a))))).* FROM t");
+        Expression expression = select.getSelectItems().get(0).getExpression();
+        Assertions.assertTrue(expression instanceof FunctionAllColumns);
+        Assertions.assertEquals("foo", ((FunctionAllColumns) expression).getFunction().getName());
+        Assertions.assertEquals("(foo(a)).*", expression.toString());
+    }
+
+    @Test
+    public void testParenthesedFunctionWithoutExpansionUnchanged() throws JSQLParserException {
+        // Without the trailing .* a parenthesised function stays a plain expression.
+        assertSqlCanBeParsedAndDeparsed("SELECT (foo(a, b)) FROM t", true);
+    }
+
+    @Test
+    public void testRowGetExpressionAfterParenthesedFunctionUnchanged() throws JSQLParserException {
+        // (function()).name must keep parsing as a RowGetExpression, not be swallowed.
+        assertSqlCanBeParsedAndDeparsed("SELECT (foo(a, b)).colname FROM t", true);
+    }
+
+    @Test
+    public void testNonFunctionCompositeExpansionStillUnsupported() {
+        // Expanding an arbitrary (non-function) expression is out of scope and must
+        // keep failing cleanly instead of producing a wrong AST.
+        Assertions.assertThrows(JSQLParserException.class,
+                () -> CCJSqlParserUtil.parse("SELECT (a + b).* FROM t"));
+    }
+}


### PR DESCRIPTION
## What

Re-enable PostgreSQL composite row expansion `(function_call).*`, e.g. `SELECT (json_populate_record(NULL::users, data)).* FROM staging_users`. JSQLParser currently rejects the trailing `.*`.

This builds on #2207, which added the feature and then had to disable it.

## Why

`FunctionAllColumns` (the AST node, deparser, validator and all four visitors) was fully implemented in #2207 but the **grammar call site was commented out** afterwards. The reason was a severe performance regression: the original `LOOKAHEAD(FunctionAllColumns())` at the `PrimaryExpression` entry was a *speculative syntactic* lookahead that triggered catastrophic backtracking on every primary expression (`393 ms/op` vs `~86 ms/op`). Issue #2412 is the user-visible symptom of that disabled feature.

The maintainer explicitly invited a re-enablement *"once performance can be proved"* and suggested treating `(((( FUNCTION )))).*` as a single-`Function` `ParenthesedExpressionList` followed by `.*`.

## How

The feature is wired into the **existing** `ParenthesedExpressionList` branch of `PrimaryExpression`, but via a **bounded semantic follower check** instead of a speculative production:

- A new helper `isFunctionAllColumnsAhead(Expression)` first peeks the next two tokens; only when they are `.` `*` does it unwrap nested `ParenthesedExpressionList` wrappers and confirm the inner expression is a `Function`. The common case (a parenthesised expression *not* followed by `.*`) therefore bails out in two comparisons, with no speculative production and no backtracking.
- Only then is the result wrapped into the existing `FunctionAllColumns`.
- `TablesNamesFinder` now descends into the wrapped function, so column/table references inside the expansion are not lost.

## Root cause

Not a missing feature but a feature *disabled for the wrong reason*: the perf toll came from the speculative syntactic lookahead, not from the feature itself. Removing the speculation (post-parse follower check) keeps the feature without the toll.

## Scope / limitation

Only `(function_call).*` is supported (the shape the existing `FunctionAllColumns` AST and #2207 cover). Arbitrary `(non-function expression).*` (e.g. `(a + b).*`, `(tbl.col).*`) remains unsupported and still fails cleanly, as before. Redundant surrounding parentheses are unwrapped to the inner function (so `(((( f() )))).*` round-trips as `(f()).*`, semantically equivalent).

## Testing

`CompositeRowExpansionTest` covers the issue case, simple/no-arg functions, the `INSERT ... SELECT` use case, multiple surrounding parentheses, and negative cases (no trailing `.*`, a `RowGetExpression`, a non-function expression). The positive tests fail on `master` and pass with this change.

Local: `spotlessApply`, `checkstyleMain/Test`, `spotbugsMain/Test`, and the full test suite (4731 tests) all green, no regression.

## Performance

`gradle jmh`, `JSQLParserBenchmark.parseSQLStatements` on `performance.sql`, `version=latest`, 10 forks × 10 iterations (100 samples) on a dedicated 32-core host:

| build | ms/op |
|---|---|
| master (feature disabled) | `3.632 ± 0.020` |
| this change | `3.639 ± 0.023` |

The `+0.19%` delta lies within the confidence intervals (the CIs overlap almost entirely) and is far from the `393 ms/op` toll that motivated disabling the feature.

## Verification of the original issue

```
SELECT (json_populate_record(NULL::users, data)).* FROM staging_users
```
fails on `master` (`Encountered: "."`) and parses + round-trips with this change, yielding a `FunctionAllColumns` select item.

Fixes #2412
