### PR TITLE
fix: support Oracle inline constraint states in CREATE TABLE

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -10913,6 +10913,25 @@ CreateIndex CreateIndex():
     }
 }
 
+List<String> ColumnDefinitionParameter(): {
+    Token tk = null;
+    List<String> parameter = new ArrayList<String>();
+} {
+    (
+        parameter=CreateParameter()
+        |
+        (
+            tk=<K_DEFERRABLE>
+            | tk=<K_DISABLE>
+            | tk=<K_ENABLE>
+            | tk=<K_NOVALIDATE>
+            | tk=<K_VALIDATE>
+        )
+        { parameter.add(tk.image); }
+    )
+    { return parameter; }
+}
+
 ColumnDefinition ColumnDefinition(): {
     ColumnDefinition coldef;
     String columnName;
@@ -10922,7 +10941,7 @@ ColumnDefinition ColumnDefinition(): {
 } {
     columnName=RelObjectName()
     colDataType=ColDataType()
-    ( LOOKAHEAD(2) parameter=CreateParameter() { columnSpecs.addAll(parameter); } )*
+    ( LOOKAHEAD(2) parameter=ColumnDefinitionParameter() { columnSpecs.addAll(parameter); } )*
     {
         coldef = new ColumnDefinition();
         coldef.setColumnName(columnName);

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateTableTest.java
@@ -1192,6 +1192,36 @@ public class CreateTableTest {
     }
 
     @Test
+    void testOracleInlineConstraintState() throws JSQLParserException {
+        String sqlStr =
+                "CREATE TABLE DIAM.IAM_DENEME1 ("
+                        + "ID VARCHAR2(36 BYTE) NOT NULL ENABLE,"
+                        + "REQUEST_ID VARCHAR2(50 BYTE),"
+                        + "CREATE_DATE TIMESTAMP(9),"
+                        + "USER_ID VARCHAR2(50 BYTE),"
+                        + "CODE VARCHAR2(100 BYTE) NOT NULL ENABLE,"
+                        + "IS_OUTSOURCE_ENABLED CHAR(1 BYTE) DEFAULT 1 NOT NULL ENABLE,"
+                        + "IS_PASSWORD_NUMERIC CHAR(1 BYTE) DEFAULT 0 NOT NULL ENABLE"
+                        + ")";
+
+        CreateTable createTable = (CreateTable) CCJSqlParserUtil.parse(sqlStr);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "CREATE TABLE test ("
+                        + "a NUMBER NOT NULL ENABLE,"
+                        + "b NUMBER NOT NULL DISABLE,"
+                        + "c NUMBER NOT NULL ENABLE NOVALIDATE,"
+                        + "d NUMBER CONSTRAINT d_nn NOT NULL DEFERRABLE VALIDATE"
+                        + ")",
+                true);
+
+        assertEquals(Arrays.asList("NOT", "NULL", "ENABLE"),
+                createTable.getColumnDefinitions().get(0).getColumnSpecs());
+        assertEquals(Arrays.asList("DEFAULT", "1", "NOT", "NULL", "ENABLE"),
+                createTable.getColumnDefinitions().get(5).getColumnSpecs());
+    }
+
+    @Test
     void testCreateTableIndexVisibilityWithOtherIndexOptions() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed(
                 "CREATE TABLE t1 (a int, KEY idx_a (a) INVISIBLE COMMENT 'retiring')", true);


### PR DESCRIPTION
Fixes [https://github.com/JSQLParser/JSqlParser/issues/2446](https://github.com/JSQLParser/JSqlParser/issues/2446)

Parse ENABLE, DISABLE, VALIDATE, NOVALIDATE, and DEFERRABLE
as column definition parameters without affecting row movement clauses.

Add regression coverage for Oracle NOT NULL ENABLE definitions.