### PR TITLE
feat: complete SQL Server OPTION query hint support

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
@@ -17,6 +17,7 @@ import net.sf.jsqlparser.statement.OutputClause;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.FromItem;
+import net.sf.jsqlparser.statement.select.OptionClause;
 import net.sf.jsqlparser.statement.select.ParenthesedSelect;
 import net.sf.jsqlparser.statement.select.WithItem;
 
@@ -41,6 +42,7 @@ public class Merge implements Statement {
     private List<MergeOperation> operations;
 
     private OutputClause outputClause;
+    private OptionClause option;
 
     private void deriveOperationsFromStandardClauses() {
         List<MergeOperation> operations = new ArrayList<>();
@@ -214,6 +216,19 @@ public class Merge implements Statement {
         return this;
     }
 
+    public OptionClause getOption() {
+        return option;
+    }
+
+    public Merge setOption(OptionClause option) {
+        this.option = option;
+        return this;
+    }
+
+    public Merge withOption(OptionClause option) {
+        return setOption(option);
+    }
+
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     public String toString() {
@@ -246,6 +261,13 @@ public class Merge implements Statement {
 
         if (outputClause != null) {
             b.append(outputClause);
+        }
+
+        if (option != null) {
+            if (outputClause != null) {
+                b.setLength(b.length() - 1);
+            }
+            b.append(option);
         }
 
         return b.toString();

--- a/src/main/java/net/sf/jsqlparser/statement/select/OptionClause.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/OptionClause.java
@@ -15,8 +15,9 @@ import java.util.List;
 
 /**
  * Models the SQL Server (T-SQL) {@code OPTION (...)} query hint clause, which attaches a list of
- * {@link OptionHint}s to the end of a {@code SELECT}, {@code UPDATE} or {@code DELETE} statement,
- * see <a href="https://learn.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query">Hints
+ * {@link OptionHint}s to the end of a {@code SELECT}, {@code UPDATE}, {@code DELETE} or
+ * {@code MERGE} statement, see
+ * <a href="https://learn.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query">Hints
  * (Transact-SQL) - Query Hints</a>.
  */
 public class OptionClause implements Serializable {

--- a/src/main/java/net/sf/jsqlparser/util/deparser/MergeDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/MergeDeParser.java
@@ -63,6 +63,13 @@ public class MergeDeParser extends AbstractDeParser<Merge>
         if (merge.getOutputClause() != null) {
             merge.getOutputClause().appendTo(builder);
         }
+
+        if (merge.getOption() != null) {
+            if (merge.getOutputClause() != null) {
+                builder.setLength(builder.length() - 1);
+            }
+            builder.append(merge.getOption());
+        }
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/MergeValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/MergeValidator.java
@@ -11,6 +11,7 @@ package net.sf.jsqlparser.util.validation.validator;
 
 import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.statement.merge.*;
+import net.sf.jsqlparser.statement.select.OptionHint;
 import net.sf.jsqlparser.statement.update.UpdateSet;
 import net.sf.jsqlparser.util.validation.ValidationCapability;
 
@@ -31,6 +32,14 @@ public class MergeValidator<Void> extends AbstractValidator<Merge>
             merge.getOperations().forEach(operation -> operation.accept(this, null));
         }
         validateOptionalFromItems(merge.getFromItem());
+        if (merge.getOption() != null) {
+            for (OptionHint optionHint : merge.getOption().getOptionHints()) {
+                validateOptionalExpression(optionHint.getValue());
+                if (optionHint.getParameters() != null) {
+                    optionHint.getParameters().forEach(this::validateOptionalExpression);
+                }
+            }
+        }
     }
 
     @Override

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4388,6 +4388,7 @@ Statement Merge( List<WithItem<?>> with ) : {
     Expression condition;
     List<MergeOperation> operations;
     OutputClause outputClause;
+    OptionClause optionClause = null;
 }
 {
     <K_MERGE> { merge.setOracleHint(getOracleHint()); } <K_INTO> table=TableWithAlias() { merge.setTable(table); }
@@ -4397,6 +4398,8 @@ Statement Merge( List<WithItem<?>> with ) : {
     operations = MergeOperations() { merge.setOperations(operations); }
 
     [ outputClause = OutputClause() { merge.setOutputClause(outputClause); } ]
+
+    [ LOOKAHEAD(2) optionClause = OptionClause() { merge.setOption(optionClause); } ]
 
     { return merge.withWithItemsList(with); }
 }
@@ -4803,7 +4806,7 @@ Select Select() #Select:
 
             [ LOOKAHEAD(<K_ORDER> <K_BY>) orderByElements = OrderByElements() { select.setOrderByElements(orderByElements); } ]
             [ LOOKAHEAD(2) interpolateElements = InterpolateClause() { select.setInterpolate(interpolateElements); } ]
-            [ LOOKAHEAD(2) optionClause = OptionClause() { select.setOption(optionClause); } ]
+            [ LOOKAHEAD(2, { !(select instanceof Values) }) optionClause = OptionClause() { select.setOption(optionClause); } ]
 
             [ LOOKAHEAD(<K_LIMIT>) limit=LimitWithOffset() {select.setLimit(limit);} ]
             [ LOOKAHEAD(<K_OFFSET>) offset = Offset() { select.setOffset(offset);} ]
@@ -6952,6 +6955,23 @@ InterpolateElement InterpolateElement():
     { return interpolateElement; }
 }
 
+Expression OptionHintParameter():
+{
+    UserVariable userVariable = null;
+    Expression parameter = null;
+}
+{
+    (
+        LOOKAHEAD({ getToken(1).kind == S_AT_IDENTIFIER && getToken(2).kind == K_UNKNOWN })
+        userVariable = UserVariable() <K_UNKNOWN>
+        {
+            return new Column(userVariable + " UNKNOWN");
+        }
+        |
+        parameter = Expression() { return parameter; }
+    )
+}
+
 OptionClause OptionClause():
 {
     OptionClause optionClause = new OptionClause();
@@ -6977,8 +6997,8 @@ OptionHint OptionHint():
         (
             LOOKAHEAD("=") "=" value = Expression() { optionHint.setValue(value); optionHint.setUseEquals(true); }
             |
-            LOOKAHEAD("(") "(" parameter = Expression() { optionHint.addParameter(parameter); }
-            ( "," parameter = Expression() { optionHint.addParameter(parameter); } )*
+            LOOKAHEAD("(") "(" parameter = OptionHintParameter() { optionHint.addParameter(parameter); }
+            ( "," parameter = OptionHintParameter() { optionHint.addParameter(parameter); } )*
             ")"
             |
             LOOKAHEAD({ isOptionHintValueAhead() }) value = Expression() { optionHint.setValue(value); }

--- a/src/test/java/net/sf/jsqlparser/statement/select/OptionClauseTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/OptionClauseTest.java
@@ -13,7 +13,10 @@ import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
 
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.insert.Insert;
+import net.sf.jsqlparser.statement.merge.Merge;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -145,6 +148,64 @@ public class OptionClauseTest {
 
         Statement update = CCJSqlParserUtil.parse("UPDATE t SET a = 1 OPTION (RECOMPILE)");
         Assertions.assertNotNull(((net.sf.jsqlparser.statement.update.Update) update).getOption());
+    }
+
+    @Test
+    public void testOptionOptimizeForUnknownParameter() throws JSQLParserException {
+        String sql = "SELECT * FROM t WHERE c = @p OPTION (OPTIMIZE FOR (@p UNKNOWN))";
+        PlainSelect plainSelect =
+                (PlainSelect) assertSqlCanBeParsedAndDeparsed(sql, true);
+        OptionHint optimizeFor = plainSelect.getOption().getOptionHints().get(0);
+        Assertions.assertEquals(1, optimizeFor.getParameters().size());
+        Column parameter =
+                Assertions.assertInstanceOf(Column.class, optimizeFor.getParameters().get(0));
+        Assertions.assertEquals("@p UNKNOWN", parameter.getColumnName());
+    }
+
+    @Test
+    public void testOptionOptimizeForMixedParameters() throws JSQLParserException {
+        String sql = "SELECT * FROM t WHERE c = @p OPTION (OPTIMIZE FOR (@p = 1, @q UNKNOWN))";
+        PlainSelect plainSelect =
+                (PlainSelect) assertSqlCanBeParsedAndDeparsed(sql, true);
+        OptionHint optimizeFor = plainSelect.getOption().getOptionHints().get(0);
+        Assertions.assertEquals(2, optimizeFor.getParameters().size());
+        Assertions.assertEquals("@p = 1", optimizeFor.getParameters().get(0).toString());
+        Column parameter =
+                Assertions.assertInstanceOf(Column.class, optimizeFor.getParameters().get(1));
+        Assertions.assertEquals("@q UNKNOWN", parameter.getColumnName());
+    }
+
+    @Test
+    public void testOptionAfterInsertValuesIsRejected() {
+        Assertions.assertThrows(JSQLParserException.class,
+                () -> CCJSqlParserUtil.parse(
+                        "INSERT INTO t (a) VALUES (1) OPTION (RECOMPILE)"));
+    }
+
+    @Test
+    public void testOptionAfterInsertSelect() throws JSQLParserException {
+        String sql = "INSERT INTO t (a) SELECT a FROM s OPTION (RECOMPILE)";
+        Statement statement = assertSqlCanBeParsedAndDeparsed(sql, true);
+        Insert insert = (Insert) statement;
+        Assertions.assertNotNull(insert.getSelect().getOption());
+    }
+
+    @Test
+    public void testOptionAfterMergeStatement() throws JSQLParserException {
+        String sql =
+                "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = s.a OPTION (HASH JOIN)";
+        Statement statement = assertSqlCanBeParsedAndDeparsed(sql, true);
+        Merge merge = (Merge) statement;
+        Assertions.assertNotNull(merge.getOption());
+        Assertions.assertEquals("HASH JOIN", merge.getOption().getOptionHints().get(0).getName());
+    }
+
+    @Test
+    public void testOptionAfterMergeOutputClause() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = s.a "
+                        + "OUTPUT deleted.a OPTION (HASH JOIN)",
+                false);
     }
 
     @Test


### PR DESCRIPTION
## Description

Completes two SQL Server `OPTION` follow-ups from #2472:

1. Parse, retain, validate and deparse `OPTION (...)` after `MERGE`, including after `OUTPUT`.
2. Parse `OPTIMIZE FOR (@variable UNKNOWN)` as an existing table-less `Column`, avoiding a new expression type and Visitor methods.

Also reject `OPTION` after standalone `VALUES`, including `INSERT ... VALUES`, because SQL Server permits query hints on `INSERT` only in its nested `SELECT`. `INSERT ... SELECT ... OPTION` remains supported.

## Testing

`OptionClauseTest`: 19/19 passed. New cases cover `MERGE`, `OUTPUT`, `OPTIMIZE FOR`, invalid `INSERT ... VALUES` and valid `INSERT ... SELECT` forms.

## Performance

`JSQLParserBenchmark.parseSQLStatements` on `performance.sql`, `version=latest`, JDK 17.0.20, 10 forks x (3 warmup + 10 measurement iterations), 100 samples per run, two interleaved runs per build on a 32-thread Intel Core i9-13900KS host:

| build | run 1 (ms/op) | run 2 (ms/op) |
|---|---:|---:|
| base `7013909` | 3.724 ± 0.026 | 3.717 ± 0.023 |
| this PR `bf17921` | 3.714 ± 0.022 | 3.738 ± 0.025 |

Mean delta: +0.15%. All confidence intervals overlap -> no regression.
