### PR TITLE
avoid quadratic backtracking when parsing bracketed server names

### DIFF
--- a/src/main/java/net/sf/jsqlparser/schema/Server.java
+++ b/src/main/java/net/sf/jsqlparser/schema/Server.java
@@ -14,7 +14,7 @@ import java.util.regex.*;
 public final class Server implements MultiPartName {
 
     public static final Pattern SERVER_PATTERN =
-            Pattern.compile("\\[([^\\]]+?)(?:\\\\([^\\]]+))?\\]");
+            Pattern.compile("\\[([^\\]\\\\]+)(?:\\\\([^\\]]+))?\\]");
 
     private String serverName;
 

--- a/src/test/java/net/sf/jsqlparser/schema/ServerTest.java
+++ b/src/test/java/net/sf/jsqlparser/schema/ServerTest.java
@@ -10,9 +10,26 @@
 package net.sf.jsqlparser.schema;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 public class ServerTest {
+
+    @Test
+    public void testCraftedServerNameDoesNotBacktrack() throws Exception {
+        final StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < 40000; i++) {
+            sb.append("a\\");
+        }
+        final String crafted = sb.toString();
+
+        // an unterminated bracketed name full of backslashes used to backtrack quadratically
+        final Server server = assertTimeoutPreemptively(Duration.ofSeconds(2),
+                () -> new Server(crafted));
+        assertEquals(crafted, server.getFullyQualifiedName());
+    }
 
     @Test
     public void testServerNameParsing() throws Exception {


### PR DESCRIPTION
Server's SERVER_PATTERN lets the first capturing group consume backslashes, so a bracketed name that is full of backslashes but never closes (for example `[a\a\a...`) makes the matcher explore every possible split between the server and instance groups, and the matching cost grows roughly quadratically with the length of the string, which can stall a thread that builds a Server from an untrusted qualified name. Excluding the backslash separator from the first group removes that ambiguity so matching stays linear, while `[server\instance]` and plain `[server]` still split exactly as before. The added test builds a Server from a long crafted value and would previously time out.