### PR TITLE
fix(parser): support CHARACTER SET in CAST CHAR types

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -11410,12 +11410,14 @@ ColDataType DataType():
             ( tk=<K_DATETIMELITERAL> | tk=<DT_ZONE> | tk = <DATA_TYPE>  | tk = <K_SIGNED>  | tk = <K_UNSIGNED>
                 | tk=<K_CHARACTER>  |  tk=<K_BIT> | tk=<K_BYTES> | tk=<K_BINARY> | tk=<K_BOOLEAN>
                 | tk=<K_CHAR> | tk=<K_JSON> | tk=<K_STRING> ) { type = tk.image; }
-            [
-                // MySQL seems to allow: INT UNSIGNED
-                LOOKAHEAD(2) ( LOOKAHEAD(2) ( tk = <DATA_TYPE>  | tk = <K_SIGNED>  | tk = <K_UNSIGNED>
-                                   | tk=<K_CHARACTER>  | tk=<K_BIT> | tk=<K_BYTES> | tk=<K_BINARY> | tk=<K_BOOLEAN>
-                                   | tk=<K_CHAR> | tk=<K_JSON>  | tk=<K_STRING> ) { type += " " + tk.image; } )+
-            ]
+            (
+                // MySQL seems to allow: INT UNSIGNED. Do not consume CHARACTER when it starts
+                // the trailing CHARACTER SET clause of a character type.
+                LOOKAHEAD(2, { getToken(1).kind != K_CHARACTER || getToken(2).kind != K_SET })
+                ( tk = <DATA_TYPE>  | tk = <K_SIGNED>  | tk = <K_UNSIGNED>
+                    | tk=<K_CHARACTER>  | tk=<K_BIT> | tk=<K_BYTES> | tk=<K_BINARY> | tk=<K_BOOLEAN>
+                    | tk=<K_CHAR> | tk=<K_JSON>  | tk=<K_STRING> ) { type += " " + tk.image; }
+            )*
             [
                 LOOKAHEAD(2) "(" ( tk=<S_LONG> { precision = Integer.valueOf(tk.image); } |  tk=<K_MAX> { precision = Integer.MAX_VALUE; } )
                 [ <K_BYTE> | <K_CHAR> ]

--- a/src/test/java/net/sf/jsqlparser/expression/CastExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/CastExpressionTest.java
@@ -68,6 +68,21 @@ public class CastExpressionTest {
         Assertions.assertTrue(select.getSelectItem(0).getExpression() instanceof CastExpression);
     }
 
+    @Test
+    void testCastCharWithCharacterSet() throws JSQLParserException {
+        String sqlStr = "SELECT CAST('abc' AS CHAR CHARACTER SET utf8mb4)";
+        PlainSelect select = (PlainSelect) assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        CastExpression castExpression = Assertions.assertInstanceOf(CastExpression.class,
+                select.getSelectItem(0).getExpression());
+
+        Assertions.assertEquals("CHAR", castExpression.getColDataType().getDataType());
+        Assertions.assertEquals("utf8mb4", castExpression.getColDataType().getCharacterSet());
+
+        assertSqlCanBeParsedAndDeparsed(
+                "SELECT CAST('abc' AS CHAR(10) CHARACTER SET utf8mb4)", true);
+        assertSqlCanBeParsedAndDeparsed("SELECT CAST('abc' AS CHARACTER VARYING)", true);
+    }
+
 
     @Test
     public void testCastToSigned() throws JSQLParserException {


### PR DESCRIPTION
Fixes [https://github.com/JSQLParser/JSqlParser/issues/2298](https://github.com/JSQLParser/JSqlParser/issues/2298)