### PR TITLE
feat: parse BigQuery JSON string literals as implicit casts

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -477,6 +477,8 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
             // DT_ZONE (TIMESTAMP WITH TIME ZONE / WITHOUT TIME ZONE) is also a valid
             // implicit cast type prefix handled by DataType(), but distinct from DATA_TYPE.
             if (k1 == DT_ZONE) return true;
+            // BigQuery JSON 'literal' - JSON lexes as K_JSON, but DataType() accepts it
+            if (k1 == K_JSON) return getToken(2).kind == S_CHAR_LITERAL;
             if (k1 != DATA_TYPE) return false;
             int k2 = getToken(2).kind;
             if (k2 != OPENING_BRACKET) return true; // DATA_TYPE literal - simple cast

--- a/src/test/java/net/sf/jsqlparser/expression/CastExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/CastExpressionTest.java
@@ -53,6 +53,18 @@ public class CastExpressionTest {
     }
 
     @Test
+    void testImplicitCastJsonLiteral() throws JSQLParserException {
+        String sqlStr = "SELECT JSON '{\"name\": \"Jakob\"}'";
+        PlainSelect select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+
+        Assertions.assertTrue(select.getSelectItem(0).getExpression() instanceof CastExpression);
+
+        // BigQuery wraps JSON literals in functions, e. g. BOOL(JSON 'true')
+        sqlStr = "SELECT BOOL(JSON 'true') AS vacancy";
+        TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+    }
+
+    @Test
     void testImplicitCastTimestampIssue1364() throws JSQLParserException {
         String sqlStr = "SELECT TIMESTAMP WITH TIME ZONE '2004-10-19 10:23:54+02'";
         PlainSelect select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);


### PR DESCRIPTION
## Problem

BigQuery-style JSON string literals fail to parse on the `manticore` branch:

```sql
SELECT BOOL(JSON 'true') AS vacancy
SELECT SAFE.FLOAT64(JSON '9.8') AS result
SELECT JSON_VALUE(JSON '{"name": "Jakob"}', '$.name') AS name
```

all throw `ParseException: Encountered: <S_CHAR_LITERAL>` at the literal after `JSON`. These parsed fine before the Pratt-parser rework (e.g. in the 5.4-SNAPSHOT line from late 2025).

## Cause

`isImplicitCastAhead()` only treats `DT_ZONE` and `DATA_TYPE` tokens as implicit-cast prefixes. `JSON` lexes as `K_JSON` (it is needed as a keyword elsewhere: `FORMAT JSON`, `FOR JSON AUTO`, ...), so `JSON 'literal'` never reaches `ImplicitCast()`, even though `DataType()` already accepts `K_JSON` as a data type. Inside function arguments the parser then consumes `JSON` as a column and fails on the following string literal.

## Fix

Accept `K_JSON` in `isImplicitCastAhead()` when it is directly followed by a string literal, which is unambiguous with all keyword uses of `JSON`:

```java
// BigQuery JSON 'literal' - JSON lexes as K_JSON, but DataType() accepts it
if (k1 == K_JSON) return getToken(2).kind == S_CHAR_LITERAL;
```

Adds a regression test to `CastExpressionTest` covering the standalone literal and the function-argument case.

Validated against the JSQLTranspiler test suite (1042 tests), where this fix resolves 24 BigQuery JSON parse failures without affecting any other test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
