### PR TITLE
fix(parser): support IF EXISTS in ALTER TABLE MODIFY COLUMN

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -1118,8 +1118,9 @@ public class AlterExpression implements Serializable {
                 } else if (hasColumns) {
                     b.append("COLUMNS ");
                 }
-                if (useIfNotExists
-                        && operation == AlterOperation.ADD) {
+                if (usingIfExists) {
+                    b.append("IF EXISTS ");
+                } else if (useIfNotExists) {
                     b.append("IF NOT EXISTS ");
                 }
             }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -12633,7 +12633,14 @@ AlterExpression AlterExpressionAddAlterModify():
                     <K_COLUMNS> { alterExp.hasColumns(true); }
                 )
             )?
-            [ LOOKAHEAD(2) <K_IF> <K_NOT> <K_EXISTS> { alterExp.setUseIfNotExists(true); } ]
+            [
+                LOOKAHEAD(2) <K_IF>
+                (
+                    <K_NOT> <K_EXISTS> { alterExp.setUseIfNotExists(true); }
+                    |
+                    <K_EXISTS> { alterExp.setUsingIfExists(true); }
+                )
+            ]
             (
                 LOOKAHEAD(3) AlterExpressionColumnChanges(alterExp)
                 |

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -1109,6 +1109,25 @@ public class AlterTest {
         assertSqlCanBeParsedAndDeparsed(stmt);
     }
 
+    @ParameterizedTest
+    @MethodSource("provideModifyColumnExistenceClauses")
+    public void testModifyColumnExistenceClauses(String sql, boolean usingIfExists,
+            boolean useIfNotExists) throws JSQLParserException {
+        Alter alter = (Alter) assertSqlCanBeParsedAndDeparsed(sql);
+        AlterExpression expression = alter.getAlterExpressions().get(0);
+
+        assertEquals(usingIfExists, expression.isUsingIfExists());
+        assertEquals(useIfNotExists, expression.isUseIfNotExists());
+    }
+
+    private static Stream<Arguments> provideModifyColumnExistenceClauses() {
+        return Stream.of(
+                Arguments.of("ALTER TABLE t MODIFY COLUMN IF EXISTS c INT", true, false),
+                Arguments.of("ALTER TABLE t MODIFY IF EXISTS c INT", true, false),
+                Arguments.of("ALTER TABLE t MODIFY COLUMN IF NOT EXISTS c INT", false, true),
+                Arguments.of("ALTER TABLE t MODIFY IF NOT EXISTS c INT", false, true));
+    }
+
     @Test
     public void testIssue2027() throws JSQLParserException {
         String sql = "ALTER TABLE `foo_bar` ADD COLUMN `baz` text";


### PR DESCRIPTION
Fixes [https://github.com/JSQLParser/JSqlParser/issues/2112](https://github.com/JSQLParser/JSqlParser/issues/2112)

- accept both IF EXISTS and IF NOT EXISTS with optional COLUMN
- preserve existence clauses when deparsing
- add round-trip and AST regression tests