### PR TITLE
feat(parser): turn on the dialect's lexer feature preset in withDialect

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
+++ b/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
@@ -13,7 +13,10 @@ import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.parser.feature.FeatureConfiguration;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 public abstract class AbstractJSqlParser<P> {
 
@@ -22,7 +25,21 @@ public abstract class AbstractJSqlParser<P> {
     protected List<ParseException> parseErrors = new ArrayList<>();
 
     public enum Dialect {
-        ORACLE, EXASOL
+        ANSI_SQL, ORACLE, MYSQL(Feature.allowBackslashEscapeCharacter,
+                Feature.allowHashLineComments), MARIADB(Feature.allowBackslashEscapeCharacter,
+                        Feature.allowHashLineComments), SQLSERVER(
+                                Feature.allowSquareBracketQuotation), POSTGRESQL, H2, EXASOL;
+
+        private final Set<Feature> lexerFeatures;
+
+        Dialect(Feature... lexerFeatures) {
+            this.lexerFeatures = lexerFeatures.length == 0 ? EnumSet.noneOf(Feature.class)
+                    : EnumSet.copyOf(Arrays.asList(lexerFeatures));
+        }
+
+        public Set<Feature> getLexerFeatures() {
+            return lexerFeatures;
+        }
     }
 
     public P withSquareBracketQuotation() {
@@ -62,7 +79,11 @@ public abstract class AbstractJSqlParser<P> {
     }
 
     public P withDialect(Dialect dialect) {
-        return withFeature(Feature.dialect, dialect.name());
+        withFeature(Feature.dialect, dialect.name());
+        for (Feature lexerFeature : dialect.getLexerFeatures()) {
+            withFeature(lexerFeature, true);
+        }
+        return me();
     }
 
     public P withAllowedNestingDepth(int allowedNestingDepth) {

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -318,3 +318,15 @@ Additionally there are Features to control the Parser's effort at the cost of th
             , parser -> parser
                 .withBackslashEscapeCharacter(true)
     );
+
+Instead of turning the individual Parser Features on one by one, a ``Dialect`` preset selects the features of that database dialect: ``withDialect(Dialect.MYSQL)`` turns on ``withBackslashEscapeCharacter`` and ``withHashLineComments`` (both MySQL and MariaDB syntax), ``withDialect(Dialect.SQLSERVER)`` turns on ``withSquareBracketQuotation``. Features set explicitly after the dialect preset win over the preset.
+
+.. code-block:: java
+
+    // Select the Database Dialect: turns on that dialect's parser features
+    sqlStr="SELECT `col` FROM t WHERE a = 'x\\'yz' AND b = 42#24";
+    Statement stmt3 = CCJSqlParserUtil.parse(
+            sqlStr
+            , parser -> parser
+                .withDialect(Dialect.MYSQL)
+    );

--- a/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
@@ -564,4 +564,51 @@ public class CCJSqlParserUtilTest {
         assertEquals("SELECT 1 # comment",
                 CCJSqlParserUtil.parse("SELECT 1 # comment").toString());
     }
+
+    @Test
+    public void testDialectPresets() throws Exception {
+        // MYSQL and MARIADB: backslash escapes and # line comments (MySQL 8
+        // manual "Comments" and "String Literals", MariaDB KB "Comment Syntax"
+        // and "String Literals"); backticks are always on, brackets are not
+        // MySQL syntax
+        for (AbstractJSqlParser.Dialect dialect : new AbstractJSqlParser.Dialect[] {
+                AbstractJSqlParser.Dialect.MYSQL, AbstractJSqlParser.Dialect.MARIADB}) {
+            assertEquals("SELECT `col` FROM t WHERE a = 'x\\'yz' AND b = 42", CCJSqlParserUtil
+                    .parse("SELECT `col` FROM t WHERE a = 'x\\'yz' AND b = 42#24",
+                            p -> p.withDialect(dialect))
+                    .toString());
+        }
+        // SQLSERVER: bracket quotation only (Microsoft Learn "Database
+        // Identifiers"), `#` stays available for identifiers (temp tables)
+        assertEquals("SELECT [my column] FROM t",
+                CCJSqlParserUtil.parse("SELECT [my column] FROM t",
+                        p -> p.withDialect(AbstractJSqlParser.Dialect.SQLSERVER)).toString());
+        // empty presets keep the defaults: the #2507 operator, no backslash
+        // escapes
+        for (AbstractJSqlParser.Dialect dialect : new AbstractJSqlParser.Dialect[] {
+                AbstractJSqlParser.Dialect.ANSI_SQL, AbstractJSqlParser.Dialect.ORACLE,
+                AbstractJSqlParser.Dialect.POSTGRESQL, AbstractJSqlParser.Dialect.H2,
+                AbstractJSqlParser.Dialect.EXASOL}) {
+            assertEquals("SELECT 42 # 24",
+                    CCJSqlParserUtil.parse("SELECT 42 # 24", p -> p.withDialect(dialect))
+                            .toString());
+            assertThrows(JSQLParserException.class, () -> CCJSqlParserUtil
+                    .parse("SELECT 'a\\'b'", p -> p.withDialect(dialect)));
+        }
+    }
+
+    @Test
+    public void testDialectPresetSwitchOverrides() throws Exception {
+        // an explicit switch after the preset wins: `#` is the #2507
+        // operator again
+        assertEquals("SELECT 1 # comment", CCJSqlParserUtil.parse("SELECT 1 # comment",
+                p -> p.withDialect(AbstractJSqlParser.Dialect.MYSQL).withHashLineComments(false))
+                .toString());
+        // the preset never turns a previously enabled switch off
+        assertEquals("SELECT [my column] FROM mytable",
+                CCJSqlParserUtil.parse("SELECT [my column] FROM mytable",
+                        p -> p.withSquareBracketQuotation(true)
+                                .withDialect(AbstractJSqlParser.Dialect.MYSQL))
+                        .toString());
+    }
 }


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What

`withDialect(Dialect.MYSQL)` now also enables that dialect's lexer feature preset, on top of the grammar gating it already performs (#2510):

```java
CCJSqlParserUtil.parse("SELECT `col` FROM t WHERE a = 'x\\'yz' AND b = 42#24",
        p -> p.withDialect(Dialect.MYSQL))
// -> SELECT `col` FROM t WHERE a = 'x\'yz' AND b = 42
```

## Why

Each one-lexeme-two-dialects conflict settled so far left a switch behind: square bracket quotation (v3.0, #677), backslash escapes (v4.6), `#` line comments (#2508). Every user of a dialect has to know and wire the full set by hand, and the set grows by one on every future conflict.

## How

`Dialect` gains `ANSI_SQL`, `MYSQL`, `MARIADB`, `SQLSERVER`, `POSTGRESQL` and `H2` next to `ORACLE` and `EXASOL`, and carries its preset as an `EnumSet<Feature>`; `withDialect` enables the preset after setting `Feature.dialect`. The existing EXASOL grammar gating (`Import()/Export()`, `SubImport()`) compares enum names and is untouched; the EXASOL preset stays empty.

Presets per dialect, from the vendor docs:

| dialect | preset |
| --- | --- |
| MYSQL, MARIADB | backslash escapes, `#` line comments |
| SQLSERVER | square bracket quotation |
| ANSI_SQL, ORACLE, POSTGRESQL, H2, EXASOL | none (the defaults) |

MySQL 8 manual ([Comments](https://dev.mysql.com/doc/refman/8.0/en/comments.html), [String Literals](https://dev.mysql.com/doc/refman/8.0/en/string-literals.html)), MariaDB KB ([Comment Syntax](https://mariadb.com/kb/en/comment-syntax/), [String Literals](https://mariadb.com/kb/en/string-literals/)), Microsoft Learn ([Database Identifiers](https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers)). Brackets are not MySQL syntax and `#` stays reserved for SQL Server identifiers (temp tables), so the presets do not cross.

The preset only turns features on, never off: an explicit switch after `withDialect` wins, and a switch enabled before it survives (MYSQL does not disable bracket quotation set earlier). Pure data mapping, no lexer changes.

Design alternative: a separate `withDatabaseType(DatabaseType)` entry point beside the validation-side `DatabaseType` enum would leave two dialect enums and two builders; extending `Dialect` keeps one entry point. Merging the validation feature sets and the parse-time switches into one table looked like a larger refactor of the validation API and is not attempted here. If you prefer the separate entry point, the rework is small.

## Testing

`CCJSqlParserUtilTest`: `testDialectPresets` (the MySQL family, SQLSERVER, and the empty presets keeping the #2507 operator while rejecting `\'` escapes), `testDialectPresetSwitchOverrides` (a switch after the preset wins, the preset never disables one). All verified failing with the preset loop removed, with MYSQL missing the backslash feature, and with the preset turning foreign switches off; full suite green.

## Performance

No benchmark: `withDialect` runs once per parse call at configuration time (the same `FeatureConfiguration` writes the individual switches make) and the token loop is untouched, so default parses execute identical code.

Closes #2510

