### PR TITLE
fix: support ClickHouse C-style ternary operator (? :) (#2436)

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -737,6 +737,12 @@ public interface ExpressionVisitor<T> {
         this.visit(rangeExpression, null);
     }
 
+    <S> T visit(TernaryExpression ternaryExpression, S context);
+
+    default void visit(TernaryExpression ternaryExpression) {
+        this.visit(ternaryExpression, null);
+    }
+
     <S> T visit(TSQLLeftJoin tsqlLeftJoin, S context);
 
     default void visit(TSQLLeftJoin tsqlLeftJoin) {

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -823,6 +823,12 @@ public class ExpressionVisitorAdapter<T>
     }
 
     @Override
+    public <S> T visit(TernaryExpression ternaryExpression, S context) {
+        return visitExpressions(ternaryExpression, context, ternaryExpression.getCondition(),
+                ternaryExpression.getThenExpression(), ternaryExpression.getElseExpression());
+    }
+
+    @Override
     public <S> T visit(TSQLLeftJoin tsqlLeftJoin, S context) {
         return visitBinaryExpression(tsqlLeftJoin, context);
     }

--- a/src/main/java/net/sf/jsqlparser/expression/TernaryExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/TernaryExpression.java
@@ -1,0 +1,68 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2025 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
+/**
+ * The C-style ternary conditional operator {@code condition ? thenExpression : elseExpression},
+ * supported for instance by ClickHouse as an alias for {@code if(condition, then, else)}.
+ */
+public class TernaryExpression extends ASTNodeAccessImpl implements Expression {
+    private Expression condition;
+    private Expression thenExpression;
+    private Expression elseExpression;
+
+    public TernaryExpression() {}
+
+    public TernaryExpression(Expression condition, Expression thenExpression,
+            Expression elseExpression) {
+        this.condition = condition;
+        this.thenExpression = thenExpression;
+        this.elseExpression = elseExpression;
+    }
+
+    public Expression getCondition() {
+        return condition;
+    }
+
+    public TernaryExpression setCondition(Expression condition) {
+        this.condition = condition;
+        return this;
+    }
+
+    public Expression getThenExpression() {
+        return thenExpression;
+    }
+
+    public TernaryExpression setThenExpression(Expression thenExpression) {
+        this.thenExpression = thenExpression;
+        return this;
+    }
+
+    public Expression getElseExpression() {
+        return elseExpression;
+    }
+
+    public TernaryExpression setElseExpression(Expression elseExpression) {
+        this.elseExpression = elseExpression;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return condition + " ? " + thenExpression + " : " + elseExpression;
+    }
+
+    @Override
+    public <T, S> T accept(ExpressionVisitor<T> expressionVisitor, S context) {
+        return expressionVisitor.visit(this, context);
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -249,6 +249,14 @@ public class TablesNamesFinder<Void>
         return null;
     }
 
+    @Override
+    public <S> Void visit(TernaryExpression ternaryExpression, S context) {
+        ternaryExpression.getCondition().accept(this, context);
+        ternaryExpression.getThenExpression().accept(this, context);
+        ternaryExpression.getElseExpression().accept(this, context);
+        return null;
+    }
+
     /**
      * Main entry for this Tool class. A list of found tables is returned.
      */

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -62,6 +62,7 @@ import net.sf.jsqlparser.expression.OracleNamedFunctionParameter;
 import net.sf.jsqlparser.expression.OverlapsCondition;
 import net.sf.jsqlparser.expression.PostgresNamedFunctionParameter;
 import net.sf.jsqlparser.expression.RangeExpression;
+import net.sf.jsqlparser.expression.TernaryExpression;
 import net.sf.jsqlparser.expression.RowConstructor;
 import net.sf.jsqlparser.expression.RowGetExpression;
 import net.sf.jsqlparser.expression.SignedExpression;
@@ -819,6 +820,16 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
     }
 
     @Override
+    public <S> StringBuilder visit(TernaryExpression ternaryExpression, S context) {
+        ternaryExpression.getCondition().accept(this, context);
+        builder.append(" ? ");
+        ternaryExpression.getThenExpression().accept(this, context);
+        builder.append(" : ");
+        ternaryExpression.getElseExpression().accept(this, context);
+        return builder;
+    }
+
+    @Override
     public <S> StringBuilder visit(Column tableColumn, S context) {
         final Table table = tableColumn.getTable();
         String tableName = null;
@@ -1043,6 +1054,10 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
 
     public void visit(RangeExpression rangeExpression) {
         visit(rangeExpression, null);
+    }
+
+    public void visit(TernaryExpression ternaryExpression) {
+        visit(ternaryExpression, null);
     }
 
     public void visit(Column tableColumn) {

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
@@ -56,6 +56,7 @@ import net.sf.jsqlparser.expression.OracleNamedFunctionParameter;
 import net.sf.jsqlparser.expression.OverlapsCondition;
 import net.sf.jsqlparser.expression.PostgresNamedFunctionParameter;
 import net.sf.jsqlparser.expression.RangeExpression;
+import net.sf.jsqlparser.expression.TernaryExpression;
 import net.sf.jsqlparser.expression.RowConstructor;
 import net.sf.jsqlparser.expression.RowGetExpression;
 import net.sf.jsqlparser.expression.SignedExpression;
@@ -1154,6 +1155,14 @@ public class ExpressionValidator extends AbstractValidator<Expression>
     }
 
     @Override
+    public <S> Void visit(TernaryExpression ternaryExpression, S context) {
+        ternaryExpression.getCondition().accept(this, context);
+        ternaryExpression.getThenExpression().accept(this, context);
+        ternaryExpression.getElseExpression().accept(this, context);
+        return null;
+    }
+
+    @Override
     public <S> Void visit(TSQLLeftJoin tsqlLeftJoin, S context) {
         tsqlLeftJoin.getLeftExpression().accept(this, context);
         tsqlLeftJoin.getRightExpression().accept(this, context);
@@ -1308,6 +1317,10 @@ public class ExpressionValidator extends AbstractValidator<Expression>
 
     public void visit(RangeExpression rangeExpression) {
         visit(rangeExpression, null);
+    }
+
+    public void visit(TernaryExpression ternaryExpression) {
+        visit(ternaryExpression, null);
     }
 
     public void visit(TSQLLeftJoin tsqlLeftJoin) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -101,6 +101,10 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
     	return this;
     }
 
+    // depth of open ClickHouse-style ternary then-branches: a ":" directly after the
+    // then-branch closes the ternary and must not be taken as the JSON path operator
+    private int ternaryThenBranchDepth = 0;
+
     private void linkAST(ASTNodeAccess access, Node node) {
         access.setASTNode(node);
         node.jjtSetValue(access);
@@ -182,6 +186,11 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
                 // comparison operator follows after "(" "+" ")"
                 return isComparisonOperator(getToken(4));
             }
+            if ("?".equals(token.image) && isTernaryAhead()) {
+                // ClickHouse ternary `cond ? then : else` — the `?` must not be taken
+                // as the PostgreSQL JSON operator here, it is consumed by prattExpressionRest
+                return false;
+            }
             return isComparisonOperator(token);
         } catch (Exception e) {
             return false;
@@ -209,6 +218,52 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
             case '^': return token.image.startsWith("^=");
             case '&': return token.image.equals("&&") || token.image.equals("&>");
             default:  return false;
+        }
+    }
+
+    /**
+     * True when the pending "?" starts a ClickHouse-style ternary conditional
+     * {@code cond ? then : else} rather than the PostgreSQL JSON operator:
+     * a standalone ":" closes the then-branch at the same nesting depth before
+     * any expression boundary (",", ";", EOF, an unbalanced closing bracket or a
+     * clause keyword such as FROM/WHERE).
+     */
+    protected boolean isTernaryAhead() {
+        try {
+            int depth = 0;
+            for (int i = 2; ; i++) {
+                Token t = getToken(i);
+                if (t == null || t.kind == EOF) {
+                    return false;
+                }
+                String image = t.image;
+                if ("(".equals(image) || "[".equals(image)) {
+                    depth++;
+                } else if (")".equals(image) || "]".equals(image)) {
+                    if (depth == 0) {
+                        return false;
+                    }
+                    depth--;
+                } else if (depth == 0) {
+                    if (":".equals(image)) {
+                        return true;
+                    }
+                    if (",".equals(image) || ";".equals(image)) {
+                        return false;
+                    }
+                    switch (t.kind) {
+                        case K_SELECT: case K_FROM: case K_WHERE: case K_GROUP:
+                        case K_HAVING: case K_ORDER: case K_LIMIT: case K_UNION:
+                        case K_INTERSECT: case K_EXCEPT: case K_MINUS: case K_INTO:
+                        case K_VALUES: case K_FETCH: case K_OFFSET:
+                            return false;
+                        default:
+                            break;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            return false;
         }
     }
 
@@ -328,12 +383,35 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
      */
     protected Expression prattExpressionRest(Expression left, int minPrec) throws ParseException {
         while (!interrupted) {
-            int op = getToken(1).kind;
+            Token t = getToken(1);
+            int op = t.kind;
+            boolean ternary = "?".equals(t.image) && isTernaryAhead();
             int prec;
             if      (op == K_AND || op == OP_DOUBLEAND) prec = 4;
             else if (op == K_XOR || op == K_OR)         prec = 2;
+            else if (ternary)                           prec = 2;
             else break;
             if (prec < minPrec) break;
+            if (ternary) {
+                // ClickHouse-style ternary conditional: cond ? then : else
+                // Right-associative: both branches parse at the full expression
+                // level (prec 2), nested ternaries are absorbed by the else-branch.
+                jj_consume_token(op, t.image);
+                Expression thenExpression;
+                ternaryThenBranchDepth++;
+                try {
+                    thenExpression = prattExpressionRest(Condition(), 2);
+                } finally {
+                    ternaryThenBranchDepth--;
+                }
+                if (!":".equals(getToken(1).image)) {
+                    throw new ParseException("Expected ':' closing the ternary conditional operator");
+                }
+                jj_consume_token(getToken(1).kind, getToken(1).image);
+                Expression elseExpression = prattExpressionRest(Condition(), 2);
+                left = new TernaryExpression(left, thenExpression, elseExpression);
+                continue;
+            }
             jj_consume_token(op, getToken(1).image);
             // +1 makes OR/AND/XOR left-associative
             Expression right = prattExpressionRest(Condition(), prec + 1);
@@ -920,6 +998,9 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
         if (t.kind == OPENING_BRACKET && getToken(2).image.equals("+")) {
             return isComparisonOperator(getToken(4));
         }
+        // ClickHouse ternary `cond ? then : else` — the `?` must not be taken as the
+        // PostgreSQL JSON operator, it is consumed by prattExpressionRest instead
+        if ("?".equals(t.image) && isTernaryAhead()) return false;
         if (isComparisonOperator(t)) return true;
         switch (t.kind) {
             // Each suffix's start token:
@@ -7980,7 +8061,7 @@ Expression PrimaryExpression() #PrimaryExpression:
 
     // Check for JSON operands
     [
-        LOOKAHEAD(2) (
+        LOOKAHEAD(2, { ternaryThenBranchDepth == 0 || !":".equals(getToken(1).image) }) (
             LOOKAHEAD(2) (
                 token="->"
                 |
@@ -8310,7 +8391,7 @@ JsonExpression JsonExpression(Expression expr, List<Map.Entry<Expression, String
         }
 
         (
-            LOOKAHEAD(2) (
+            LOOKAHEAD(2, { ternaryThenBranchDepth == 0 || !":".equals(getToken(1).image) }) (
                 token="->"
                 |
                 token=":"

--- a/src/test/java/net/sf/jsqlparser/expression/TernaryExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/TernaryExpressionTest.java
@@ -1,0 +1,132 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2025 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
+import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
+import net.sf.jsqlparser.expression.operators.relational.ComparisonOperator;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+
+/**
+ * Tests for the ClickHouse-style ternary conditional operator {@code cond ? then : else}.
+ */
+class TernaryExpressionTest {
+
+    @Test
+    void testIssue2436() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT x > 0 ? 'y' : 'n' FROM t", true);
+
+        Select select = (Select) CCJSqlParserUtil.parse("SELECT x > 0 ? 'y' : 'n' FROM t");
+        TernaryExpression ternary = (TernaryExpression) ((PlainSelect) select).getSelectItem(0)
+                .getExpression();
+        Assertions.assertTrue(ternary.getCondition() instanceof ComparisonOperator);
+        Assertions.assertTrue(ternary.getThenExpression() instanceof StringValue);
+        Assertions.assertTrue(ternary.getElseExpression() instanceof StringValue);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // select items, where, order by, group by, having
+            "SELECT a ? b : c FROM t",
+            "SELECT * FROM t WHERE a ? b : c",
+            "SELECT * FROM t WHERE a ? b : c ORDER BY x ? y : z",
+            "SELECT id FROM t GROUP BY v ? 1 : 0 HAVING count(*) > 1",
+            // function arguments, nested in parentheses and subqueries
+            "SELECT abs(a ? b : c) FROM t",
+            "SELECT (a ? b : c) FROM t",
+            "SELECT * FROM (SELECT a ? b : c AS v FROM t) x",
+            // dml statements
+            "UPDATE t SET v = a ? b : c",
+            "INSERT INTO t VALUES (a ? b : c)",
+            "DELETE FROM t WHERE a ? b : c",
+            // joins
+            "SELECT * FROM t1 JOIN t2 ON t1.a ? t1.b : t2.c",
+            // branches with arithmetic or boolean operators
+            "SELECT x > 0 ? 1 + 2 : 3 * 4 FROM t",
+            "SELECT a ? b OR c : d AND e FROM t",
+            "SELECT a IS NULL ? 'x' : y FROM t",
+            // jdbc parameters as branches
+            "SELECT a ? ? : c FROM t",
+            "SELECT a ? b : ? FROM t",
+            "SELECT * FROM t WHERE x = ? AND y ? z : w",
+            // case expression inside a branch
+            "SELECT a ? CASE WHEN b THEN c ELSE d END : e FROM t"
+    })
+    void testTernaryInVariousContexts(String sqlStr) throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+    }
+
+    @Test
+    void testPrecedenceBindsLooserThanBooleanOperators() throws JSQLParserException {
+        Select select = (Select) CCJSqlParserUtil
+                .parse("SELECT * FROM t WHERE a OR b ? c : d");
+        Expression where = ((PlainSelect) select).getWhere();
+        Assertions.assertTrue(where instanceof TernaryExpression);
+        Assertions.assertTrue(((TernaryExpression) where).getCondition() instanceof OrExpression);
+
+        select = (Select) CCJSqlParserUtil.parse("SELECT * FROM t WHERE a AND b ? c : d");
+        where = ((PlainSelect) select).getWhere();
+        Assertions.assertTrue(where instanceof TernaryExpression);
+        Assertions.assertTrue(((TernaryExpression) where).getCondition() instanceof AndExpression);
+
+        select = (Select) CCJSqlParserUtil.parse("SELECT * FROM t WHERE a ? b : c OR d");
+        where = ((PlainSelect) select).getWhere();
+        Assertions.assertTrue(where instanceof TernaryExpression);
+        Assertions.assertTrue(
+                ((TernaryExpression) where).getElseExpression() instanceof OrExpression);
+    }
+
+    @Test
+    void testRightAssociativeNesting() throws JSQLParserException {
+        // a ? b : c ? d : e ==> a ? b : (c ? d : e)
+        Select select = (Select) CCJSqlParserUtil.parse("SELECT * FROM t WHERE a ? b : c ? d : e");
+        TernaryExpression ternary = (TernaryExpression) ((PlainSelect) select).getWhere();
+        Assertions.assertTrue(ternary.getThenExpression() instanceof Column);
+        Assertions.assertTrue(ternary.getElseExpression() instanceof TernaryExpression);
+
+        // a ? b ? c : d : e ==> a ? (b ? c : d) : e
+        select = (Select) CCJSqlParserUtil.parse("SELECT * FROM t WHERE a ? b ? c : d : e");
+        ternary = (TernaryExpression) ((PlainSelect) select).getWhere();
+        Assertions.assertTrue(ternary.getThenExpression() instanceof TernaryExpression);
+        Assertions.assertTrue(ternary.getElseExpression() instanceof Column);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // PostgreSQL JSON operators must keep working
+            "SELECT col ? 'key' FROM t",
+            "SELECT col ?| 'key' FROM t",
+            "SELECT col ?& 'key' FROM t",
+            "SELECT * FROM t WHERE col ? 'key' AND x = 1",
+            // JSON path operator must keep working
+            "SELECT col -> 'key' FROM t",
+            // JDBC parameters must keep working
+            "SELECT * FROM t WHERE x = ?",
+            "SELECT * FROM t WHERE x = ?5",
+            "SELECT * FROM t WHERE x = ? AND y = ?",
+            "SELECT * FROM t LIMIT ?",
+            // array ranges and casts are unaffected
+            "SELECT ARRAY[1:3]",
+            "SELECT CAST(a AS CHAR)"
+    })
+    void testUnrelatedSyntaxUnaffected(String sqlStr) throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+    }
+}


### PR DESCRIPTION
## What

Support the ClickHouse C-style ternary conditional operator `cond ? then : else` (an alias for `if(cond, then, else)`), fixing #2436:

```sql
SELECT x > 0 ? 'y' : 'n' FROM t
SELECT * FROM t WHERE a OR b ? c : d
SELECT abs(x > 0 ? 1 : 2) FROM t
```

JSQLParser currently rejects these with `ParseException: Encountered: "?"`.

## Why / Root cause

`?` is already double-booked in the grammar: as a JDBC parameter atom (`JdbcParameter`) and as the PostgreSQL JSON existence operator (`RegularConditionRHS` consumes `expr ? 'key'`). The ternary needs the third reading: `?` **after** a complete boolean expression, closed by a `:`. Neither existing path can express that, so `x > 0 ? 'y' : 'n'` fails at the `?`.

## How

The ternary is integrated into the existing Pratt boolean loop `prattExpressionRest`, at the same precedence level as `OR` (C semantics: binds looser than `AND`/`OR`, right-associative):

- a pending `?` is routed to the ternary via a new `isTernaryAhead()` scan (same pattern as `isUnparenthesizedSelectAhead`): it is a ternary when a standalone `:` closes the then-branch at the same nesting depth before any expression boundary (`,`, `;`, `)`, EOF, clause keyword). Otherwise the `?` keeps its current meaning as the JSON operator — `isConditionSuffixAhead()`/`isComparisonOperatorAhead()` decline it only when it is a ternary.
- the `:` separator collided with the JSON path operator (`b : path` in `PrimaryExpression`/`JsonExpression`); inside a then-branch a top-level `:` now closes the ternary instead (guarded by a `ternaryThenBranchDepth` counter, `LOOKAHEAD(2, { ... })`).

AST: new `TernaryExpression(condition, thenExpression, elseExpression)` wired into `ExpressionVisitor`, `ExpressionVisitorAdapter`, `TablesNamesFinder`, `ExpressionDeParser` and `ExpressionValidator`, following the pattern of `RangeExpression`.

## Scope

Works in every expression context (select items, `WHERE`, `GROUP BY`/`HAVING`, `ORDER BY`, function arguments, join `ON`, `UPDATE SET`, `INSERT VALUES`, subqueries, nested ternaries in both branches, JDBC parameters as branches). The PostgreSQL JSON operators (`?`, `?|`, `?&`, `->`, `:` paths) and JDBC parameters (`?`, `?5`, `LIMIT ?`) keep parsing unchanged; a JSON `?` followed later by a top-level `:` at depth 0 is inherently ambiguous across dialects and stays a JSON operator only when no `:` closes it first.

## Testing

`TernaryExpressionTest` (32 tests): the issue case with AST shape assertions, 16 context round-trips (parse + deparse), precedence/associativity AST assertions (`a OR b ? c : d` groups as `(a OR b) ? c : d`, `a ? b : c ? d : e` nests right), and 11 unaffected-syntax guards for JSON operators, JSON paths, JDBC parameters and array ranges.

Local: `spotlessApply`, `checkstyleMain/Test`, `spotbugsMain`, `pmdMain` clean; full test suite green (4737 tests, 0 failures).

## Performance

`gradle jmh`, `JSQLParserBenchmark.parseSQLStatements` on `performance.sql`, `version=latest`, 10 forks × 10 iterations (100 samples) on a 32-core host:

| build | ms/op |
|---|---|
| master | `3.714 ± 0.021` |
| this change | `3.730 ± 0.023` |

The `+0.43%` delta lies within the 99.9% confidence intervals (the CIs overlap from `3.707` to `3.735`): no regression. When no `?` is present the only added cost is one string comparison per `prattExpressionRest` iteration.

## Verification of the original issue

`SELECT x > 0 ? 'y' : 'n' FROM t` now parses and round-trips:

```
SELECT x > 0 ? 'y' : 'n' FROM t
condition      : x > 0 (GreaterThan)
thenExpression : 'y'
elseExpression : 'n'
```
