### PR TITLE
fix(parser): support MySQL index options and prefix-length key parts in index DDL

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -10980,6 +10980,7 @@ List<Index.ColumnParams> ColumnNamesWithParamsList() : {
 Index.ColumnParams IndexColumnWithParams(): {
     String columnName = null;
     List<String> parameter = null;
+    List<String> param = null;
     Expression expression = null;
     Index.ColumnParams column = null;
 }
@@ -10987,14 +10988,30 @@ Index.ColumnParams IndexColumnWithParams(): {
     (
         columnName=RelObjectName()
         { parameter = null; }
-        [ parameter = CreateParameter() ]
+        // MySQL allows a key part to carry a prefix length and a direction, e.g. "c1(20) DESC",
+        // so more than one parameter has to be collected here.
+        ( LOOKAHEAD(2) param = CreateParameter()
+            {
+                if (parameter == null) {
+                    parameter = new ArrayList<String>();
+                }
+                parameter.addAll(param);
+            }
+        )*
         {
             column = new Index.ColumnParams(columnName, parameter);
         }
         |
         "(" expression=Expression() ")"
         { parameter = null; }
-        [ LOOKAHEAD(2) parameter = CreateParameter() ]
+        ( LOOKAHEAD(2) param = CreateParameter()
+            {
+                if (parameter == null) {
+                    parameter = new ArrayList<String>();
+                }
+                parameter.addAll(param);
+            }
+        )*
         {
             column = new Index.ColumnParams(expression, parameter);
         }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -10979,41 +10979,30 @@ List<Index.ColumnParams> ColumnNamesWithParamsList() : {
 
 Index.ColumnParams IndexColumnWithParams(): {
     String columnName = null;
+    // the options collected for this key part, and the result of a single CreateParameter()
+    List<String> columnParams = new ArrayList<String>();
     List<String> parameter = null;
-    List<String> param = null;
     Expression expression = null;
     Index.ColumnParams column = null;
 }
 {
     (
         columnName=RelObjectName()
-        { parameter = null; }
         // MySQL allows a key part to carry a prefix length and a direction, e.g. "c1(20) DESC",
         // so more than one parameter has to be collected here.
-        ( LOOKAHEAD(2) param = CreateParameter()
-            {
-                if (parameter == null) {
-                    parameter = new ArrayList<String>();
-                }
-                parameter.addAll(param);
-            }
-        )*
+        ( LOOKAHEAD(2) parameter = CreateParameter() { columnParams.addAll(parameter); } )*
         {
-            column = new Index.ColumnParams(columnName, parameter);
+            // ColumnParams renders a separating space for a non-null list, so a key part
+            // without options has to be given null rather than an empty list.
+            column = new Index.ColumnParams(columnName,
+                    columnParams.isEmpty() ? null : columnParams);
         }
         |
         "(" expression=Expression() ")"
-        { parameter = null; }
-        ( LOOKAHEAD(2) param = CreateParameter()
-            {
-                if (parameter == null) {
-                    parameter = new ArrayList<String>();
-                }
-                parameter.addAll(param);
-            }
-        )*
+        ( LOOKAHEAD(2) parameter = CreateParameter() { columnParams.addAll(parameter); } )*
         {
-            column = new Index.ColumnParams(expression, parameter);
+            column = new Index.ColumnParams(expression,
+                    columnParams.isEmpty() ? null : columnParams);
         }
     )
     {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -11863,6 +11863,11 @@ List<String> CreateParameter():
             | tk=<K_TIME_KEY_EXPR> | tk=<K_RAW> | tk=<K_HASH> | tk=<K_FIRST> | tk=<K_LAST> | tk = <K_SIGNED>  | tk = <K_UNSIGNED>
             | tk=<K_ENGINE> | tk=<K_IDENTITY> | tk=<K_MATERIALIZED> | tk=<K_SAMPLE> | tk=<K_ALWAYS>
             | tk=<K_VISIBLE> | tk=<K_INVISIBLE>
+            // MySQL index_option / algorithm_option / lock_option keywords, e.g. the trailing
+            // "KEY_BLOCK_SIZE = 8 ALGORITHM = INPLACE LOCK = NONE" of CREATE INDEX, the
+            // "WITH PARSER" option, and the FULLTEXT / SPATIAL index types of CREATE INDEX.
+            | tk=<K_KEY_BLOCK_SIZE> | tk=<K_ALGORITHM> | tk=<K_LOCK> | tk=<K_NONE>
+            | tk=<K_PARSER> | tk=<K_FULLTEXT> | tk=<K_SPATIAL>
             | tk="="
         )
         { param.add(tk.image); }
@@ -12038,11 +12043,19 @@ Drop Drop():
     (
         (
             tk=<S_IDENTIFIER> | tk=<K_CASCADE> | tk=<K_RESTRICT>
+            // MySQL DROP INDEX accepts a trailing algorithm_option / lock_option,
+            // e.g. "DROP INDEX i ON t ALGORITHM = INPLACE LOCK = NONE".
+            | tk=<K_ALGORITHM> | tk=<K_NONE> | tk="="
         ) { dropArgs.add(tk.image); }
         |
         (
             <K_ON> name = Table() { dropArgs.add("ON"); dropArgs.add(name.toString()); }
         )
+        |
+        // The lock_option of DROP INDEX. LOCK also starts a LOCK TABLE statement, so it is only
+        // taken as a DROP argument when it cannot be the beginning of the next statement.
+        LOOKAHEAD({ getToken(1).kind == K_LOCK && getToken(2).kind != K_TABLE })
+        tk=<K_LOCK> { dropArgs.add(tk.image); }
     )*
     {
         if (dropArgs.size() > 0) {

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -2406,4 +2406,12 @@ public class AlterTest {
 
         assertSqlCanBeParsedAndDeparsed(sql);
     }
+
+    @Test
+    public void testAlterTableAddIndexKeyPartWithPrefixLengthAndDirectionIssue2490()
+            throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE t ADD INDEX i05 (c1 (20) DESC)");
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE t ADD INDEX i33 (c1 (20) ASC)");
+        assertSqlCanBeParsedAndDeparsed("ALTER TABLE t ADD UNIQUE INDEX i34 (c1 (10) DESC)");
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
@@ -196,4 +196,42 @@ public class CreateIndexTest {
         assertSqlCanBeParsedAndDeparsed("CREATE INDEX i04 ON t (c1 (20) ASC, c2 (10) DESC)");
         assertSqlCanBeParsedAndDeparsed("CREATE UNIQUE INDEX i25 ON t (c1 (10) DESC)");
     }
+
+    @Test
+    public void testCreateIndexKeyBlockSizeIssue2490() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("CREATE INDEX i08 ON t (c1) KEY_BLOCK_SIZE = 8");
+        assertSqlCanBeParsedAndDeparsed("CREATE INDEX i09 ON t (c1) KEY_BLOCK_SIZE 8");
+        assertSqlCanBeParsedAndDeparsed(
+                "CREATE INDEX i14 ON t (c1) USING BTREE KEY_BLOCK_SIZE = 8 COMMENT 'combo' INVISIBLE");
+    }
+
+    @Test
+    public void testCreateIndexAlgorithmAndLockOptionsIssue2490() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "CREATE INDEX i10 ON t (c1) ALGORITHM = INPLACE LOCK = NONE");
+        assertSqlCanBeParsedAndDeparsed("CREATE INDEX i11 ON t (c1) ALGORITHM INPLACE LOCK NONE");
+        assertSqlCanBeParsedAndDeparsed("CREATE INDEX i12 ON t (c1) ALGORITHM = INPLACE");
+        assertSqlCanBeParsedAndDeparsed("CREATE INDEX i13 ON t (c1) LOCK = NONE");
+
+        CreateIndex createIndex = (CreateIndex) parserManager
+                .parse(new StringReader("CREATE INDEX i10 ON t (c1) ALGORITHM=INPLACE LOCK=NONE"));
+        assertEquals(List.of("ALGORITHM", "=", "INPLACE", "LOCK", "=", "NONE"),
+                createIndex.getTailParameters());
+    }
+
+    @Test
+    public void testCreateFullTextAndSpatialIndexIssue2490() throws JSQLParserException {
+        // These used to fall back to UnsupportedStatement instead of producing a CreateIndex.
+        CreateIndex fullText = (CreateIndex) parserManager
+                .parse(new StringReader("CREATE FULLTEXT INDEX i17 ON t (body)"));
+        assertEquals("FULLTEXT", fullText.getIndex().getType());
+
+        CreateIndex spatial = (CreateIndex) parserManager
+                .parse(new StringReader("CREATE SPATIAL INDEX i19 ON t (g)"));
+        assertEquals("SPATIAL", spatial.getIndex().getType());
+
+        assertSqlCanBeParsedAndDeparsed("CREATE FULLTEXT INDEX i17 ON t (body)");
+        assertSqlCanBeParsedAndDeparsed("CREATE FULLTEXT INDEX i18 ON t (body) WITH PARSER ngram");
+        assertSqlCanBeParsedAndDeparsed("CREATE SPATIAL INDEX i19 ON t (g)");
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
@@ -179,4 +179,21 @@ public class CreateIndexTest {
     public void testCreateIndexIncludeIssue2459() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed("CREATE INDEX idx_a ON t1 (a) INCLUDE (b, c)");
     }
+
+    @Test
+    public void testCreateIndexKeyPartWithPrefixLengthAndDirectionIssue2490()
+            throws JSQLParserException {
+        // MySQL writes the prefix length without a space, JSqlParser deparses it with one.
+        String statement = "CREATE INDEX i03 ON t (c1(20) DESC)";
+        CreateIndex createIndex = (CreateIndex) parserManager.parse(new StringReader(statement));
+
+        List<String> params = createIndex.getIndex().getColumns().get(0).getParams();
+        assertEquals(2, params.size());
+        assertEquals("(20)", params.get(0));
+        assertEquals("DESC", params.get(1));
+
+        assertSqlCanBeParsedAndDeparsed("CREATE INDEX i03 ON t (c1 (20) DESC)");
+        assertSqlCanBeParsedAndDeparsed("CREATE INDEX i04 ON t (c1 (20) ASC, c2 (10) DESC)");
+        assertSqlCanBeParsedAndDeparsed("CREATE UNIQUE INDEX i25 ON t (c1 (10) DESC)");
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/drop/DropTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/drop/DropTest.java
@@ -12,8 +12,10 @@ package net.sf.jsqlparser.statement.drop;
 import java.io.StringReader;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.Statements;
 import static net.sf.jsqlparser.test.TestUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
@@ -151,5 +153,20 @@ public class DropTest {
     void dropTemporaryTableTestIssue1712() throws JSQLParserException {
         String sqlStr = "drop temporary table if exists tmp_MwYT8N0z";
         assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+    }
+
+    @Test
+    public void testDropIndexAlgorithmAndLockOptionsIssue2490() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed("DROP INDEX i15 ON t ALGORITHM = INPLACE LOCK = NONE");
+        assertSqlCanBeParsedAndDeparsed("DROP INDEX i16 ON t ALGORITHM INPLACE");
+        assertSqlCanBeParsedAndDeparsed("DROP INDEX i17 ON t LOCK = NONE");
+    }
+
+    @Test
+    public void testDropTableFollowedByLockTableIssue2490() throws JSQLParserException {
+        // LOCK must not be swallowed as a DROP argument when it starts the next statement.
+        Statements statements = CCJSqlParserUtil.parseStatements(
+                "DROP TABLE t1; LOCK TABLE t2 IN SHARE MODE;");
+        assertEquals(2, statements.size());
     }
 }


### PR DESCRIPTION
Refs #2490

## Description

Fixes five of the six groups of MySQL index DDL reported in #2490. These now parse:

```sql
-- 1. key part with a prefix length *and* a direction (CREATE and ALTER)
CREATE INDEX i03 ON t (c1(20) DESC);
ALTER TABLE t ADD INDEX i05 (c1(20) DESC);

-- 2/3. CREATE INDEX index_option / algorithm_option / lock_option
CREATE INDEX i08 ON t (c1) KEY_BLOCK_SIZE = 8;
CREATE INDEX i10 ON t (c1) ALGORITHM = INPLACE LOCK = NONE;

-- 4. DROP INDEX algorithm_option / lock_option
DROP INDEX i15 ON t ALGORITHM = INPLACE LOCK = NONE;

-- 5. FULLTEXT / SPATIAL (previously fell back to UnsupportedStatement)
CREATE FULLTEXT INDEX i18 ON t (body) WITH PARSER ngram;
CREATE SPATIAL INDEX i19 ON t (g);
```

Two causes:

- `IndexColumnWithParams()` allowed only **one** `CreateParameter()` per key part, so `(20)` consumed it and the trailing `ASC`/`DESC` could not be matched. It now collects parameters in a loop. `IndexColumnsWithParamsList()` is shared by the CREATE and ALTER paths, so one change fixes both.
- The option keywords (`KEY_BLOCK_SIZE`, `ALGORITHM`, `LOCK`, `NONE`, `PARSER`, `FULLTEXT`, `SPATIAL`) were simply not reachable from the option lists that `CREATE INDEX` and `DROP INDEX` use.

## No new grammar ambiguity

Those keywords all live in `NonReservedWord()`, so adding them as new alternatives to the trailing `(...)*` loops pushed JavaCC from 13 to 15 choice-conflict warnings, and explicit syntactic `LOOKAHEAD` did not help. They are instead added to the **existing flat token lists** of `CreateParameter()` and `Drop()`, which adds no new choice point and leaves the warning count unchanged.

`LOCK` is the one real ambiguity, since it also starts a `LOCK TABLE` statement. It is guarded so it is only taken as a `DROP` argument when it cannot begin the next statement:

```java
LOOKAHEAD({ getToken(1).kind == K_LOCK && getToken(2).kind != K_TABLE })
tk=<K_LOCK> { dropArgs.add(tk.image); }
```

## Scope

Group 6 (`CAST(... AS UNSIGNED ARRAY)` for multi-valued indexes) is **not** included: it needs an `ARRAY` marker on the public `ColDataType` model, and `K_ARRAY_LITERAL` is already used in six other places. Better as its own PR, so #2490 stays open.

## Testing

- `./gradlew check` passes (checkstyle, PMD, spotless, spotbugs, JaCoCo).
- **4923 tests, 0 failures, 0 errors.**
- JavaCC reports `0 errors and 13 warnings`, identical to `master` — verified by building both states and diffing the warning list.
- Seven new tests in `CreateIndexTest`, `AlterTest` and `DropTest`, including one that pins `DROP TABLE t1; LOCK TABLE t2 IN SHARE MODE;` still parsing as two statements.

Deparsing follows the existing conventions: `c1 (20) DESC` (matching the `mycol2 (75)` output already asserted in `CreateIndexTest`) and `KEY_BLOCK_SIZE = 8`. All statements above were verified against MySQL 8.4.11 while writing #2490.

## PR Checklist

- [x] I have read the contribution guidelines and the governance document on PR expectations.
- [x] Minimal changes to code not directly related to your change
- [x] One feature/change per PR unless tightly coupled
- [x] Do a rebase on upstream `master`
