### PR TITLE
fix: allow scalar subquery as LIMIT row count (#2359)

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -5383,8 +5383,19 @@ PlainSelect PlainSelect() #PlainSelect:
     [ LOOKAHEAD(<K_ORDER> <K_BY>) orderByElements = OrderByElements() { plainSelect.setOrderByElements(orderByElements); } ]
     [ LOOKAHEAD(2) forClause = ForClause() {plainSelect.setForClause(forClause);} ]
     [ LOOKAHEAD(2) <K_EMIT> <K_CHANGES> { plainSelect.setEmitChanges(true); } ]
-    [ LOOKAHEAD(7) limit = LimitBy() { plainSelect.setLimitBy(limit);  } ]
-    [ LOOKAHEAD(<K_LIMIT>) limit = LimitWithOffset() { plainSelect.setLimit(limit);    } ]
+    // Parse the LIMIT row count once (this accepts a parenthesized subquery too), then
+    // optionally attach ClickHouse's `LIMIT ... BY ...`. Checking BY right after the limit
+    // expression avoids a numeric LOOKAHEAD, which cannot see past a long parenthesized
+    // subquery and would wrongly commit to LIMIT BY (issue #2359).
+    [ LOOKAHEAD(<K_LIMIT>) limit = LimitWithOffset()
+        [ LOOKAHEAD(<K_BY>) <K_BY> expressionList = ExpressionList() { limit.setByExpressions(expressionList); } ]
+        {
+            if (limit.getByExpressions() != null) {
+                plainSelect.setLimitBy(limit);
+            } else {
+                plainSelect.setLimit(limit);
+            }
+        } ]
     [ LOOKAHEAD(<K_OFFSET>) offset = Offset() { plainSelect.setOffset(offset);    } ]
 	[ LOOKAHEAD(<K_LIMIT>, { limit==null }) limit = LimitWithOffset() { plainSelect.setLimit(limit);    } ]
     [ LOOKAHEAD(<K_FETCH>) fetch = Fetch() { plainSelect.setFetch(fetch);    } ]
@@ -6769,24 +6780,6 @@ Limit PlainLimit() #PlainLimit:
     {
         limit.setRowCount(rowCountExpression);
         linkAST(limit,jjtThis);
-        return limit;
-    }
-}
-
-/**
- * Clickhouse LIMIT BY
- * @see <a href='https://clickhouse.com/docs/en/sql-reference/statements/select'>SELECT Query</a>
- */
-Limit LimitBy():
-{
-    Limit limit;
-    ExpressionList byExpressions;
-}
-{
-    limit = LimitWithOffset()
-    <K_BY> byExpressions = ExpressionList()
-    {
-        limit.setByExpressions(byExpressions);
         return limit;
     }
 }

--- a/src/test/java/net/sf/jsqlparser/expression/LimitExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/LimitExpressionTest.java
@@ -11,6 +11,7 @@ package net.sf.jsqlparser.expression;
 
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.select.ParenthesedSelect;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.test.TestUtils;
 import org.junit.jupiter.api.Assertions;
@@ -29,6 +30,38 @@ public class LimitExpressionTest {
 
         TestUtils.assertSqlCanBeParsedAndDeparsed(
                 "SELECT * FROM tmp3 LIMIT (SELECT 2)", true);
+    }
+
+    @Test
+    public void testIssue2359() throws JSQLParserException {
+        // PostgreSQL allows any expression, including a scalar subquery, as the LIMIT row
+        // count. A long parenthesized subquery used to fail because the ClickHouse
+        // "LIMIT ... BY ..." branch was chosen by a numeric LOOKAHEAD that cannot see past
+        // the subquery.
+        String sql = "WITH some_table AS (SELECT 1 AS some_column), "
+                + "another_table AS (SELECT 'some_value' AS condition_column) "
+                + "SELECT some_column FROM some_table ORDER BY some_column "
+                + "LIMIT (SELECT COUNT(*) FROM another_table WHERE condition_column = 'some_value')";
+
+        PlainSelect plainSelect = (PlainSelect) CCJSqlParserUtil.parse(sql);
+        Assertions.assertTrue(
+                plainSelect.getLimit().getRowCount() instanceof ParenthesedSelect);
+        Assertions.assertNull(plainSelect.getLimitBy());
+
+        TestUtils.assertSqlCanBeParsedAndDeparsed(sql, true);
+
+        // A function wrapping a scalar subquery must work as the row count too.
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT a FROM t LIMIT GREATEST(0, (SELECT COUNT(*) FROM u WHERE c = 'x'))",
+                true);
+    }
+
+    @Test
+    public void testLimitByClickHouseUnchanged() throws JSQLParserException {
+        // ClickHouse "LIMIT ... BY ..." must keep parsing and round-tripping after the LIMIT
+        // row-count disambiguation was rewritten (issue #2359).
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT id FROM t LIMIT 5 BY id", true);
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT id FROM t LIMIT 2, 5 BY id", true);
     }
 
     @Test


### PR DESCRIPTION
## What

Allow any expression, including a scalar subquery, as the LIMIT row count, e.g.:

```sql
LIMIT (SELECT COUNT(*) FROM t WHERE ...)
LIMIT GREATEST(0, (SELECT COUNT(*) FROM t WHERE ...))
```

JSQLParser currently rejects these with `Encountered: <EOF> ... Was expecting: "BY"`.

## Why / Root cause

As you noted in the issue, a `LOOKAHEAD` is too tight. `PlainSelect` disambiguated the ClickHouse `LIMIT ... BY ...` branch from a plain limit with a numeric `LOOKAHEAD(7)` on `LimitBy()`. A numeric lookahead cannot see past a long parenthesized subquery, so for `LIMIT (SELECT COUNT(*) FROM ... WHERE ...)` it wrongly committed to the `LIMIT BY` branch and then failed at the missing `BY`. Short subqueries such as `LIMIT (SELECT 1)` happened to stay under the 7-token window and worked, which is why only longer ones failed.

A naive fix (scanning ahead for a `BY` token) would not work, because a subquery may legitimately contain `ORDER BY`, whose `BY` is the same `K_BY` token.

## How

The disambiguation is moved to where it belongs: parse the LIMIT row count **once** via `LimitWithOffset()` (which already accepts a parenthesized subquery through its `LOOKAHEAD(3) ParenthesedSelect()` branch), then check the **immediately following** token for `BY`:

```jjtree
[ LOOKAHEAD(<K_LIMIT>) limit = LimitWithOffset()
    [ LOOKAHEAD(<K_BY>) <K_BY> expressionList = ExpressionList() { limit.setByExpressions(expressionList); } ]
    {
        if (limit.getByExpressions() != null) {
            plainSelect.setLimitBy(limit);
        } else {
            plainSelect.setLimit(limit);
        }
    } ]
```

`LimitWithOffset` already carries `byExpressions`, so there is **no AST and no public API change**. The now-unused `LimitBy()` production is removed (it was only ever called from this one site).

## Scope

All existing LIMIT shapes keep working: `LIMIT n`, `LIMIT n, m`, `LIMIT n OFFSET m`, `OFFSET m LIMIT n`, `LIMIT ALL`, and ClickHouse `LIMIT n BY ...` / `LIMIT n, m BY ...`. The previously-unsupported `OFFSET m LIMIT n BY x` ordering stays unsupported (out of scope, unchanged).

## Testing

`LimitExpressionTest.testIssue2359` reproduces the issue (fails on `master`, passes with this change) and asserts the row count is a `ParenthesedSelect` stored on `limit` (not `limitBy`). `testLimitByClickHouseUnchanged` guards the rewritten `LIMIT ... BY ...` path.

Local: `spotlessApply`, `checkstyleMain/Test`, `spotbugsMain`, `pmdMain` clean; `SelectTest` (725), `ClickHouseTest` (15), `LimitExpressionTest` (6) and the full test suite green apart from pre-existing failures unrelated to this change (`ParserKeywordsUtilsTest` writing a temp file to `C:\WINDOWS`, and Mockito `MockMaker` init on JDK 21).

## Performance

`gradle jmh`, `JSQLParserBenchmark.parseSQLStatements` on `performance.sql`, `version=latest`, 10 forks × 10 iterations (100 samples) on a 32-core host:

| build | ms/op |
|---|---|
| master (`LOOKAHEAD(7) LimitBy()`) | `3.598 ± 0.017` |
| this change | `3.603 ± 0.017` |

The `+0.14%` delta lies within the 99.9% confidence intervals (the CIs overlap almost entirely): no regression.

## Verification of the original issue

```sql
WITH some_table AS (SELECT 1 AS some_column),
     another_table AS (SELECT 'some_value' AS condition_column)
SELECT some_column FROM some_table ORDER BY some_column
LIMIT (SELECT COUNT(*) FROM another_table WHERE condition_column = 'some_value')
```
fails on `master` and parses + round-trips with this change.

Fixes #2359

