### PR TITLE
feat: support CREATE DATABASE (#2070)

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
+++ b/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
@@ -30,6 +30,7 @@ import net.sf.jsqlparser.statement.alter.Alter;
 import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.analyze.Analyze;
 import net.sf.jsqlparser.statement.comment.Comment;
+import net.sf.jsqlparser.statement.create.database.CreateDatabase;
 import net.sf.jsqlparser.statement.create.function.CreateFunction;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.procedure.CreateProcedure;
@@ -475,6 +476,12 @@ public enum Feature {
      */
     drop, dropTable, dropIndex, dropView, dropSchema, dropSequence, dropTableIfExists, dropIndexIfExists, dropViewIfExists, dropSchemaIfExists, dropSequenceIfExists,
 
+    /**
+     * SQL "CREATE DATABASE" statement is allowed
+     *
+     * @see CreateDatabase
+     */
+    createDatabase,
     /**
      * SQL "CREATE SCHEMA" statement is allowed
      *

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitor.java
@@ -16,6 +16,7 @@ import net.sf.jsqlparser.statement.alter.RenameTableStatement;
 import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.analyze.Analyze;
 import net.sf.jsqlparser.statement.comment.Comment;
+import net.sf.jsqlparser.statement.create.database.CreateDatabase;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.policy.CreatePolicy;
 import net.sf.jsqlparser.statement.create.schema.CreateSchema;
@@ -116,6 +117,12 @@ public interface StatementVisitor<T> {
 
     default void visit(CreateSchema createSchema) {
         this.visit(createSchema, null);
+    }
+
+    <S> T visit(CreateDatabase createDatabase, S context);
+
+    default void visit(CreateDatabase createDatabase) {
+        this.visit(createDatabase, null);
     }
 
     <S> T visit(CreateTable createTable, S context);

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
@@ -20,6 +20,7 @@ import net.sf.jsqlparser.statement.alter.RenameTableStatement;
 import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.analyze.Analyze;
 import net.sf.jsqlparser.statement.comment.Comment;
+import net.sf.jsqlparser.statement.create.database.CreateDatabase;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.policy.CreatePolicy;
 import net.sf.jsqlparser.statement.create.schema.CreateSchema;
@@ -258,6 +259,11 @@ public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
 
     @Override
     public <S> T visit(CreateSchema createSchema, S context) {
+        return null;
+    }
+
+    @Override
+    public <S> T visit(CreateDatabase createDatabase, S context) {
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/create/database/CreateDatabase.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/database/CreateDatabase.java
@@ -1,0 +1,113 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.database;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.StatementVisitor;
+
+/**
+ * A {@code CREATE DATABASE} statement. Modelled after MySQL, where the statement takes an optional
+ * {@code IF NOT EXISTS} and vendor-specific options, which are captured verbatim.
+ */
+public class CreateDatabase implements Statement {
+
+    private String databaseName;
+    private boolean hasIfNotExists = false;
+    private List<String> databaseOptions = null;
+
+    @Override
+    public <T, S> T accept(StatementVisitor<T> statementVisitor, S context) {
+        return statementVisitor.visit(this, context);
+    }
+
+    /**
+     * The name of the database.
+     *
+     * @return the database name
+     */
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public CreateDatabase setDatabaseName(String databaseName) {
+        this.databaseName = databaseName;
+        return this;
+    }
+
+    public boolean hasIfNotExists() {
+        return hasIfNotExists;
+    }
+
+    public CreateDatabase setIfNotExists(boolean hasIfNotExists) {
+        this.hasIfNotExists = hasIfNotExists;
+        return this;
+    }
+
+    /**
+     * The vendor-specific options of the database, captured as raw tokens.
+     *
+     * @return the list of option tokens, {@code null} when no options were given
+     */
+    public List<String> getDatabaseOptions() {
+        return databaseOptions;
+    }
+
+    public CreateDatabase setDatabaseOptions(List<String> databaseOptions) {
+        this.databaseOptions = databaseOptions;
+        return this;
+    }
+
+    public CreateDatabase withDatabaseName(String databaseName) {
+        return this.setDatabaseName(databaseName);
+    }
+
+    public CreateDatabase withIfNotExists(boolean hasIfNotExists) {
+        return this.setIfNotExists(hasIfNotExists);
+    }
+
+    public CreateDatabase withDatabaseOptions(List<String> databaseOptions) {
+        return this.setDatabaseOptions(databaseOptions);
+    }
+
+    public CreateDatabase addDatabaseOptions(String... databaseOptions) {
+        List<String> collection =
+                Optional.ofNullable(getDatabaseOptions()).orElseGet(ArrayList::new);
+        Collections.addAll(collection, databaseOptions);
+        return this.withDatabaseOptions(collection);
+    }
+
+    public CreateDatabase addDatabaseOptions(Collection<String> databaseOptions) {
+        List<String> collection =
+                Optional.ofNullable(getDatabaseOptions()).orElseGet(ArrayList::new);
+        collection.addAll(databaseOptions);
+        return this.withDatabaseOptions(collection);
+    }
+
+    @Override
+    public String toString() {
+        String sql = "CREATE DATABASE";
+        if (hasIfNotExists) {
+            sql += " IF NOT EXISTS";
+        }
+        if (databaseName != null) {
+            sql += " " + databaseName;
+        }
+        if (databaseOptions != null && !databaseOptions.isEmpty()) {
+            sql += " " + String.join(" ", databaseOptions);
+        }
+        return sql;
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -94,6 +94,7 @@ import net.sf.jsqlparser.statement.alter.RenameTableStatement;
 import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.analyze.Analyze;
 import net.sf.jsqlparser.statement.comment.Comment;
+import net.sf.jsqlparser.statement.create.database.CreateDatabase;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.policy.CreatePolicy;
 import net.sf.jsqlparser.statement.create.schema.CreateSchema;
@@ -1164,6 +1165,17 @@ public class TablesNamesFinder<Void>
     @Override
     public void visit(CreateSchema createSchema) {
         StatementVisitor.super.visit(createSchema);
+    }
+
+    @Override
+    public <S> Void visit(CreateDatabase createDatabase, S context) {
+        throwUnsupported(createDatabase);
+        return null;
+    }
+
+    @Override
+    public void visit(CreateDatabase createDatabase) {
+        StatementVisitor.super.visit(createDatabase);
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -41,6 +41,7 @@ import net.sf.jsqlparser.statement.alter.RenameTableStatement;
 import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.analyze.Analyze;
 import net.sf.jsqlparser.statement.comment.Comment;
+import net.sf.jsqlparser.statement.create.database.CreateDatabase;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.policy.CreatePolicy;
 import net.sf.jsqlparser.statement.create.schema.CreateSchema;
@@ -427,6 +428,12 @@ public class StatementDeParser extends AbstractDeParser<Statement>
 
     @Override
     public <S> StringBuilder visit(CreateSchema aThis, S context) {
+        builder.append(aThis.toString());
+        return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(CreateDatabase aThis, S context) {
         builder.append(aThis.toString());
         return builder;
     }

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/StatementValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/StatementValidator.java
@@ -37,6 +37,7 @@ import net.sf.jsqlparser.statement.alter.RenameTableStatement;
 import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.analyze.Analyze;
 import net.sf.jsqlparser.statement.comment.Comment;
+import net.sf.jsqlparser.statement.create.database.CreateDatabase;
 import net.sf.jsqlparser.statement.create.function.CreateFunction;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.policy.CreatePolicy;
@@ -296,6 +297,13 @@ public class StatementValidator extends AbstractValidator<Statement>
     public <S> Void visit(CreateSchema aThis, S context) {
         validateFeatureAndName(Feature.createSchema, NamedObject.schema, aThis.getSchemaName());
         aThis.getStatements().forEach(s -> s.accept(this, context));
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(CreateDatabase aThis, S context) {
+        validateFeatureAndName(Feature.createDatabase, NamedObject.database,
+                aThis.getDatabaseName());
         return null;
     }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -47,6 +47,7 @@ import net.sf.jsqlparser.statement.analyze.*;
 import net.sf.jsqlparser.statement.alter.*;
 import net.sf.jsqlparser.statement.alter.sequence.*;
 import net.sf.jsqlparser.statement.comment.*;
+import net.sf.jsqlparser.statement.create.database.*;
 import net.sf.jsqlparser.statement.create.function.*;
 import net.sf.jsqlparser.statement.create.index.*;
 import net.sf.jsqlparser.statement.create.policy.*;
@@ -10820,6 +10821,22 @@ List<String> PathSpecification():
     }
 }
 
+CreateDatabase CreateDatabase():
+{
+    CreateDatabase createDatabase = new CreateDatabase();
+    String databaseName = null;
+    List<String> databaseOptions = null;
+}
+{
+    <K_DATABASE>
+    [ LOOKAHEAD(2) <K_IF> <K_NOT> <K_EXISTS> { createDatabase.setIfNotExists(true); } ]
+    databaseName = RelObjectName() { createDatabase.setDatabaseName(databaseName); }
+    [ databaseOptions = captureRest() { createDatabase.setDatabaseOptions(databaseOptions); } ]
+    {
+        return createDatabase;
+    }
+}
+
 /**
  * Parses a single table-level constraint inside CREATE TABLE (...).
  * Handles INDEX, PRIMARY KEY, UNIQUE, KEY, FOREIGN KEY, CHECK, EXCLUDE.
@@ -13266,6 +13283,8 @@ Statement Create():
         statement = CreateFunctionStatement(isUsingOrReplace)
         |
         statement = CreateSchema()
+        |
+        statement = CreateDatabase()
         |
         statement = CreateSequence()
         |

--- a/src/test/java/net/sf/jsqlparser/statement/create/database/CreateDatabaseTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/database/CreateDatabaseTest.java
@@ -1,0 +1,76 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.database;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
+import static net.sf.jsqlparser.test.TestUtils.assertDeparse;
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class CreateDatabaseTest {
+
+    @Test
+    void testCreateDatabaseIssue2070() throws JSQLParserException {
+        String statement = "CREATE DATABASE USERS";
+        assertSqlCanBeParsedAndDeparsed(statement);
+        assertDeparse(new CreateDatabase().withDatabaseName("USERS"), statement);
+    }
+
+    @Test
+    void testCreateDatabaseIfNotExists() throws JSQLParserException {
+        String statement = "CREATE DATABASE IF NOT EXISTS mydb";
+        assertSqlCanBeParsedAndDeparsed(statement);
+        assertDeparse(new CreateDatabase().withDatabaseName("mydb").withIfNotExists(true),
+                statement);
+    }
+
+    @Test
+    void testCreateDatabaseQuotedName() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("CREATE DATABASE `my db`");
+        assertSqlCanBeParsedAndDeparsed("CREATE DATABASE \"my db\"");
+    }
+
+    @Test
+    void testCreateDatabaseWithOptions() throws JSQLParserException {
+        String statement =
+                "CREATE DATABASE IF NOT EXISTS mydb DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci";
+        assertSqlCanBeParsedAndDeparsed(statement);
+
+        Statement parsed = CCJSqlParserUtil.parse(statement);
+        CreateDatabase createDatabase = assertInstanceOf(CreateDatabase.class, parsed);
+        assertEquals("mydb", createDatabase.getDatabaseName());
+        assertTrue(createDatabase.hasIfNotExists());
+        assertEquals(
+                Arrays.asList("DEFAULT", "CHARACTER", "SET", "utf8mb4", "COLLATE",
+                        "utf8mb4_unicode_ci"),
+                createDatabase.getDatabaseOptions());
+    }
+
+    @Test
+    void testCreateDatabaseAST() throws JSQLParserException {
+        Statement statement = CCJSqlParserUtil.parse("CREATE DATABASE USERS");
+        CreateDatabase createDatabase = assertInstanceOf(CreateDatabase.class, statement);
+        assertEquals("USERS", createDatabase.getDatabaseName());
+        assertFalse(createDatabase.hasIfNotExists());
+
+        statement = CCJSqlParserUtil.parse("CREATE DATABASE IF NOT EXISTS mydb");
+        createDatabase = assertInstanceOf(CreateDatabase.class, statement);
+        assertEquals("mydb", createDatabase.getDatabaseName());
+        assertTrue(createDatabase.hasIfNotExists());
+    }
+}


### PR DESCRIPTION
## What
Adds a typed `CreateDatabase` statement for `CREATE DATABASE [IF NOT EXISTS] <name> [options]`, which previously fell through to the generic `UnsupportedStatement` capture.

## Why
The grammar has no production for `CREATE DATABASE` (#2070), so users cannot access the database name from the AST. `CREATE SCHEMA` already has a typed statement and MySQL treats `CREATE SCHEMA` as a synonym of `CREATE DATABASE`.

## How
- New `CreateDatabase()` production dispatched from `Create()` right after `CreateSchema()`, following the same shape: `LOOKAHEAD(2)`-guarded `IF NOT EXISTS` and `RelObjectName()` for the name.
- Vendor-specific options after the name are captured verbatim via the existing `captureRest()` helper (same approach as `UnsupportedStatement` and `CreateFunctionalStatement`), so `CREATE DATABASE mydb DEFAULT CHARACTER SET utf8mb4` keeps parsing and round-trips unchanged instead of failing.
- AST class `net.sf.jsqlparser.statement.create.database.CreateDatabase` plus wiring in `StatementVisitor`, `StatementVisitorAdapter`, `StatementDeParser`, `StatementValidator` (new `Feature.createDatabase` validated against `NamedObject.database`) and `TablesNamesFinder`.

## Root cause
Missing feature: `CREATE DATABASE` had no grammar production and always hit the `captureRest()` fallback.

## Testing
- New `CreateDatabaseTest` (5 cases): the issue's SQL, `IF NOT EXISTS`, quoted names, options capture with AST assertions; `./gradlew test --tests ...CreateDatabaseTest` passes.
- Full local suite on the branch: 4801 tests, 0 failures.

## Verification of the original issue
Before (master `406a4d4`): `CCJSqlParserUtil.parse("CREATE DATABASE USERS")` returns `UnsupportedStatement` with no access to the database name.
After: returns `CreateDatabase` with `getDatabaseName() = "USERS"` and the deparse round-trips; same for `CREATE DATABASE IF NOT EXISTS mydb DEFAULT CHARACTER SET utf8mb4`.

Grammar change, paired `gradle jmh` run (`JSQLParserBenchmark.parseSQLStatements` on `performance.sql`, `version=latest`, 10 forks x 10 iterations = 100 samples, 32-core host):

| build | ms/op |
|---|---|
| master `406a4d4` | 3.734 ± 0.030 |
| this PR | 3.725 ± 0.028 |

Delta within the confidence intervals -> no regression.

*Limitation:* options are kept as raw tokens rather than structured AST nodes (the option sets differ heavily between MySQL and PostgreSQL); they can be modelled individually in a follow-up if preferred. The bare form `CREATE DATABASE` (no name) now throws a `ParseException` instead of returning `UnsupportedStatement`; both MySQL and PostgreSQL require the name.

Fixes #2070

