### PR TITLE
fix: support MySQL # line comments (#2499)

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1845,7 +1845,11 @@ TOKEN : /* Numeric Constants */
 
 SPECIAL_TOKEN:
 {
-   < LINE_COMMENT: ("--" | "//") (~["\r","\n"])*>
+   // The `#` comment requires a following blank: `#` without one stays an
+   // identifier start (SQL Server `#temp`, `##global`) and `#>` / `#>>`
+   // JSON operators must keep their usual lexing (issue #1197, #1695).
+   < LINE_COMMENT: ("--" | "//") (~["\r","\n"])*
+       | "#" [" ", "\t"] (~["\r","\n"])*>
 }
 
 // Nested block comments:  /* ... /* ... */ ... */

--- a/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
@@ -222,6 +222,40 @@ public class CCJSqlParserUtilTest {
     }
 
     @Test
+    public void testLineCommentHashTrailing() throws Exception {
+        assertEquals("SELECT 1", CCJSqlParserUtil.parse("SELECT 1 # trailing comment").toString());
+    }
+
+    @Test
+    public void testLineCommentHashLeading() throws Exception {
+        assertEquals("SELECT 1", CCJSqlParserUtil.parse("# leading comment\nSELECT 1").toString());
+    }
+
+    @Test
+    public void testLineCommentHashWithinSelect() throws Exception {
+        assertEquals("SELECT 1 + 2, 3",
+                CCJSqlParserUtil.parse("SELECT 1 + 2 # note\n, 3").toString());
+    }
+
+    @Test
+    public void testHashWithoutBlankStaysIdentifier() throws Exception {
+        // without a following blank `#` is an identifier start, not a comment (#1197, #1695)
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM #temp");
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM ##global");
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM #$tab1#");
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM $#tab1#");
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM #$tab#tab1");
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT a#b FROM t");
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT 1 #note");
+    }
+
+    @Test
+    public void testHashJsonOperatorsStayOperators() throws Exception {
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT js #> '{a}' FROM t");
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT js #>> '{a,b}' FROM t");
+    }
+
+    @Test
     public void testParseStatementsFail() throws Exception {
         String sqlStr = "select * from dual;WHATEVER!!";
 


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What

Support MySQL `#` line comments, fixing #2499:

```sql
SELECT 1 + 2 # note
, 3
# leading comment
SELECT 1
```

Both forms currently fail with a `ParseException`: `#` lexes as an identifier and the comment text then fails as keywords (`SELECT 1 # comment` fails on `comment`).

## Why / Root cause

`LINE_COMMENT` only knows `--` and `//`. A `#` falls through to the identifier token (`#` is a legal identifier start and part character), so the comment text itself has to parse and does not.

## How

One additional alternation in the `LINE_COMMENT` token: a `#` followed by a blank runs to end of line. The blank gate keeps every existing `#` lexing intact:

- `#temp`, `##global`, `#$tab1#`, `a#b` stay identifiers (#1197, #1695)
- `#>` / `#>>` JSON operators are untouched (`>` is not a blank; `-#` and `<#>` never start at the `#`)

## Scope

- `SELECT 1 #comment` (no blank) still lexes as an identifier (alias), as before: treating it as a comment would collide with `#temp` style identifiers.
- A bare `#` column followed by a blank (`SELECT # FROM t`) now starts a comment instead of parsing; no dialect defines such an unquoted column name.
- `SELECT 5 # 3` (PostgreSQL bitwise XOR, never supported) now parses as `SELECT 5` plus comment, the same way `SELECT 1 -- 2` already behaves.

## Testing

`CCJSqlParserUtilTest`: 5 new tests. The 3 comment form tests were verified failing on master; the 2 guard tests pin the identifier and JSON operator families (they fail when the blank gate is removed). Full suite green.

## Performance

`gradle jmh`, `JSQLParserBenchmark.parseSQLStatements` on `performance.sql`, `version=latest`, 10 forks × 10 iterations (100 samples) on a 32-core host:

| build | ms/op |
| --- | --- |
| master `1e4e92b` | 3.755 ± 0.024 |
| branch `eaf9884` | 3.789 ± 0.029 |

Δ +0.9% with overlapping 99.9% CIs → no regression.
