### PR TITLE
fix: treat a positional parameter '?' as a valid end of the ternary then-branch

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -280,7 +280,9 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
      * in operand position instead (directly after an operator, e.g. `x = :name`
      * or directly after the leading "?") starts a JDBC named parameter.
      * DATA_TYPE tokens end expressions as well, because a cast's target type
-     * (`b :: int`) or a bare type keyword closes the then-branch.
+     * (`b :: int`) or a bare type keyword closes the then-branch. The bare "?"
+     * positional parameter has no token-kind constant (anonymous token), so it
+     * is recognized by its image, like the closing brackets.
      */
     private boolean canEndExpression(Token t) {
         if (t == null) {
@@ -294,7 +296,8 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
                 return true;
             default:
                 return (t.kind >= MIN_NON_RESERVED_WORD && t.kind <= MAX_NON_RESERVED_WORD)
-                        || ")".equals(t.image) || "]".equals(t.image);
+                        || ")".equals(t.image) || "]".equals(t.image)
+                        || "?".equals(t.image);
         }
     }
 

--- a/src/test/java/net/sf/jsqlparser/expression/TernaryExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/TernaryExpressionTest.java
@@ -10,6 +10,7 @@
 package net.sf.jsqlparser.expression;
 
 import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.operators.arithmetic.Addition;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
 import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
@@ -65,6 +66,8 @@ class TernaryExpressionTest {
             "SELECT a IS NULL ? 'x' : y FROM t",
             // jdbc parameters as branches
             "SELECT a ? ? : c FROM t",
+            "SELECT a ? b + ? : c FROM t",
+            "SELECT a ? ? : ? FROM t",
             "SELECT a ? b : ? FROM t",
             "SELECT * FROM t WHERE x = ? AND y ? z : w",
             // case expression inside a branch
@@ -154,6 +157,23 @@ class TernaryExpressionTest {
         TernaryExpression ternary = (TernaryExpression) ((PlainSelect) select).getSelectItem(0)
                 .getExpression();
         Assertions.assertTrue(ternary.getThenExpression() instanceof CastExpression);
+    }
+
+    @Test
+    void testTernaryWithPositionalParameterThenBranch() throws JSQLParserException {
+        // regression guard: a bare "?" positional parameter is a complete
+        // expression, so the ":" after it closes the ternary instead of being
+        // skipped in favor of the jsonb reading
+        Select select = (Select) CCJSqlParserUtil.parse("SELECT a ? ? : c FROM t");
+        TernaryExpression ternary = (TernaryExpression) ((PlainSelect) select).getSelectItem(0)
+                .getExpression();
+        Assertions.assertTrue(ternary.getThenExpression() instanceof JdbcParameter);
+        Assertions.assertTrue(ternary.getElseExpression() instanceof Column);
+
+        // a positional parameter as the LAST token of the then-branch, too
+        select = (Select) CCJSqlParserUtil.parse("SELECT a ? b + ? : c FROM t");
+        ternary = (TernaryExpression) ((PlainSelect) select).getSelectItem(0).getExpression();
+        Assertions.assertTrue(ternary.getThenExpression() instanceof Addition);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What

A ternary whose then-branch ends with a plain positional parameter parses as a `TernaryExpression` again:

```sql
SELECT a ? ? : c FROM t
SELECT a ? b + ? : c FROM t
SELECT a ? ? : ? FROM t
```

## Why / Root cause

Follow-up to #2476, found while regression-testing the snapshot build (reported in https://github.com/JSQLParser/JSqlParser/pull/2476#issuecomment-5305330067): `canEndExpression()` whitelisted `S_PARAMETER` (`$N` style) but not the bare `?`. The bare `?` is an anonymous token (no token-kind constant, outside the non-reserved range), so the scan skipped the `:` closing the then-branch and the parser silently committed to the jsonb reading. On current master the statements above parse as `JsonOperator(a, JsonExpression(?:c))` while `7b64825` still parsed them as `TernaryExpression(a, JdbcParameter, c)` (regression). In the wrong tree the `?` is no longer a `JdbcParameter` node (relevant for parameter extraction), and the wrong AST deparse round-trips stably (`a ? ?:c`), which is why the existing round-trip case did not catch it.

## How

Add `|| "?".equals(t.image)` to the default branch of `canEndExpression()`, the same image comparison already used for `")"` and `"]"`: a positional parameter is a complete primary expression, so a `:` directly after it closes the then-branch. The `?|` / `?&` operators have different images and are unaffected. The statements fixed by #2476 are unaffected as well: there the `:` follows `null` or an operator token, so the new check is not reached (`j ? :key`, `j ? 'k' AND x = :p`, `j ? ?` all keep their current reading).

## Scope

One condition in the ternary-vs-jsonb disambiguation predicate plus an AST-shape regression test; grammar productions and AST classes are untouched.

## Testing

`TernaryExpressionTest.testTernaryWithPositionalParameterThenBranch` pins the AST shape (root `TernaryExpression`, then-branch `JdbcParameter` / `Addition`, else-branch `Column`): it fails on current master with `ClassCastException: JsonOperator cannot be cast to TernaryExpression` and passes with this change. The round-trip list gains `SELECT a ? b + ? : c FROM t` and `SELECT a ? ? : ? FROM t`. All 45 `TernaryExpressionTest` tests pass with this change.

## Performance

`gradle jmh`, `JSQLParserBenchmark.parseSQLStatements` on `performance.sql`, `version=latest`, 10 forks x 10 iterations (100 samples per run, two interleaved runs per build) on a 32-core host:

| build | ms/op |
|---|---|
| `master` (5080d19) | 3.731 ± 0.023 / 3.748 ± 0.029 |
| this PR (21ac7c4) | 3.760 ± 0.029 / 3.736 ± 0.021 |

The two builds interleave across the repeated runs (pair 1: `+0.78%`, pair 2: `-0.32%`); every delta lies within the 99.9% confidence intervals: no regression.
