### PR TITLE
fix(parser): support CAST to an array type for MySQL multi-valued indexes

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -9946,7 +9946,13 @@ CastExpression CastExpression():
             ")"
         )
         |
-        type=ColDataType() { retval.setColDataType(type); }
+        (
+            type=ColDataType() { retval.setColDataType(type); }
+            // MySQL casts to an array of the given type when a multi-valued index key part is
+            // defined, e.g. CAST(data->'$.zips' AS UNSIGNED ARRAY). ARRAY reads as a further
+            // word of the type, the way INT UNSIGNED already does.
+            [ <K_ARRAY_LITERAL> { type.setDataType(type.getDataType() + " ARRAY"); } ]
+        )
     )
 
     // BigQuery FORMAT clause

--- a/src/test/java/net/sf/jsqlparser/expression/CastExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/CastExpressionTest.java
@@ -13,6 +13,7 @@ import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
 
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.operators.relational.ParenthesedExpressionList;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.test.TestUtils;
 import org.junit.jupiter.api.Assertions;
@@ -154,5 +155,19 @@ public class CastExpressionTest {
                         infoAccess.getExpression());
         Assertions.assertEquals(1, parenthesedCast.size());
         Assertions.assertInstanceOf(CastExpression.class, parenthesedCast.get(0));
+    }
+
+    @Test
+    public void testCastToArrayIssue2490() throws JSQLParserException {
+        // MySQL casts to an array of the given type when a multi-valued index key part is
+        // defined, and accepts the same cast anywhere else an expression is allowed.
+        assertSqlCanBeParsedAndDeparsed("SELECT CAST(data -> '$.zips' AS UNSIGNED ARRAY) FROM t");
+        assertSqlCanBeParsedAndDeparsed("SELECT CAST(x AS CHAR (10) ARRAY) FROM t");
+
+        PlainSelect select = (PlainSelect) CCJSqlParserUtil
+                .parse("SELECT CAST(data -> '$.zips' AS UNSIGNED ARRAY) FROM t");
+        CastExpression cast = Assertions.assertInstanceOf(CastExpression.class,
+                select.getSelectItem(0).getExpression());
+        Assertions.assertEquals("UNSIGNED ARRAY", cast.getColDataType().getDataType());
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -2414,4 +2414,10 @@ public class AlterTest {
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE t ADD INDEX i33 (c1 (20) ASC)");
         assertSqlCanBeParsedAndDeparsed("ALTER TABLE t ADD UNIQUE INDEX i34 (c1 (10) DESC)");
     }
+
+    @Test
+    public void testAlterTableAddMultiValuedIndexIssue2490() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "ALTER TABLE t ADD INDEX i31 ((CAST(data -> '$.zips' AS UNSIGNED ARRAY)))");
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
@@ -234,4 +234,10 @@ public class CreateIndexTest {
         assertSqlCanBeParsedAndDeparsed("CREATE FULLTEXT INDEX i18 ON t (body) WITH PARSER ngram");
         assertSqlCanBeParsedAndDeparsed("CREATE SPATIAL INDEX i19 ON t (g)");
     }
+
+    @Test
+    public void testCreateMultiValuedIndexIssue2490() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "CREATE INDEX i20 ON t ((CAST(data -> '$.zips' AS UNSIGNED ARRAY)))");
+    }
 }


### PR DESCRIPTION
Refs #2490

## Description

Fixes the last open group of #2490, group 6, multi-valued (functional) indexes:

```sql
CREATE INDEX i20 ON t ((CAST(data->'$.zips' AS UNSIGNED ARRAY)));
ALTER TABLE t ADD INDEX i31 ((CAST(data->'$.zips' AS UNSIGNED ARRAY)));
```

Both failed at the `ARRAY` keyword inside the cast target type, because that keyword was not reachable from the type of a `CAST`.

## Approach

`ARRAY` is accepted as a further word of the cast target type, exactly the way `INT UNSIGNED` is already assembled by `DataType()`. The type therefore reads `UNSIGNED ARRAY`, so:

- no change to the public `ColDataType` model is needed, and
- both output paths, `CastExpression#toString()` and `ExpressionDeParser`, render it through the same `ColDataType#toString()`, so the statement round trips.

It is added to the `CastExpression()` production only, which is where MySQL permits it. The `ARRAY<type>` constructor form and the `[]` array suffix are untouched, and no other statement gains a trailing `ARRAY`.

If you would rather have this exposed as an explicit flag on `ColDataType` for programmatic access, say the word and I will change it.

## Testing

- `./gradlew check` passes: checkstyle, PMD, spotless, spotbugs, JaCoCo.
- **4927 tests, 0 failures, 0 errors.**
- JavaCC reports `0 errors and 13 warnings`, unchanged from master, verified by regenerating the parser on both states.
- Three new tests: the `CREATE INDEX` form, the `ALTER TABLE` form, and the cast itself, including `CAST(x AS CHAR(10) ARRAY)` to cover a type that carries a precision, plus an assertion that the parsed type is `UNSIGNED ARRAY`.
- Verified that `CAST(x AS UNSIGNED)` and `ARRAY<INT>[1, 2]` still parse unchanged.

All statements were verified against MySQL 8.4.11 while writing #2490.

## PR Checklist

- [x] I have read the contribution guidelines and the governance document on PR expectations.
