### PR TITLE
fix(parser): support Oracle USING INDEX TABLESPACE in ALTER TABLE ADD CONSTRAINT

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -11717,7 +11717,7 @@ ForeignKeyIndex ForeignKeySpec(String constraintName):
 }
 
 /**
- * Parses USING [INDEX] name clause in ALTER TABLE constraint tails.
+ * Parses USING [INDEX] [name] [TABLESPACE name] clause in ALTER TABLE constraint tails.
  */
 void AlterExpressionUsingIndex(AlterExpression alterExp):
 {
@@ -11726,7 +11726,14 @@ void AlterExpressionUsingIndex(AlterExpression alterExp):
 {
     <K_USING> { alterExp.addParameters("USING"); }
     [ LOOKAHEAD(2) <K_INDEX> { alterExp.addParameters("INDEX"); } ]
-    sk4=RelObjectName() { alterExp.addParameters(sk4); }
+    (
+        LOOKAHEAD(2, <K_TABLESPACE>) <K_TABLESPACE> sk4=RelObjectName()
+        { alterExp.addParameters("TABLESPACE"); alterExp.addParameters(sk4); }
+        |
+        sk4=RelObjectName() { alterExp.addParameters(sk4); }
+        [ LOOKAHEAD(2) <K_TABLESPACE> sk4=RelObjectName()
+          { alterExp.addParameters("TABLESPACE"); alterExp.addParameters(sk4); } ]
+    )
 }
 
 /**

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -2364,4 +2364,46 @@ public class AlterTest {
 
         assertSqlCanBeParsedAndDeparsed(sql);
     }
+
+    @Test
+    public void testAlterTableAddConstraintPrimaryKeyUsingIndexTablespace()
+            throws JSQLParserException {
+        String sql =
+                "ALTER TABLE bfmcs.your_table ADD CONSTRAINT your_table_pk PRIMARY KEY (ID) USING INDEX TABLESPACE your_tablespace";
+        Statement stmt = CCJSqlParserUtil.parse(sql);
+        assertInstanceOf(Alter.class, stmt);
+
+        Alter alter = (Alter) stmt;
+        List<AlterExpression> alterExpressions = alter.getAlterExpressions();
+        assertNotNull(alterExpressions);
+        assertEquals(1, alterExpressions.size());
+
+        AlterExpression alterExp = alterExpressions.get(0);
+        assertEquals(AlterOperation.ADD, alterExp.getOperation());
+        assertEquals(Arrays.asList("USING", "INDEX", "TABLESPACE", "your_tablespace"),
+                alterExp.getParameters());
+
+        assertSqlCanBeParsedAndDeparsed(sql);
+    }
+
+    @Test
+    public void testAlterTableAddConstraintPrimaryKeyUsingIndexNameAndTablespace()
+            throws JSQLParserException {
+        String sql =
+                "ALTER TABLE your_table ADD CONSTRAINT pk_test PRIMARY KEY (ID) USING INDEX idx_test TABLESPACE ts_test";
+        Statement stmt = CCJSqlParserUtil.parse(sql);
+        assertInstanceOf(Alter.class, stmt);
+
+        Alter alter = (Alter) stmt;
+        List<AlterExpression> alterExpressions = alter.getAlterExpressions();
+        assertNotNull(alterExpressions);
+        assertEquals(1, alterExpressions.size());
+
+        AlterExpression alterExp = alterExpressions.get(0);
+        assertEquals(AlterOperation.ADD, alterExp.getOperation());
+        assertEquals(Arrays.asList("USING", "INDEX", "idx_test", "TABLESPACE", "ts_test"),
+                alterExp.getParameters());
+
+        assertSqlCanBeParsedAndDeparsed(sql);
+    }
 }


### PR DESCRIPTION
Fixes [https://github.com/JSQLParser/JSqlParser/issues/2039](https://github.com/JSQLParser/JSqlParser/issues/2039)