### PR TITLE
fix: reject illegal MERGE WHEN NOT MATCHED clause pairings (#2480)

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/merge/MergeSide.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/MergeSide.java
@@ -29,6 +29,29 @@ public enum MergeSide {
      * @throws IllegalArgumentException if {@code image} is neither {@code TARGET} nor
      *         {@code SOURCE}
      */
+    /**
+     * Validates the clause pairing of a {@code WHEN NOT MATCHED} branch: {@code BY TARGET} (the
+     * default) only allows an {@code INSERT} clause, {@code BY SOURCE} only allows {@code UPDATE}
+     * or {@code DELETE}.
+     *
+     * @param side the parsed {@code BY TARGET}/{@code BY SOURCE} qualifier, null when absent
+     * @param operation the parsed clause
+     * @return the passed {@code operation}
+     * @throws IllegalArgumentException when the pairing is not legal in any dialect
+     */
+    public static MergeOperation validatePairing(MergeSide side, MergeOperation operation) {
+        if (side == MergeSide.SOURCE) {
+            if (operation instanceof MergeInsert) {
+                throw new IllegalArgumentException(
+                        "WHEN NOT MATCHED BY SOURCE cannot take an INSERT clause");
+            }
+        } else if (!(operation instanceof MergeInsert)) {
+            throw new IllegalArgumentException(
+                    "WHEN NOT MATCHED [BY TARGET] cannot take an UPDATE or DELETE clause");
+        }
+        return operation;
+    }
+
     public static MergeSide fromImage(String image) {
         for (MergeSide value : values()) {
             if (value.name().equalsIgnoreCase(image)) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4489,7 +4489,7 @@ MergeOperation MergeWhenNotMatched() : {
         |
         operation = MergeDeleteClause(predicate) { ((MergeDelete) operation).setSide(side); }
     )
-    { return operation; }
+    { return MergeSide.validatePairing(side, operation); }
 }
 
 // table names seem to allow ":" delimiters, e.g. for Informix see #1134

--- a/src/test/java/net/sf/jsqlparser/statement/merge/MergeTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/merge/MergeTest.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import static net.sf.jsqlparser.test.TestUtils.assertOracleHintExists;
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -362,5 +363,37 @@ public class MergeTest {
                         insert1, false),
                 Arguments.of(Arrays.asList(insert1, insert2, update1, update2, delete1), update1,
                         insert1, true));
+    }
+
+    @Test
+    void testMergeRejectsInvalidWhenNotMatchedClausePairings() {
+        // WHEN MATCHED rows exist in the target: INSERT is not legal
+        assertThrows(JSQLParserException.class, () -> CCJSqlParserUtil.parse(
+                "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN INSERT (a) VALUES (1)"));
+
+        // WHEN NOT MATCHED [BY TARGET] rows do not exist in the target: only INSERT is legal
+        assertInvalidMergePairing(
+                "MERGE INTO t USING s ON t.id = s.id WHEN NOT MATCHED THEN UPDATE SET a = 1");
+        assertInvalidMergePairing(
+                "MERGE INTO t USING s ON t.id = s.id WHEN NOT MATCHED THEN DELETE");
+        assertInvalidMergePairing(
+                "MERGE INTO t USING s ON t.id = s.id WHEN NOT MATCHED BY TARGET THEN UPDATE SET a = 1");
+        assertInvalidMergePairing(
+                "MERGE INTO t USING s ON t.id = s.id WHEN NOT MATCHED BY TARGET THEN DELETE");
+
+        // WHEN NOT MATCHED BY SOURCE rows exist in the target: INSERT is not legal
+        assertInvalidMergePairing(
+                "MERGE INTO t USING s ON t.id = s.id WHEN NOT MATCHED BY SOURCE THEN INSERT (a) VALUES (1)");
+    }
+
+    private static void assertInvalidMergePairing(String sql) {
+        JSQLParserException exception = assertThrows(JSQLParserException.class,
+                () -> CCJSqlParserUtil.parse(sql));
+        Throwable cause = exception;
+        while (cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        assertThat(cause).isInstanceOf(IllegalArgumentException.class);
+        assertThat(cause.getMessage()).contains("WHEN NOT MATCHED");
     }
 }


### PR DESCRIPTION
## What

Rejects the five illegal `WHEN NOT MATCHED` side / clause pairings at parse time instead of silently rewriting them: `WHEN NOT MATCHED [BY TARGET] THEN UPDATE/DELETE` and `WHEN NOT MATCHED BY SOURCE THEN INSERT` now throw, matching what SQL Server and BigQuery do. Fixes #2480.

## Why

On master these pairings are accepted and the deparse collapses them into the opposite semantics: `WHEN NOT MATCHED [BY TARGET] THEN UPDATE/DELETE` prints as `WHEN MATCHED` (condition inverted) and `WHEN NOT MATCHED BY SOURCE THEN INSERT` prints as `WHEN NOT MATCHED` (`BY SOURCE` dropped, a different row set). A silent semantic rewrite is the worst failure mode for tools that parse SQL to inspect it. This closes the gap left by #2453, which calibrated the six legal combinations but did not guard the illegal ones.

## How

`MergeWhenNotMatched` ends with `MergeSide.validatePairing(side, operation)`, which enforces the pairing rule already documented on `MergeSide`: `BY TARGET` (the default) only allows `INSERT`, `BY SOURCE` only allows `UPDATE`/`DELETE`. The validation lives in `MergeSide` next to the existing `fromImage` validation and keeps the grammar action a single statement. `WHEN MATCHED THEN INSERT` is already rejected by the grammar and is pinned by a test as well.

Alternative considered (not implemented): accept the illegal pairings and render them faithfully. This would require extending `MergeUpdate` / `MergeDelete` / `MergeInsert` with combinations no dialect accepts (`MergeUpdate` currently has no `NOT MATCHED` dimension), adding AST surface for SQL that no database executes. Happy to switch to that direction or to move the check into the statement validator instead, if preferred.

## Root cause

`MergeWhenNotMatched` accepted any clause for any side, while the AST can only represent the legal pairings (`MergeUpdate:82` / `MergeDelete:55` render `WHEN MATCHED` for any side other than `SOURCE`, `MergeInsert:77` always renders `WHEN NOT MATCHED`), so the deparse silently changed the meaning.

## Testing

- New `MergeTest#testMergeRejectsInvalidWhenNotMatchedClausePairings`: on master the five illegal pairings parse (test fails), with this change they throw `JSQLParserException` with the pairing message; `./gradlew test --tests net.sf.jsqlparser.statement.merge.MergeTest` -> 26 tests, 0 failures.
- The six legal combinations keep round-tripping (existing `#2421` tests, untouched).

## Verification of the original issue

| Case from #2480 | master `f41c0b8` | with this change |
|---|---|---|
| `WHEN NOT MATCHED [BY TARGET] THEN UPDATE/DELETE` | accepted, deparses as `WHEN MATCHED` | rejected with `WHEN NOT MATCHED [BY TARGET] cannot take an UPDATE or DELETE clause` |
| `WHEN NOT MATCHED BY SOURCE THEN INSERT` | accepted, deparses as `WHEN NOT MATCHED` | rejected with `WHEN NOT MATCHED BY SOURCE cannot take an INSERT clause` |
| all six legal pairings | accepted, round-trip | unchanged |

Grammar tokens, productions and LOOKAHEADs are untouched (javacc warnings stay at 13) and the benchmark input `performance.sql` contains no `MERGE` statement, so the changed path never executes in `gradle jmh`; no performance impact is possible.

Programmatic AST construction (building an illegal `MergeUpdate` by hand and printing it) is not guarded; the check protects the parse entry point.

Fixes #2480
