### PR TITLE
feat(parser): support DuckDB MAP literals and PIVOT queries

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -621,6 +621,14 @@ public interface ExpressionVisitor<T> {
         this.visit(arrayConstructor, null);
     }
 
+    default <S> T visit(MapExpression mapExpression, S context) {
+        return null;
+    }
+
+    default void visit(MapExpression mapExpression) {
+        this.visit(mapExpression, null);
+    }
+
     <S> T visit(VariableAssignment variableAssignment, S context);
 
     default void visit(VariableAssignment variableAssignment) {

--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -12,6 +12,7 @@ package net.sf.jsqlparser.expression;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 import net.sf.jsqlparser.expression.operators.arithmetic.Addition;
 import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseAnd;
@@ -691,6 +692,16 @@ public class ExpressionVisitorAdapter<T>
     @Override
     public <S> T visit(ArrayConstructor arrayConstructor, S context) {
         return visitExpressions(arrayConstructor, context, arrayConstructor.getExpressions());
+    }
+
+    @Override
+    public <S> T visit(MapExpression mapExpression, S context) {
+        ArrayList<Expression> subExpressions = new ArrayList<>();
+        for (Map.Entry<Expression, Expression> entry : mapExpression.getEntries()) {
+            subExpressions.add(entry.getKey());
+            subExpressions.add(entry.getValue());
+        }
+        return visitExpressions(mapExpression, context, subExpressions);
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/expression/MapExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/MapExpression.java
@@ -1,0 +1,79 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
+/**
+ * DuckDB's {@code MAP {key: value, ...}} literal expression.
+ *
+ * @see <a href="https://duckdb.org/docs/sql/data_types/map.html">DuckDB MAP type</a>
+ */
+public class MapExpression extends ASTNodeAccessImpl implements Expression {
+
+    private List<Map.Entry<Expression, Expression>> entries = new ArrayList<>();
+
+    public MapExpression() {}
+
+    public MapExpression(Collection<? extends Map.Entry<Expression, Expression>> entries) {
+        this.entries.addAll(entries);
+    }
+
+    public List<Map.Entry<Expression, Expression>> getEntries() {
+        return entries;
+    }
+
+    public void setEntries(List<Map.Entry<Expression, Expression>> entries) {
+        this.entries = entries;
+    }
+
+    public MapExpression withEntries(List<Map.Entry<Expression, Expression>> entries) {
+        setEntries(entries);
+        return this;
+    }
+
+    public MapExpression addEntries(
+            Collection<? extends Map.Entry<Expression, Expression>> entries) {
+        this.entries.addAll(entries);
+        return this;
+    }
+
+    public MapExpression addEntry(Expression key, Expression value) {
+        entries.add(new AbstractMap.SimpleEntry<>(key, value));
+        return this;
+    }
+
+    public StringBuilder appendTo(StringBuilder builder) {
+        builder.append("MAP {");
+        for (int i = 0; i < entries.size(); i++) {
+            if (i > 0) {
+                builder.append(", ");
+            }
+            Map.Entry<Expression, Expression> entry = entries.get(i);
+            builder.append(entry.getKey()).append(": ").append(entry.getValue());
+        }
+        return builder.append("}");
+    }
+
+    @Override
+    public String toString() {
+        return appendTo(new StringBuilder()).toString();
+    }
+
+    @Override
+    public <T, S> T accept(ExpressionVisitor<T> expressionVisitor, S context) {
+        return expressionVisitor.visit(this, context);
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/select/FromItemVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/FromItemVisitor.java
@@ -9,12 +9,11 @@
  */
 package net.sf.jsqlparser.statement.select;
 
+import java.util.Collection;
+import java.util.List;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.imprt.Import;
 import net.sf.jsqlparser.statement.piped.FromQuery;
-
-import java.util.Collection;
-import java.util.List;
 
 public interface FromItemVisitor<T> {
 
@@ -83,6 +82,14 @@ public interface FromItemVisitor<T> {
 
     default void visit(PlainSelect plainSelect) {
         this.visit(plainSelect, null);
+    }
+
+    default <S> T visit(PivotQuery pivotQuery, S context) {
+        return null;
+    }
+
+    default void visit(PivotQuery pivotQuery) {
+        this.visit(pivotQuery, null);
     }
 
     <S> T visit(SetOperationList setOperationList, S context);

--- a/src/main/java/net/sf/jsqlparser/statement/select/FromItemVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/FromItemVisitorAdapter.java
@@ -9,6 +9,8 @@
  */
 package net.sf.jsqlparser.statement.select;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
@@ -16,9 +18,6 @@ import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.imprt.Import;
 import net.sf.jsqlparser.statement.piped.FromQuery;
-
-import java.util.ArrayList;
-import java.util.Collection;
 
 @SuppressWarnings({"PMD.UncommentedEmptyMethodBody"})
 public class FromItemVisitorAdapter<T> implements FromItemVisitor<T> {
@@ -123,6 +122,11 @@ public class FromItemVisitorAdapter<T> implements FromItemVisitor<T> {
     @Override
     public <S> T visit(PlainSelect plainSelect, S context) {
         return plainSelect.accept(selectVisitor, context);
+    }
+
+    @Override
+    public <S> T visit(PivotQuery pivotQuery, S context) {
+        return pivotQuery.accept(selectVisitor, context);
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/statement/select/PivotQuery.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/PivotQuery.java
@@ -1,0 +1,160 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.select;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.Function;
+import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+
+/**
+ * DuckDB's simplified {@code PIVOT} query.
+ *
+ * <p>
+ * Unlike {@link Pivot}, which is a clause attached to a {@link FromItem}, this construct is a query
+ * in its own right and can therefore be used as a statement, CTE, or parenthesized subquery.
+ *
+ * @see <a href="https://duckdb.org/docs/sql/statements/pivot.html">DuckDB PIVOT</a>
+ */
+public class PivotQuery extends Select {
+
+    private FromItem fromItem;
+    private ExpressionList<Expression> onExpressions;
+    private List<SelectItem<Function>> usingItems;
+    private ExpressionList<Expression> groupByExpressions;
+
+    public FromItem getFromItem() {
+        return fromItem;
+    }
+
+    public void setFromItem(FromItem fromItem) {
+        this.fromItem = fromItem;
+    }
+
+    public PivotQuery withFromItem(FromItem fromItem) {
+        setFromItem(fromItem);
+        return this;
+    }
+
+    public ExpressionList<Expression> getOnExpressions() {
+        return onExpressions;
+    }
+
+    public void setOnExpressions(ExpressionList<Expression> onExpressions) {
+        this.onExpressions = onExpressions;
+    }
+
+    public PivotQuery withOnExpressions(ExpressionList<Expression> onExpressions) {
+        setOnExpressions(onExpressions);
+        return this;
+    }
+
+    public PivotQuery addOnExpressions(Expression... expressions) {
+        return addOnExpressions(Arrays.asList(expressions));
+    }
+
+    public PivotQuery addOnExpressions(Collection<? extends Expression> expressions) {
+        ExpressionList<Expression> collection =
+                Optional.ofNullable(getOnExpressions()).orElseGet(ExpressionList::new);
+        collection.addAll(expressions);
+        return withOnExpressions(collection);
+    }
+
+    public List<SelectItem<Function>> getUsingItems() {
+        return usingItems;
+    }
+
+    public void setUsingItems(List<SelectItem<Function>> usingItems) {
+        this.usingItems = usingItems;
+    }
+
+    public PivotQuery withUsingItems(List<SelectItem<Function>> usingItems) {
+        setUsingItems(usingItems);
+        return this;
+    }
+
+    public PivotQuery addUsingItems(SelectItem<Function>... usingItems) {
+        List<SelectItem<Function>> collection =
+                Optional.ofNullable(getUsingItems()).orElseGet(ArrayList::new);
+        Collections.addAll(collection, usingItems);
+        return withUsingItems(collection);
+    }
+
+    public PivotQuery addUsingItems(Collection<? extends SelectItem<Function>> usingItems) {
+        List<SelectItem<Function>> collection =
+                Optional.ofNullable(getUsingItems()).orElseGet(ArrayList::new);
+        collection.addAll(usingItems);
+        return withUsingItems(collection);
+    }
+
+    public ExpressionList<Expression> getGroupByExpressions() {
+        return groupByExpressions;
+    }
+
+    public void setGroupByExpressions(ExpressionList<Expression> groupByExpressions) {
+        this.groupByExpressions = groupByExpressions;
+    }
+
+    public PivotQuery withGroupByExpressions(ExpressionList<Expression> groupByExpressions) {
+        setGroupByExpressions(groupByExpressions);
+        return this;
+    }
+
+    public PivotQuery addGroupByExpressions(Expression... expressions) {
+        return addGroupByExpressions(Arrays.asList(expressions));
+    }
+
+    public PivotQuery addGroupByExpressions(Collection<? extends Expression> expressions) {
+        ExpressionList<Expression> collection =
+                Optional.ofNullable(getGroupByExpressions()).orElseGet(ExpressionList::new);
+        collection.addAll(expressions);
+        return withGroupByExpressions(collection);
+    }
+
+    @Override
+    public StringBuilder appendSelectBodyTo(StringBuilder builder) {
+        builder.append("PIVOT ").append(fromItem);
+        if (onExpressions != null) {
+            builder.append(" ON ").append(onExpressions);
+        }
+        if (usingItems != null) {
+            builder.append(" USING ").append(Select.getStringList(usingItems));
+        }
+        if (groupByExpressions != null) {
+            builder.append(" GROUP BY ").append(groupByExpressions);
+        }
+        return builder;
+    }
+
+    @Override
+    public <T, S> T accept(SelectVisitor<T> selectVisitor, S context) {
+        return selectVisitor.visit(this, context);
+    }
+
+    @Override
+    public <T, S> T accept(FromItemVisitor<T> fromItemVisitor, S context) {
+        return fromItemVisitor.visit(this, context);
+    }
+
+    @Override
+    public SampleClause getSampleClause() {
+        return null;
+    }
+
+    @Override
+    public FromItem setSampleClause(SampleClause sampleClause) {
+        return null;
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/select/SelectVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/SelectVisitor.java
@@ -9,10 +9,9 @@
  */
 package net.sf.jsqlparser.statement.select;
 
+import java.util.List;
 import net.sf.jsqlparser.statement.OutputClause;
 import net.sf.jsqlparser.statement.piped.FromQuery;
-
-import java.util.List;
 
 public interface SelectVisitor<T> {
     default <S> T visitWithItems(List<WithItem<?>> withItemsList, S context) {
@@ -38,6 +37,14 @@ public interface SelectVisitor<T> {
 
     default void visit(PlainSelect plainSelect) {
         this.visit(plainSelect, null);
+    }
+
+    default <S> T visit(PivotQuery pivotQuery, S context) {
+        return null;
+    }
+
+    default void visit(PivotQuery pivotQuery) {
+        this.visit(pivotQuery, null);
     }
 
     <S> T visit(FromQuery fromQuery, S context);

--- a/src/main/java/net/sf/jsqlparser/statement/select/SelectVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/select/SelectVisitorAdapter.java
@@ -11,6 +11,7 @@ package net.sf.jsqlparser.statement.select;
 
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.expression.Function;
 import net.sf.jsqlparser.statement.OutputClause;
 import net.sf.jsqlparser.statement.piped.FromQuery;
 
@@ -214,6 +215,32 @@ public class SelectVisitorAdapter<T> implements SelectVisitor<T> {
         // }
 
         fromItemVisitor.visitFromItem(plainSelect.getIntoTempTable(), context);
+        return null;
+    }
+
+    @Override
+    public <S> T visit(PivotQuery pivotQuery, S context) {
+        visitWithItems(pivotQuery.getWithItemsList(), context);
+
+        fromItemVisitor.visitFromItem(pivotQuery.getFromItem(), context);
+        expressionVisitor.visitExpressions(pivotQuery.getOnExpressions(), context);
+
+        if (pivotQuery.getUsingItems() != null) {
+            for (SelectItem<Function> item : pivotQuery.getUsingItems()) {
+                item.accept(selectItemVisitor, context);
+            }
+        }
+
+        expressionVisitor.visitExpressions(pivotQuery.getGroupByExpressions(), context);
+        expressionVisitor.visitOrderBy(pivotQuery.getOrderByElements(), context);
+        expressionVisitor.visitLimit(pivotQuery.getLimit(), context);
+
+        if (pivotQuery.getOffset() != null) {
+            expressionVisitor.visitExpression(pivotQuery.getOffset().getOffset(), context);
+        }
+        if (pivotQuery.getFetch() != null) {
+            expressionVisitor.visitExpression(pivotQuery.getFetch().getExpression(), context);
+        }
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -375,36 +375,33 @@ public class TablesNamesFinder<Void>
 
     @Override
     public <S> Void visit(PivotQuery pivotQuery, S context) {
-        List<WithItem<?>> withItemsList = pivotQuery.getWithItemsList();
-        if (withItemsList != null && !withItemsList.isEmpty()) {
-            for (WithItem<?> withItem : withItemsList) {
-                withItem.accept((SelectVisitor<?>) this, context);
-            }
-        }
+        visitWithItems(pivotQuery.getWithItemsList(), context);
+        visitFromItem(pivotQuery.getFromItem(), context);
+        visitExpressions(pivotQuery.getOnExpressions(), context);
+        visitSelectItems(pivotQuery.getUsingItems(), context);
+        visitExpressions(pivotQuery.getGroupByExpressions(), context);
+        visitOrderBy(pivotQuery.getOrderByElements(), context);
+        visitLimit(pivotQuery.getLimit(), context);
 
-        if (pivotQuery.getFromItem() != null) {
-            pivotQuery.getFromItem().accept(this, context);
-        }
-        if (pivotQuery.getOnExpressions() != null) {
-            pivotQuery.getOnExpressions().accept(this, context);
-        }
-        if (pivotQuery.getUsingItems() != null) {
-            for (SelectItem<?> item : pivotQuery.getUsingItems()) {
+        visitPivotPagination(pivotQuery, context);
+        return null;
+    }
+
+    private <S> void visitSelectItems(List<? extends SelectItem<?>> selectItems, S context) {
+        if (selectItems != null) {
+            for (SelectItem<?> item : selectItems) {
                 item.accept(this, context);
             }
         }
-        if (pivotQuery.getGroupByExpressions() != null) {
-            pivotQuery.getGroupByExpressions().accept(this, context);
-        }
-        visitOrderBy(pivotQuery.getOrderByElements(), context);
-        visitLimit(pivotQuery.getLimit(), context);
+    }
+
+    private <S> void visitPivotPagination(PivotQuery pivotQuery, S context) {
         if (pivotQuery.getOffset() != null) {
             pivotQuery.getOffset().getOffset().accept(this, context);
         }
         if (pivotQuery.getFetch() != null && pivotQuery.getFetch().getExpression() != null) {
             pivotQuery.getFetch().getExpression().accept(this, context);
         }
-        return null;
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -73,6 +73,7 @@ import net.sf.jsqlparser.statement.DeclareStatement;
 import net.sf.jsqlparser.statement.DescribeStatement;
 import net.sf.jsqlparser.statement.ExplainStatement;
 import net.sf.jsqlparser.statement.IfElseStatement;
+import net.sf.jsqlparser.statement.OutputClause;
 import net.sf.jsqlparser.statement.PurgeObjectType;
 import net.sf.jsqlparser.statement.PurgeStatement;
 import net.sf.jsqlparser.statement.ResetStatement;
@@ -93,7 +94,6 @@ import net.sf.jsqlparser.statement.alter.AlterSession;
 import net.sf.jsqlparser.statement.alter.AlterSystemStatement;
 import net.sf.jsqlparser.statement.alter.RenameTableStatement;
 import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
-import net.sf.jsqlparser.statement.OutputClause;
 import net.sf.jsqlparser.statement.analyze.Analyze;
 import net.sf.jsqlparser.statement.comment.Comment;
 import net.sf.jsqlparser.statement.create.database.CreateDatabase;
@@ -156,6 +156,7 @@ import net.sf.jsqlparser.statement.select.LateralSubSelect;
 import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.ParenthesedFromItem;
 import net.sf.jsqlparser.statement.select.ParenthesedSelect;
+import net.sf.jsqlparser.statement.select.PivotQuery;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.select.SelectItem;
@@ -373,8 +374,47 @@ public class TablesNamesFinder<Void>
     }
 
     @Override
+    public <S> Void visit(PivotQuery pivotQuery, S context) {
+        List<WithItem<?>> withItemsList = pivotQuery.getWithItemsList();
+        if (withItemsList != null && !withItemsList.isEmpty()) {
+            for (WithItem<?> withItem : withItemsList) {
+                withItem.accept((SelectVisitor<?>) this, context);
+            }
+        }
+
+        if (pivotQuery.getFromItem() != null) {
+            pivotQuery.getFromItem().accept(this, context);
+        }
+        if (pivotQuery.getOnExpressions() != null) {
+            pivotQuery.getOnExpressions().accept(this, context);
+        }
+        if (pivotQuery.getUsingItems() != null) {
+            for (SelectItem<?> item : pivotQuery.getUsingItems()) {
+                item.accept(this, context);
+            }
+        }
+        if (pivotQuery.getGroupByExpressions() != null) {
+            pivotQuery.getGroupByExpressions().accept(this, context);
+        }
+        visitOrderBy(pivotQuery.getOrderByElements(), context);
+        visitLimit(pivotQuery.getLimit(), context);
+        if (pivotQuery.getOffset() != null) {
+            pivotQuery.getOffset().getOffset().accept(this, context);
+        }
+        if (pivotQuery.getFetch() != null && pivotQuery.getFetch().getExpression() != null) {
+            pivotQuery.getFetch().getExpression().accept(this, context);
+        }
+        return null;
+    }
+
+    @Override
     public void visit(PlainSelect plainSelect) {
         SelectVisitor.super.visit(plainSelect);
+    }
+
+    @Override
+    public void visit(PivotQuery pivotQuery) {
+        SelectVisitor.super.visit(pivotQuery);
     }
 
     /**
@@ -1844,6 +1884,15 @@ public class TablesNamesFinder<Void>
     public <S> Void visit(ArrayConstructor array, S context) {
         for (Expression expression : array.getExpressions()) {
             expression.accept(this, context);
+        }
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(MapExpression mapExpression, S context) {
+        for (Map.Entry<Expression, Expression> entry : mapExpression.getEntries()) {
+            entry.getKey().accept(this, context);
+            entry.getValue().accept(this, context);
         }
         return null;
     }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -45,12 +45,12 @@ import net.sf.jsqlparser.expression.JsonAggregateFunction;
 import net.sf.jsqlparser.expression.JsonExpression;
 import net.sf.jsqlparser.expression.JsonFunction;
 import net.sf.jsqlparser.expression.JsonTableFunction;
-import net.sf.jsqlparser.expression.XmlTableFunction;
 import net.sf.jsqlparser.expression.KeepExpression;
 import net.sf.jsqlparser.expression.KeyExpression;
 import net.sf.jsqlparser.expression.LambdaExpression;
 import net.sf.jsqlparser.expression.LongValue;
 import net.sf.jsqlparser.expression.LowExpression;
+import net.sf.jsqlparser.expression.MapExpression;
 import net.sf.jsqlparser.expression.MySQLGroupConcat;
 import net.sf.jsqlparser.expression.NextValExpression;
 import net.sf.jsqlparser.expression.NotExpression;
@@ -62,12 +62,12 @@ import net.sf.jsqlparser.expression.OracleNamedFunctionParameter;
 import net.sf.jsqlparser.expression.OverlapsCondition;
 import net.sf.jsqlparser.expression.PostgresNamedFunctionParameter;
 import net.sf.jsqlparser.expression.RangeExpression;
-import net.sf.jsqlparser.expression.TernaryExpression;
 import net.sf.jsqlparser.expression.RowConstructor;
 import net.sf.jsqlparser.expression.RowGetExpression;
 import net.sf.jsqlparser.expression.SignedExpression;
 import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.expression.StructType;
+import net.sf.jsqlparser.expression.TernaryExpression;
 import net.sf.jsqlparser.expression.TimeKeyExpression;
 import net.sf.jsqlparser.expression.TimeValue;
 import net.sf.jsqlparser.expression.TimestampValue;
@@ -79,6 +79,7 @@ import net.sf.jsqlparser.expression.VariableAssignment;
 import net.sf.jsqlparser.expression.WhenClause;
 import net.sf.jsqlparser.expression.WindowElement;
 import net.sf.jsqlparser.expression.XMLSerializeExpr;
+import net.sf.jsqlparser.expression.XmlTableFunction;
 import net.sf.jsqlparser.expression.operators.arithmetic.Addition;
 import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseAnd;
 import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseLeftShift;
@@ -1617,6 +1618,22 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
             expression.accept(this, context);
         }
         builder.append("]");
+        return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(MapExpression mapExpression, S context) {
+        builder.append("MAP {");
+        for (int i = 0; i < mapExpression.getEntries().size(); i++) {
+            if (i > 0) {
+                builder.append(", ");
+            }
+            Map.Entry<Expression, Expression> entry = mapExpression.getEntries().get(i);
+            entry.getKey().accept(this, context);
+            builder.append(": ");
+            entry.getValue().accept(this, context);
+        }
+        builder.append("}");
         return builder;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -62,6 +62,7 @@ import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.ParenthesedFromItem;
 import net.sf.jsqlparser.statement.select.ParenthesedSelect;
 import net.sf.jsqlparser.statement.select.Pivot;
+import net.sf.jsqlparser.statement.select.PivotQuery;
 import net.sf.jsqlparser.statement.select.PivotVisitor;
 import net.sf.jsqlparser.statement.select.PivotXml;
 import net.sf.jsqlparser.statement.select.PlainSelect;
@@ -426,6 +427,81 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
 
 
 
+        return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(PivotQuery pivotQuery, S context) {
+        List<WithItem<?>> withItemsList = pivotQuery.getWithItemsList();
+        if (withItemsList != null && !withItemsList.isEmpty()) {
+            builder.append("WITH ");
+            for (Iterator<WithItem<?>> iter = withItemsList.iterator(); iter.hasNext();) {
+                iter.next().accept((SelectVisitor<?>) this, context);
+                if (iter.hasNext()) {
+                    builder.append(",");
+                }
+                builder.append(" ");
+            }
+        }
+
+        builder.append("PIVOT ");
+        pivotQuery.getFromItem().accept(this, context);
+
+        if (pivotQuery.getOnExpressions() != null) {
+            builder.append(" ON ");
+            pivotQuery.getOnExpressions().accept(expressionVisitor, context);
+        }
+        if (pivotQuery.getUsingItems() != null) {
+            builder.append(" USING ");
+            for (Iterator<? extends SelectItem<?>> iter =
+                    pivotQuery.getUsingItems().iterator(); iter.hasNext();) {
+                iter.next().accept(this, context);
+                if (iter.hasNext()) {
+                    builder.append(", ");
+                }
+            }
+        }
+        if (pivotQuery.getGroupByExpressions() != null) {
+            builder.append(" GROUP BY ");
+            pivotQuery.getGroupByExpressions().accept(expressionVisitor, context);
+        }
+
+        Alias alias = pivotQuery.getAlias();
+        if (alias != null) {
+            builder.append(alias);
+        }
+        Pivot pivot = pivotQuery.getPivot();
+        if (pivot != null) {
+            pivot.accept(this, context);
+        }
+        UnPivot unpivot = pivotQuery.getUnPivot();
+        if (unpivot != null) {
+            unpivot.accept(this, context);
+        }
+
+        if (pivotQuery.getOrderByElements() != null) {
+            new OrderByDeParser(expressionVisitor, builder).deParse(pivotQuery.isOracleSiblings(),
+                    pivotQuery.getOrderByElements());
+            deParseInterpolate(pivotQuery.getInterpolate());
+        }
+        if (pivotQuery.getOption() != null) {
+            builder.append(pivotQuery.getOption());
+        }
+        if (pivotQuery.getLimitBy() != null) {
+            new LimitDeparser(expressionVisitor, builder).deParse(pivotQuery.getLimitBy());
+        }
+        if (pivotQuery.getLimit() != null) {
+            new LimitDeparser(expressionVisitor, builder).deParse(pivotQuery.getLimit());
+        }
+        if (pivotQuery.getOffset() != null) {
+            visit(pivotQuery.getOffset());
+        }
+        if (pivotQuery.getFetch() != null) {
+            visit(pivotQuery.getFetch());
+        }
+        if (pivotQuery.getIsolation() != null) {
+            builder.append(pivotQuery.getIsolation());
+        }
         return builder;
     }
 
@@ -909,6 +985,11 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
 
     public void visit(PlainSelect plainSelect) {
         visit(plainSelect, null);
+    }
+
+    @Override
+    public void visit(PivotQuery pivotQuery) {
+        visit(pivotQuery, null);
     }
 
     public void visit(SelectItem<?> selectExpressionItem) {

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
@@ -9,6 +9,7 @@
  */
 package net.sf.jsqlparser.util.validation.validator;
 
+import java.util.Map;
 import net.sf.jsqlparser.expression.AllValue;
 import net.sf.jsqlparser.expression.AnalyticExpression;
 import net.sf.jsqlparser.expression.AnyComparisonExpression;
@@ -39,12 +40,12 @@ import net.sf.jsqlparser.expression.JsonAggregateFunction;
 import net.sf.jsqlparser.expression.JsonExpression;
 import net.sf.jsqlparser.expression.JsonFunction;
 import net.sf.jsqlparser.expression.JsonTableFunction;
-import net.sf.jsqlparser.expression.XmlTableFunction;
 import net.sf.jsqlparser.expression.KeepExpression;
 import net.sf.jsqlparser.expression.KeyExpression;
 import net.sf.jsqlparser.expression.LambdaExpression;
 import net.sf.jsqlparser.expression.LongValue;
 import net.sf.jsqlparser.expression.LowExpression;
+import net.sf.jsqlparser.expression.MapExpression;
 import net.sf.jsqlparser.expression.MySQLGroupConcat;
 import net.sf.jsqlparser.expression.NextValExpression;
 import net.sf.jsqlparser.expression.NotExpression;
@@ -56,12 +57,12 @@ import net.sf.jsqlparser.expression.OracleNamedFunctionParameter;
 import net.sf.jsqlparser.expression.OverlapsCondition;
 import net.sf.jsqlparser.expression.PostgresNamedFunctionParameter;
 import net.sf.jsqlparser.expression.RangeExpression;
-import net.sf.jsqlparser.expression.TernaryExpression;
 import net.sf.jsqlparser.expression.RowConstructor;
 import net.sf.jsqlparser.expression.RowGetExpression;
 import net.sf.jsqlparser.expression.SignedExpression;
 import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.expression.StructType;
+import net.sf.jsqlparser.expression.TernaryExpression;
 import net.sf.jsqlparser.expression.TimeKeyExpression;
 import net.sf.jsqlparser.expression.TimeValue;
 import net.sf.jsqlparser.expression.TimestampValue;
@@ -75,6 +76,7 @@ import net.sf.jsqlparser.expression.WindowElement;
 import net.sf.jsqlparser.expression.WindowOffset;
 import net.sf.jsqlparser.expression.WindowRange;
 import net.sf.jsqlparser.expression.XMLSerializeExpr;
+import net.sf.jsqlparser.expression.XmlTableFunction;
 import net.sf.jsqlparser.expression.operators.arithmetic.Addition;
 import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseAnd;
 import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseLeftShift;
@@ -1009,6 +1011,15 @@ public class ExpressionValidator extends AbstractValidator<Expression>
     }
 
     @Override
+    public <S> Void visit(MapExpression mapExpression, S context) {
+        for (Map.Entry<Expression, Expression> entry : mapExpression.getEntries()) {
+            entry.getKey().accept(this, context);
+            entry.getValue().accept(this, context);
+        }
+        return null;
+    }
+
+    @Override
     public void validate(Expression expression) {
         expression.accept(this, null);
     }
@@ -1248,6 +1259,10 @@ public class ExpressionValidator extends AbstractValidator<Expression>
 
     public void visit(ArrayConstructor aThis) {
         visit(aThis, null);
+    }
+
+    public void visit(MapExpression mapExpression) {
+        visit(mapExpression, null);
     }
 
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/SelectValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/SelectValidator.java
@@ -28,17 +28,18 @@ import net.sf.jsqlparser.statement.select.LateralSubSelect;
 import net.sf.jsqlparser.statement.select.MinusOp;
 import net.sf.jsqlparser.statement.select.MySqlSelectIntoClause;
 import net.sf.jsqlparser.statement.select.Offset;
+import net.sf.jsqlparser.statement.select.OptionClause;
+import net.sf.jsqlparser.statement.select.OptionHint;
 import net.sf.jsqlparser.statement.select.ParenthesedFromItem;
 import net.sf.jsqlparser.statement.select.ParenthesedSelect;
 import net.sf.jsqlparser.statement.select.Pivot;
+import net.sf.jsqlparser.statement.select.PivotQuery;
 import net.sf.jsqlparser.statement.select.PivotVisitor;
 import net.sf.jsqlparser.statement.select.PivotXml;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.SelectItem;
 import net.sf.jsqlparser.statement.select.SelectItemVisitor;
 import net.sf.jsqlparser.statement.select.SelectVisitor;
-import net.sf.jsqlparser.statement.select.OptionClause;
-import net.sf.jsqlparser.statement.select.OptionHint;
 import net.sf.jsqlparser.statement.select.SetOperationList;
 import net.sf.jsqlparser.statement.select.TableFunction;
 import net.sf.jsqlparser.statement.select.TableStatement;
@@ -156,6 +157,36 @@ public class SelectValidator extends AbstractValidator<SelectItem<?>>
 
         validateOptional(plainSelect.getPivot(), p -> p.accept(this, context));
 
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(PivotQuery pivotQuery, S context) {
+        if (isNotEmpty(pivotQuery.getWithItemsList())) {
+            pivotQuery.getWithItemsList()
+                    .forEach(withItem -> withItem.accept((SelectVisitor<Void>) this, context));
+        }
+
+        validateFeature(Feature.pivot);
+        validateOptionalFromItem(pivotQuery.getFromItem());
+        validateOptionalExpressions(pivotQuery.getOnExpressions());
+        if (isNotEmpty(pivotQuery.getUsingItems())) {
+            pivotQuery.getUsingItems().forEach(item -> item.accept(this, context));
+        }
+        validateOptionalExpressions(pivotQuery.getGroupByExpressions());
+        validateOptionalOrderByElements(pivotQuery.getOrderByElements());
+        validateOptionalInterpolate(pivotQuery.getInterpolate());
+        validateOptionalOption(pivotQuery.getOption());
+
+        if (pivotQuery.getLimit() != null) {
+            getValidator(LimitValidator.class).validate(pivotQuery.getLimit());
+        }
+        if (pivotQuery.getOffset() != null) {
+            validateOffset(pivotQuery.getOffset());
+        }
+        if (pivotQuery.getFetch() != null) {
+            validateFetch(pivotQuery.getFetch());
+        }
         return null;
     }
 
@@ -418,6 +449,10 @@ public class SelectValidator extends AbstractValidator<SelectItem<?>>
 
     public void visit(PlainSelect plainSelect) {
         visit(plainSelect, null);
+    }
+
+    public void visit(PivotQuery pivotQuery) {
+        visit(pivotQuery, null);
     }
 
     public void visit(SelectItem<?> selectExpressionItem) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -106,6 +106,10 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
     // then-branch closes the ternary and must not be taken as the JSON path operator
     private int ternaryThenBranchDepth = 0;
 
+    // depth of DuckDB MAP keys: the following ":" separates a key from its value
+    // and must not be taken as the JSON path operator
+    private int mapKeyDepth = 0;
+
     private void linkAST(ASTNodeAccess access, Node node) {
         access.setASTNode(node);
         node.jjtSetValue(access);
@@ -536,10 +540,10 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
         try {
             if (getToken(1).kind != OPENING_BRACKET) return false;
             int k2 = getToken(2).kind;
-            // Direct subquery: ( SELECT/WITH ) → ParenthesedSelect handles it
+            // Direct subquery: ( SELECT/WITH/PIVOT ) → ParenthesedSelect handles it
             // ( VALUES ) can be ParenthesedFromItem(Values) or ParenthesedSelect;
             // ParenthesedFromItem is checked first so Values-as-FROM-item works
-            if (k2 == K_SELECT || k2 == K_WITH) return false;
+            if (k2 == K_SELECT || k2 == K_WITH || k2 == K_PIVOT) return false;
             // ( ( SELECT ) UNION ( SELECT ) ) → isNestedSetOperationAhead handles it
             // Other (( patterns: ( (SELECT...) JOIN ... ) or ( (table) ) → ParenthesedFromItem
             if (k2 == K_LATERAL) return false; // handled by LateralSubSelect
@@ -4810,6 +4814,8 @@ Select Select() #Select:
         |
         (
             (
+                LOOKAHEAD(2) select = PivotQuery()
+                |
                 LOOKAHEAD(3) select = PlainSelect()
                 |
                 LOOKAHEAD(3) select = Values()
@@ -6101,8 +6107,37 @@ List<SelectItem<Function>> PivotFunctionItems():
 }
 {
     item = FunctionItem() {functionItems.add(item);}
-    ( "," item = FunctionItem() {functionItems.add(item);} )*
+    ( LOOKAHEAD(2) "," item = FunctionItem() {functionItems.add(item);} )*
     { return functionItems; }
+}
+
+PivotQuery PivotQuery():
+{
+    PivotQuery pivotQuery = new PivotQuery();
+    FromItem fromItem;
+    ExpressionList<Expression> onExpressions = null;
+    List<SelectItem<Function>> usingItems = null;
+    ExpressionList<Expression> groupByExpressions = null;
+}
+{
+    <K_PIVOT> fromItem = FromItem()
+    (
+        <K_ON> onExpressions = ExpressionList()
+        [ LOOKAHEAD(2) <K_USING> usingItems = PivotFunctionItems() ]
+        [ LOOKAHEAD(2) <K_GROUP> <K_BY> groupByExpressions = ExpressionList() ]
+        |
+        <K_USING> usingItems = PivotFunctionItems()
+        [ LOOKAHEAD(2) <K_GROUP> <K_BY> groupByExpressions = ExpressionList() ]
+        |
+        <K_GROUP> <K_BY> groupByExpressions = ExpressionList()
+    )
+    {
+        pivotQuery.setFromItem(fromItem);
+        pivotQuery.setOnExpressions(onExpressions);
+        pivotQuery.setUsingItems(usingItems);
+        pivotQuery.setGroupByExpressions(groupByExpressions);
+        return pivotQuery;
+    }
 }
 
 SelectItem<ExpressionList<?>> ExpressionListItem():
@@ -8203,6 +8238,10 @@ Expression PrimaryExpression() #PrimaryExpression:
 
         | LOOKAHEAD(2, {!interrupted}) retval=CharacterPrimary()
 
+        | LOOKAHEAD({ !interrupted && getToken(1).kind == DATA_TYPE
+                && "MAP".equalsIgnoreCase(getToken(1).image)
+                && getToken(2).kind == OPENING_CURLY_BRACKET }) retval=MapExpression()
+
         | LOOKAHEAD({!interrupted && isImplicitCastAhead()}) retval=ImplicitCast()
 
         | retval = JdbcParameter()
@@ -8352,7 +8391,8 @@ Expression PrimaryExpression() #PrimaryExpression:
 
     // Check for JSON operands
     [
-        LOOKAHEAD(2, { ternaryThenBranchDepth == 0 || !":".equals(getToken(1).image) }) (
+        LOOKAHEAD(2, { (ternaryThenBranchDepth == 0 && mapKeyDepth == 0)
+                || !":".equals(getToken(1).image) }) (
             LOOKAHEAD(2) (
                 token="->"
                 |
@@ -8576,6 +8616,43 @@ ArrayConstructor ArrayConstructor(boolean arrayKeyword) : {
     { return array; }
 }
 
+MapExpression MapExpression() #MapExpression:
+{
+    MapExpression mapExpression = new MapExpression();
+    Expression key;
+    Expression value;
+}
+{
+    <DATA_TYPE> <OPENING_CURLY_BRACKET>
+    [
+        key = MapKeyExpression() <DOUBLE_COLON> value = Expression()
+        { mapExpression.addEntry(key, value); }
+        (
+            "," key = MapKeyExpression() <DOUBLE_COLON> value = Expression()
+            { mapExpression.addEntry(key, value); }
+        )*
+    ]
+    <CLOSING_CURLY_BRACKET>
+    {
+        linkAST(mapExpression, jjtThis);
+        return mapExpression;
+    }
+}
+
+Expression MapKeyExpression():
+{
+    Expression key;
+}
+{
+    try {
+        { mapKeyDepth++; }
+        key = Expression()
+    } finally {
+        mapKeyDepth--;
+    }
+    { return key; }
+}
+
 List<Map.Entry<String, ColDataType>> StructParameters():
 {
     String parameterName = "";
@@ -8682,7 +8759,8 @@ JsonExpression JsonExpression(Expression expr, List<Map.Entry<Expression, String
         }
 
         (
-            LOOKAHEAD(2, { ternaryThenBranchDepth == 0 || !":".equals(getToken(1).image) }) (
+            LOOKAHEAD(2, { (ternaryThenBranchDepth == 0 && mapKeyDepth == 0)
+                    || !":".equals(getToken(1).image) }) (
                 token="->"
                 |
                 token=":"

--- a/src/test/java/net/sf/jsqlparser/statement/select/DuckDBCompatibilityTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/DuckDBCompatibilityTest.java
@@ -1,0 +1,70 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.select;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.MapExpression;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.create.view.CreateView;
+import net.sf.jsqlparser.test.TestUtils;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+import org.junit.jupiter.api.Test;
+
+class DuckDBCompatibilityTest {
+
+    @Test
+    void testMapLiteral() throws JSQLParserException {
+        String sql = "SELECT MAP {'key': 'value', 'key2': 'other'} AS m FROM t";
+
+        Select select = (Select) TestUtils.assertSqlCanBeParsedAndDeparsed(sql, true);
+        MapExpression mapExpression = assertInstanceOf(MapExpression.class,
+                select.getPlainSelect().getSelectItem(0).getExpression());
+
+        assertThat(mapExpression.getEntries()).hasSize(2);
+        assertThat(TablesNamesFinder.findTables(sql)).containsExactly("t");
+    }
+
+    @Test
+    void testCreateViewWithMapLiteral() throws JSQLParserException {
+        String sql = "CREATE VIEW v AS SELECT "
+                + "MAP {'category': name, 'count': name} AS summary FROM products";
+
+        CreateView createView =
+                (CreateView) TestUtils.assertSqlCanBeParsedAndDeparsed(sql, true);
+        MapExpression mapExpression = assertInstanceOf(MapExpression.class,
+                createView.getSelect().getPlainSelect().getSelectItem(0).getExpression());
+
+        assertThat(mapExpression.getEntries()).hasSize(2);
+        assertThat(TablesNamesFinder.findTables(sql)).contains("products");
+    }
+
+    @Test
+    void testPivotStatement() throws JSQLParserException {
+        String sql = "PIVOT sales ON region USING SUM(amount)";
+
+        Statement statement = TestUtils.assertSqlCanBeParsedAndDeparsed(sql, true);
+
+        assertInstanceOf(PivotQuery.class, statement);
+    }
+
+    @Test
+    void testPivotInSubquery() throws JSQLParserException {
+        String sql = "SELECT * FROM (PIVOT sales ON region USING SUM(amount))";
+
+        Select select = (Select) TestUtils.assertSqlCanBeParsedAndDeparsed(sql, true);
+        ParenthesedSelect parenthesedSelect =
+                assertInstanceOf(ParenthesedSelect.class, select.getPlainSelect().getFromItem());
+
+        assertInstanceOf(PivotQuery.class, parenthesedSelect.getSelect());
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/statement/select/PivotQueryTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/PivotQueryTest.java
@@ -1,0 +1,94 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.select;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.create.view.CreateView;
+import net.sf.jsqlparser.test.TestUtils;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+import org.junit.jupiter.api.Test;
+
+class PivotQueryTest {
+
+    @Test
+    void testDuckDBPivotStatement() throws JSQLParserException {
+        String sql = "PIVOT sales ON region USING SUM(amount)";
+
+        Statement statement = TestUtils.assertSqlCanBeParsedAndDeparsed(sql, true);
+        PivotQuery pivotQuery = assertInstanceOf(PivotQuery.class, statement);
+        Table table = assertInstanceOf(Table.class, pivotQuery.getFromItem());
+
+        assertThat(table.getFullyQualifiedName()).isEqualTo("sales");
+        assertThat(pivotQuery.getOnExpressions()).hasSize(1);
+        assertThat(pivotQuery.getUsingItems()).hasSize(1);
+        assertThat(TablesNamesFinder.findTables(sql)).containsExactly("sales");
+    }
+
+    @Test
+    void testDuckDBPivotInSubquery() throws JSQLParserException {
+        String sql = "SELECT * FROM (PIVOT sales ON region USING SUM(amount))";
+
+        Select select = (Select) TestUtils.assertSqlCanBeParsedAndDeparsed(sql, true);
+        ParenthesedSelect parenthesedSelect =
+                assertInstanceOf(ParenthesedSelect.class, select.getPlainSelect().getFromItem());
+
+        assertInstanceOf(PivotQuery.class, parenthesedSelect.getSelect());
+        assertThat(TablesNamesFinder.findTables(sql)).containsExactly("sales");
+    }
+
+    @Test
+    void testDuckDBPivotFullSimplifiedSyntax() throws JSQLParserException {
+        String sql = "PIVOT sales ON region, category "
+                + "USING SUM(amount) AS total, COUNT(*) AS count "
+                + "GROUP BY year ORDER BY year DESC LIMIT 10";
+
+        PivotQuery pivotQuery = (PivotQuery) TestUtils.assertSqlCanBeParsedAndDeparsed(sql, true);
+
+        assertThat(pivotQuery.getOnExpressions()).hasSize(2);
+        assertThat(pivotQuery.getUsingItems()).hasSize(2);
+        assertThat(pivotQuery.getGroupByExpressions()).hasSize(1);
+        assertThat(pivotQuery.getOrderByElements()).hasSize(1);
+        assertNotNull(pivotQuery.getLimit());
+    }
+
+    @Test
+    void testDuckDBPivotOptionalClauses() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed("PIVOT sales ON region", true);
+        TestUtils.assertSqlCanBeParsedAndDeparsed("PIVOT sales USING SUM(amount)", true);
+        TestUtils.assertSqlCanBeParsedAndDeparsed("PIVOT sales GROUP BY region", true);
+    }
+
+    @Test
+    void testDuckDBPivotInCreateView() throws JSQLParserException {
+        String sql = "CREATE VIEW v AS PIVOT sales ON region USING SUM(amount)";
+
+        CreateView createView =
+                (CreateView) TestUtils.assertSqlCanBeParsedAndDeparsed(sql, true);
+
+        assertInstanceOf(PivotQuery.class, createView.getSelect());
+    }
+
+    @Test
+    void testExistingPivotClauseStillWorks() throws JSQLParserException {
+        String sql = "SELECT * FROM sales "
+                + "PIVOT (SUM(amount) FOR region IN ('US', 'EU'))";
+
+        Select select = (Select) TestUtils.assertSqlCanBeParsedAndDeparsed(sql, true);
+        Table table = assertInstanceOf(Table.class, select.getPlainSelect().getFromItem());
+
+        assertNotNull(table.getPivot());
+    }
+}


### PR DESCRIPTION
Support and closes [https://github.com/JSQLParser/JSqlParser/issues/2423](https://github.com/JSQLParser/JSqlParser/issues/2423)


## Summary

Adds support for DuckDB MAP literals and simplified PIVOT queries.

Supported examples:

```sql
SELECT MAP {'key': 'value', 'key2': 'other'} AS m FROM t;

CREATE VIEW v AS
SELECT MAP {'category': name, 'count': name} AS summary
FROM products;

PIVOT sales ON region USING SUM(amount);

SELECT * FROM (PIVOT sales ON region USING SUM(amount));
```

## Changes

- Added `MapExpression` for DuckDB `MAP {key: value}` literals.
- Added `PivotQuery` for DuckDB simplified PIVOT syntax.
- Integrated both nodes with visitors, deparsers, validators, and `TablesNamesFinder`.
- Added support for PIVOT as a top-level query and subquery.
- Preserved the existing Oracle/SQL Server-style `PIVOT (...)` syntax.

## Tests

Added tests covering all four reported DuckDB cases, additional PIVOT clauses, table-name extraction, and existing PIVOT compatibility.

Relevant parser and regression tests pass without introducing new JavaCC warnings.

