### PR TITLE
fix: do not treat a named parameter ':' as the ternary else separator (#2475)

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -227,11 +227,14 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
      * {@code cond ? then : else} rather than the PostgreSQL JSON operator:
      * a standalone ":" closes the then-branch at the same nesting depth before
      * any expression boundary (",", ";", EOF, an unbalanced closing bracket or a
-     * clause keyword such as FROM/WHERE).
+     * clause keyword such as FROM/WHERE). A ":" in operand position (directly
+     * after an operator) starts a JDBC named parameter instead and cannot close
+     * the then-branch.
      */
     protected boolean isTernaryAhead() {
         try {
             int depth = 0;
+            Token prev = null;
             for (int i = 2; ; i++) {
                 Token t = getToken(i);
                 if (t == null || t.kind == EOF) {
@@ -246,7 +249,7 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
                     }
                     depth--;
                 } else if (depth == 0) {
-                    if (":".equals(image)) {
+                    if (":".equals(image) && canEndExpression(prev)) {
                         return true;
                     }
                     if (",".equals(image) || ";".equals(image)) {
@@ -262,9 +265,36 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
                             break;
                     }
                 }
+                prev = t;
             }
         } catch (Exception e) {
             return false;
+        }
+    }
+
+    /**
+     * True when the token can be the LAST token of an expression: an
+     * identifier, a literal, a JDBC parameter, or a balanced closing bracket.
+     * Only such a token may directly precede the ":" closing the ternary
+     * then-branch, since the then-branch must be a complete expression. A ":"
+     * in operand position instead (directly after an operator, e.g. `x = :name`
+     * or directly after the leading "?") starts a JDBC named parameter.
+     * DATA_TYPE tokens end expressions as well, because a cast's target type
+     * (`b :: int`) or a bare type keyword closes the then-branch.
+     */
+    private boolean canEndExpression(Token t) {
+        if (t == null) {
+            return false;
+        }
+        switch (t.kind) {
+            case S_IDENTIFIER: case S_QUOTED_IDENTIFIER: case S_PARAMETER:
+            case S_LONG: case S_DOUBLE: case S_HEX: case S_CHAR_LITERAL:
+            case K_DATE_LITERAL: case K_DATETIMELITERAL: case DATA_TYPE:
+            case K_NULL: case K_TRUE: case K_FALSE:
+                return true;
+            default:
+                return (t.kind >= MIN_NON_RESERVED_WORD && t.kind <= MAX_NON_RESERVED_WORD)
+                        || ")".equals(t.image) || "]".equals(t.image);
         }
     }
 

--- a/src/test/java/net/sf/jsqlparser/expression/TernaryExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/TernaryExpressionTest.java
@@ -14,6 +14,7 @@ import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
 import net.sf.jsqlparser.expression.operators.relational.ComparisonOperator;
+import net.sf.jsqlparser.expression.operators.relational.JsonOperator;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
@@ -67,7 +68,11 @@ class TernaryExpressionTest {
             "SELECT a ? b : ? FROM t",
             "SELECT * FROM t WHERE x = ? AND y ? z : w",
             // case expression inside a branch
-            "SELECT a ? CASE WHEN b THEN c ELSE d END : e FROM t"
+            "SELECT a ? CASE WHEN b THEN c ELSE d END : e FROM t",
+            // cast target type ends the then-branch (a bare ":" after a type
+            // keyword is the ternary separator, not a named parameter)
+            "SELECT a ? b :: int : c FROM t",
+            "SELECT x > 0 ? CAST(b AS int) : c FROM t"
     })
     void testTernaryInVariousContexts(String sqlStr) throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed(sqlStr, true);
@@ -127,6 +132,42 @@ class TernaryExpressionTest {
             "SELECT CAST(a AS CHAR)"
     })
     void testUnrelatedSyntaxUnaffected(String sqlStr) throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+    }
+
+    @Test
+    void testJsonbOperatorWithNamedParameter() throws JSQLParserException {
+        // regression guard (ternary support, #2466): a ":" in operand position
+        // starts a JDBC named parameter and must not close a ternary then-branch
+        Select select = (Select) CCJSqlParserUtil.parse("SELECT * FROM t WHERE j ? :key");
+        Expression where = ((PlainSelect) select).getWhere();
+        Assertions.assertTrue(where instanceof JsonOperator);
+        Assertions.assertTrue(
+                ((JsonOperator) where).getRightExpression() instanceof JdbcNamedParameter);
+    }
+
+    @Test
+    void testTernaryWithCastThenBranch() throws JSQLParserException {
+        // regression guard: a DATA_TYPE token can end the then-branch, so the
+        // ":" after the cast target type must close the ternary
+        Select select = (Select) CCJSqlParserUtil.parse("SELECT a ? b :: int : c FROM t");
+        TernaryExpression ternary = (TernaryExpression) ((PlainSelect) select).getSelectItem(0)
+                .getExpression();
+        Assertions.assertTrue(ternary.getThenExpression() instanceof CastExpression);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // PostgreSQL jsonb operator combined with JDBC named parameters
+            "SELECT * FROM t WHERE j ? :key",
+            "SELECT * FROM t WHERE j ? 'k' AND x = :p",
+            "SELECT * FROM t WHERE j ? 'k' OR x = :p",
+            "SELECT * FROM t WHERE j ? :key AND x = 1",
+            // named parameters keep working inside ternary branches, too
+            "SELECT a ? :t : :e FROM t",
+            "SELECT * FROM t WHERE c = :c AND a ? :t : :e"
+    })
+    void testTernaryAndJsonbWithJdbcNamedParameters(String sqlStr) throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed(sqlStr, true);
     }
 }


### PR DESCRIPTION
## What

The PostgreSQL jsonb operator `?` keeps working when the same condition also contains JDBC named parameters:

```sql
SELECT * FROM t WHERE j ? :key
SELECT * FROM t WHERE j ? 'k' AND x = :p
```

## Why / Root cause

`isTernaryAhead()` (introduced with the ClickHouse ternary in #2466) committed to the ternary reading as soon as its token scan found ANY standalone `:` at bracket depth 0 before a clause boundary. A JDBC named parameter starts with the very same `:` token, so the statements above were misread as a ternary and then failed with `Expected ':' closing the ternary conditional operator` (both parsed before #2466: regression).

## How

The scan now requires the `:` to be preceded by a token that can legally END an expression (`canEndExpression()`): identifier, literal, type keyword (a cast target, e.g. `b :: int`), JDBC parameter, non-reserved keyword, or a balanced closing bracket. The then-branch of a ternary must be a complete expression, so its closing `:` can never follow an operator directly. A `:` in operand position (after `=`, `AND`, the leading `?`, ...) starts a named parameter instead: the scan skips it and keeps looking for the real separator.

Consequences:

- `j ? :key` / `j ? 'k' AND x = :p` parse again as jsonb operator + named parameter (same `JsonOperator` AST as before #2466).
- Real ternaries are unaffected: all pre-existing `TernaryExpressionTest` cases stay green (`a ? b : c`, `a ? ? : c` with a positional parameter as then-branch, parentheses, `a ? b OR c : d`, `CASE ... END : e`, right-associative nesting).
- Ternaries whose then-branch ends in a cast keep working: `a ? b :: int : c` still parses as a `TernaryExpression` with a `CastExpression` then-branch (the type keyword ends the expression, so the `:` after it closes the ternary).
- Named parameters keep working inside ternary branches: `a ? :t : :e` now has a defined reading (named parameter then- and else-branches).

## Scope

Only the ternary-vs-JSON disambiguation predicate changes; the ternary grammar productions, the `TernaryExpression` AST, and the JSON operator handling are untouched.

## Testing

`TernaryExpressionTest.testTernaryAndJsonbWithJdbcNamedParameters` (6 round-trip cases) and `testJsonbOperatorWithNamedParameter` (AST shape) reproduce the issue: 5 of these executions fail on `master` with `JSQLParserException`. `testTernaryWithCastThenBranch` guards the cast-then-branch reading. All 42 tests of `TernaryExpressionTest` pass with this change.

## Performance

`gradle jmh`, `JSQLParserBenchmark.parseSQLStatements` on `performance.sql`, `version=latest`, 10 forks x 10 iterations (100 samples per run, two interleaved runs per build) on a 32-core host:

| build | ms/op |
|---|---|
| `master` (7b64825) | 3.717 ± 0.023 / 3.729 ± 0.022 |
| this PR (4e411b1) | 3.726 ± 0.021 / 3.715 ± 0.020 |

The two builds interleave across the repeated runs (pair 1: `+0.24%`, pair 2: `-0.37%`); every delta lies within the 99.9% confidence intervals: no regression.

## Verification of the original issue

Both statements from the issue fail on `master` and parse + round-trip with this change.

Fixes #2475
