### PR TITLE
avoid quadratic backtracking in the oracle hint comment pattern

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/OracleHint.java
+++ b/src/main/java/net/sf/jsqlparser/expression/OracleHint.java
@@ -24,7 +24,7 @@ public class OracleHint extends ASTNodeAccessImpl implements Expression {
 
     private static final Pattern SINGLE_LINE = Pattern.compile("--\\+ *([^ ].*[^ ])");
     private static final Pattern MULTI_LINE =
-            Pattern.compile("/\\*\\+ *([^ ].*[^ ]) *\\*+/", Pattern.MULTILINE | Pattern.DOTALL);
+            Pattern.compile("\\A/\\*\\+ *([^ ].*[^ ]) *\\*+/", Pattern.MULTILINE | Pattern.DOTALL);
 
     private String value;
     private boolean singleLine = false;

--- a/src/test/java/net/sf/jsqlparser/expression/OracleHintTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/OracleHintTest.java
@@ -9,6 +9,10 @@
  */
 package net.sf.jsqlparser.expression;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import java.time.Duration;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.test.TestUtils;
 import org.junit.jupiter.api.Test;
@@ -44,6 +48,20 @@ class OracleHintTest {
         String sqlString =
                 "MERGE /*+parallel*/ INTO dual USING z ON (a=b) WHEN MATCHED THEN UPDATE SET a=b";
         TestUtils.assertSqlCanBeParsedAndDeparsed(sqlString, true);
+    }
+
+    @Test
+    void testCraftedHintCommentDoesNotBacktrack() {
+        final StringBuilder sb = new StringBuilder("-- /*+ ");
+        for (int i = 0; i < 100000; i++) {
+            sb.append('*');
+        }
+        final String crafted = sb.toString();
+
+        // a line comment carrying an unterminated /*+ marker (no closing */) used to make the
+        // block hint pattern backtrack quadratically, and it is not an oracle hint anyway
+        assertTimeoutPreemptively(Duration.ofSeconds(2),
+                () -> assertFalse(OracleHint.isHintMatch(crafted)));
     }
 
 }


### PR DESCRIPTION
OracleHint checks every comment that precedes a select/insert/update/delete/merge against the block-hint pattern with an unanchored find, so a single line comment that happens to contain a /*+ marker followed by a long run of stars and no closing */ makes the greedy match backtrack quadratically (a comment with 100k stars takes around twelve seconds), and this is reachable straight through CCJSqlParserUtil.parse. A hint only ever begins the comment though, so anchoring the pattern at the start of the input lets it reject that line-comment case immediately while still matching every real /*+ ... */ hint exactly as before. I have added a regression test that pins the crafted comment under a short preemptive timeout.