### PR TITLE
Separate JSON operators with spaces so #> deparses correctly

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/JsonExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/JsonExpression.java
@@ -87,7 +87,10 @@ public class JsonExpression extends ASTNodeAccessImpl implements Expression {
         StringBuilder b = new StringBuilder();
         b.append(expr.toString());
         for (Map.Entry<Expression, String> ident : idents) {
-            b.append(ident.getValue()).append(ident.getKey());
+            // Separate the operator with spaces: without them `#>`/`#>>` glue onto
+            // the operand (e.g. `a#>'{b}'`), and since `#` is a legal identifier
+            // character the result re-parses as `a#` `>` `...` -- a different tree.
+            b.append(' ').append(ident.getValue()).append(' ').append(ident.getKey());
         }
         return b.toString();
     }

--- a/src/test/java/net/sf/jsqlparser/expression/JsonExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/JsonExpressionTest.java
@@ -10,6 +10,7 @@
 package net.sf.jsqlparser.expression;
 
 import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,21 @@ class JsonExpressionTest {
                         + "    THEN (SELECT ((('{\"obj\":{\"field\": \"value\"}}'::JSON -> 'obj'::TEXT ->> 'field'::TEXT))))\n"
                         + " END";
         assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+    }
+
+    @Test
+    void testHashArrowOperatorsRoundTrip() throws JSQLParserException {
+        // #> and #>> must survive deparse+reparse: without spaces the operator glues
+        // onto the object (a#>'{b}') and re-parses as the comparison a# > '{b}'.
+        for (String sqlStr : new String[] {"SELECT a #> '{b}' FROM t",
+                "SELECT a #>> '{b}' FROM t"}) {
+            PlainSelect st = (PlainSelect) CCJSqlParserUtil.parse(sqlStr);
+            Assertions.assertInstanceOf(JsonExpression.class, st.getSelectItem(0).getExpression());
+            PlainSelect reparsed = (PlainSelect) CCJSqlParserUtil.parse(st.toString());
+            Assertions.assertInstanceOf(JsonExpression.class,
+                    reparsed.getSelectItem(0).getExpression(),
+                    sqlStr + " deparsed to " + st);
+        }
     }
 
     @Test


### PR DESCRIPTION
`JsonExpression.toString()` appends each operator directly onto its operand, so
`a #> '{b}'` deparses to `a#>'{b}'`. Because `#` is a legal identifier character,
that output re-parses as `a#` `>` `'{b}'` -- a GreaterThan comparison rather than
the original JSON expression, so deparse+reparse is not round-trip safe.

Emit a space on each side of the operator, matching how the JsonOperator is printed
elsewhere. Added a test that parses `#>` and `#>>`, deparses, and checks the result
still parses back to a JsonExpression.
