### PR TITLE
fix: keep all clauses when deparsing SELECT without FROM (#2483)

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/PlainSelect.java
@@ -607,43 +607,35 @@ public class PlainSelect extends Select {
             if (ksqlWindow != null) {
                 builder.append(" WINDOW ").append(ksqlWindow);
             }
-            if (preWhere != null) {
-                builder.append(" PREWHERE ").append(preWhere);
-            }
-            if (where != null) {
-                builder.append(" WHERE ").append(where);
-            }
-            if (oracleHierarchical != null) {
-                builder.append(oracleHierarchical);
-            }
-            if (preferringClause != null) {
-                builder.append(" ").append(preferringClause);
-            }
-            if (groupBy != null) {
-                builder.append(" ").append(groupBy);
-            }
-            if (having != null) {
-                builder.append(" HAVING ").append(having);
-            }
-            if (qualify != null) {
-                builder.append(" QUALIFY ").append(qualify);
-            }
-            if (windowDefinitions != null) {
-                builder.append(" WINDOW ");
-                builder.append(windowDefinitions.stream().map(WindowDefinition::toString)
-                        .collect(joining(", ")));
-            }
-            if (emitChanges) {
-                builder.append(" EMIT CHANGES");
-            }
-        } else {
-            // without from
-            if (preWhere != null) {
-                builder.append(" PREWHERE ").append(preWhere);
-            }
-            if (where != null) {
-                builder.append(" WHERE ").append(where);
-            }
+        }
+        if (preWhere != null) {
+            builder.append(" PREWHERE ").append(preWhere);
+        }
+        if (where != null) {
+            builder.append(" WHERE ").append(where);
+        }
+        if (oracleHierarchical != null) {
+            builder.append(oracleHierarchical);
+        }
+        if (preferringClause != null) {
+            builder.append(" ").append(preferringClause);
+        }
+        if (groupBy != null) {
+            builder.append(" ").append(groupBy);
+        }
+        if (having != null) {
+            builder.append(" HAVING ").append(having);
+        }
+        if (qualify != null) {
+            builder.append(" QUALIFY ").append(qualify);
+        }
+        if (windowDefinitions != null) {
+            builder.append(" WINDOW ");
+            builder.append(windowDefinitions.stream().map(WindowDefinition::toString)
+                    .collect(joining(", ")));
+        }
+        if (emitChanges) {
+            builder.append(" EMIT CHANGES");
         }
         if (intoTempTable != null) {
             builder.append(" INTO TEMP ").append(intoTempTable);

--- a/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SelectTest.java
@@ -1908,6 +1908,29 @@ public class SelectTest {
     }
 
     @Test
+    public void testSelectWithoutFromRetainsWhereGroupByHaving() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT 1 WHERE 1 = 1");
+        PlainSelect plainSelect =
+                (PlainSelect) assertSqlCanBeParsedAndDeparsed("SELECT 1 GROUP BY 1 HAVING 1 = 1");
+        assertNotNull(plainSelect.getGroupBy());
+        assertNotNull(plainSelect.getHaving());
+    }
+
+    @Test
+    public void testSelectWithoutFromRetainsWindowAndQualify() throws JSQLParserException {
+        PlainSelect plainSelect =
+                (PlainSelect) assertSqlCanBeParsedAndDeparsed("SELECT 1 WINDOW w AS (ORDER BY 1)");
+        assertEquals(1, plainSelect.getWindowDefinitions().size());
+        assertSqlCanBeParsedAndDeparsed("SELECT 1 QUALIFY 1 = 1");
+    }
+
+    @Test
+    public void testSelectWithoutFromRetainsHierarchicalAndPreferring() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("SELECT 1 START WITH 1 = 1 CONNECT BY LEVEL <= 1");
+        assertSqlCanBeParsedAndDeparsed("SELECT 1 PREFERRING HIGH 1");
+    }
+
+    @Test
     public void testWeirdSelect() throws JSQLParserException {
         String sql =
                 "select r.reviews_id, substring(rd.reviews_text, 100) as reviews_text, r.reviews_rating, r.date_added, r.customers_name from reviews r, reviews_description rd where r.products_id = '19' and r.reviews_id = rd.reviews_id and rd.languages_id = '1' and r.reviews_status = 1 order by r.reviews_id desc limit 0, 6";


### PR DESCRIPTION
## What
`PlainSelect.toString()` silently dropped every clause except `WHERE` / `PREWHERE` for a `SELECT` without `FROM`: `GROUP BY`, `HAVING`, `WINDOW`, `QUALIFY`, `START WITH` / `CONNECT BY` and `PREFERRING` parsed fine and were stored on the AST, but disappeared from the rendered SQL.

## Why
FROM-less SELECT is supported Standard SQL (#1514). A parse -> toString -> reparse round trip silently rewrites the statement, the worst failure mode for audit / rewriting tools. The `StatementDeParser` path already renders all these clauses unconditionally, so the two render paths disagreed.

## How
`PlainSelect.appendSelectBodyTo`: keep only the FROM-adjacent parts (`FROM`, lateral views, joins, `FINAL`, ksql `WINDOW`) inside the `fromItem != null` branch, move the shared clause chain out, and delete the truncated `else // without from` branch. This mirrors `SelectDeParser`, which already prints the whole chain outside its FROM block. Output for SELECTs with FROM is byte-identical (same checks in the same order).

## Root cause
The `else // without from` branch of `PlainSelect.appendSelectBodyTo` rendered `preWhere` / `where` only, while the whole clause chain sat inside the `fromItem != null` branch.

## Testing
- New regression tests `SelectTest#testSelectWithoutFromRetainsWhereGroupByHaving`, `#testSelectWithoutFromRetainsWindowAndQualify`, `#testSelectWithoutFromRetainsHierarchicalAndPreferring`: on master the round-trip assertions fail (`toString()` returns `SELECT 1`), with the fix all pass.
- `./gradlew spotlessApply check`: 4858 tests, 0 failures, 0 errors.
- jmh not applicable: deparse-side change only, the parse path and grammar are untouched (same reasoning as #2479).

## Verification of the original issue
On master `ad69ecc` (jshell, `CCJSqlParserUtil.parse(...).toString()`):

```
IN : SELECT 1 GROUP BY 1 HAVING 1=1
OUT: SELECT 1

IN : SELECT 1 WINDOW w AS (ORDER BY 1)
OUT: SELECT 1

IN : SELECT 1 START WITH 1 = 1 CONNECT BY LEVEL <= 1
OUT: SELECT 1
```

With the fix, all statements from the issue round-trip through both `toString()` and `StatementDeParser` (both are asserted by the new tests).

Fixes #2483

