### PR TITLE
feat(parser): support double quoted string literals behind allowDoubleQuotedStrings

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/StringValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/StringValue.java
@@ -36,6 +36,12 @@ public final class StringValue extends ASTNodeAccessImpl implements Expression {
                 && escapedValue.endsWith("'")) {
             value = escapedValue.substring(1, escapedValue.length() - 1);
             return;
+        } else if (escapedValue.length() >= 2 && escapedValue.startsWith("\"")
+                && escapedValue.endsWith("\"")) {
+            // double quoted String Literals (Feature.allowDoubleQuotedStrings)
+            value = escapedValue.substring(1, escapedValue.length() - 1);
+            quoteStr = "\"";
+            return;
         } else if (escapedValue.length() >= 4 && escapedValue.startsWith("$$")
                 && escapedValue.endsWith("$$")) {
             value = escapedValue.substring(2, escapedValue.length() - 2);

--- a/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
+++ b/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
@@ -26,8 +26,10 @@ public abstract class AbstractJSqlParser<P> {
 
     public enum Dialect {
         ANSI_SQL, ORACLE, MYSQL(Feature.allowBackslashEscapeCharacter,
-                Feature.allowHashLineComments), MARIADB(Feature.allowBackslashEscapeCharacter,
-                        Feature.allowHashLineComments), SQLSERVER(
+                Feature.allowHashLineComments,
+                Feature.allowDoubleQuotedStrings), MARIADB(Feature.allowBackslashEscapeCharacter,
+                        Feature.allowHashLineComments,
+                        Feature.allowDoubleQuotedStrings), SQLSERVER(
                                 Feature.allowSquareBracketQuotation), POSTGRESQL, H2, EXASOL;
 
         private final Set<Feature> lexerFeatures;
@@ -96,6 +98,14 @@ public abstract class AbstractJSqlParser<P> {
 
     public P withBackslashEscapeCharacter(boolean allowBackslashEscapeCharacter) {
         return withFeature(Feature.allowBackslashEscapeCharacter, allowBackslashEscapeCharacter);
+    }
+
+    public P withDoubleQuotedStrings() {
+        return withFeature(Feature.allowDoubleQuotedStrings, true);
+    }
+
+    public P withDoubleQuotedStrings(boolean allowDoubleQuotedStrings) {
+        return withFeature(Feature.allowDoubleQuotedStrings, allowDoubleQuotedStrings);
     }
 
     public P withHashLineComments() {

--- a/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
+++ b/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
@@ -796,6 +796,12 @@ public enum Feature {
     allowBackslashEscapeCharacter(false),
 
     /**
+     * allows double quoted String Literals (BigQuery, Spark/Databricks, MySQL default sql_mode);
+     * disabled by default, where double quotes stay quoted identifiers (ANSI SQL)
+     */
+    allowDoubleQuotedStrings(false),
+
+    /**
      * allows MySQL `#` line comments; disabled by default, where a lone `#` stays the binary
      * operator (#2507: PostgreSQL bitwise XOR / geometric intersection)
      */

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2077,6 +2077,11 @@ TOKEN:
             matchedToken.kind = squaredBracketOpenIndex;
             input_stream.backup(image.length() - 1);
         }
+        if ( configuration.getAsBoolean(Feature.allowDoubleQuotedStrings)
+            && matchedToken.image.charAt(0) == '"' ) {
+            // `charLiteralIndex` defined in TokenManagerDeclaration above
+            matchedToken.kind = charLiteralIndex;
+        }
     }
 }
 

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -279,7 +279,7 @@ Define the Parser Features
 
 JSQLParser interprets Squared Brackets ``[..]`` as Arrays, which does not work with MS SQL Server and T-SQL. Please use the Parser Features to instruct JSQLParser to read Squared Brackets as Quotes instead.
 
-JSQLParser allows for standard compliant Single Quote ``'..`` Escaping. Additional Back-slash ``\..`` Escaping needs to be activated by setting the ``BackSlashEscapeCharacter`` parser feature.
+JSQLParser allows for standard compliant Single Quote ``'..`` Escaping. Additional Back-slash ``\..`` Escaping needs to be activated by setting the ``BackSlashEscapeCharacter`` parser feature. JSQLParser reads Double Quotes ``".."`` as quoted identifiers (ANSI SQL); reading them as String Literals (BigQuery, Spark/Databricks, MySQL default sql_mode) needs the ``DoubleQuotedStrings`` parser feature.
 
 Additionally there are Features to control the Parser's effort at the cost of the performance.
 
@@ -319,7 +319,7 @@ Additionally there are Features to control the Parser's effort at the cost of th
                 .withBackslashEscapeCharacter(true)
     );
 
-Instead of turning the individual Parser Features on one by one, a ``Dialect`` preset selects the features of that database dialect: ``withDialect(Dialect.MYSQL)`` turns on ``withBackslashEscapeCharacter`` and ``withHashLineComments`` (both MySQL and MariaDB syntax), ``withDialect(Dialect.SQLSERVER)`` turns on ``withSquareBracketQuotation``. Features set explicitly after the dialect preset win over the preset.
+Instead of turning the individual Parser Features on one by one, a ``Dialect`` preset selects the features of that database dialect: ``withDialect(Dialect.MYSQL)`` turns on ``withBackslashEscapeCharacter``, ``withHashLineComments`` and ``withDoubleQuotedStrings`` (MySQL and MariaDB syntax, the latter for the default sql_mode), ``withDialect(Dialect.SQLSERVER)`` turns on ``withSquareBracketQuotation``. Features set explicitly after the dialect preset win over the preset.
 
 .. code-block:: java
 

--- a/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
@@ -12,6 +12,7 @@ package net.sf.jsqlparser.parser;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.LongValue;
+import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.expression.operators.arithmetic.Addition;
 import net.sf.jsqlparser.expression.operators.arithmetic.Multiplication;
 import net.sf.jsqlparser.expression.operators.relational.ParenthesedExpressionList;
@@ -20,6 +21,7 @@ import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.Statements;
 import net.sf.jsqlparser.statement.UnsupportedStatement;
 import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.select.TableStatement;
 import net.sf.jsqlparser.test.MemoryLeakVerifier;
 import net.sf.jsqlparser.test.TestUtils;
@@ -44,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CCJSqlParserUtilTest {
 
@@ -610,5 +613,46 @@ public class CCJSqlParserUtilTest {
                         p -> p.withSquareBracketQuotation(true)
                                 .withDialect(AbstractJSqlParser.Dialect.MYSQL))
                         .toString());
+    }
+
+    @Test
+    public void testDoubleQuotedStringsFeature() throws Exception {
+        // default (flag off): double quotes are quoted identifiers, unchanged
+        PlainSelect select = (PlainSelect) ((Select) CCJSqlParserUtil
+                .parse("SELECT \"not an identifier\"")).getSelectBody();
+        assertTrue(select.getSelectItems().get(0).getExpression() instanceof Column);
+        // on: the BigQuery/Spark/MySQL-default reading, double quotes are
+        // string literals, the quote kept on round-trip
+        select = (PlainSelect) ((Select) CCJSqlParserUtil.parse("SELECT \"not an identifier\"",
+                p -> p.withDoubleQuotedStrings(true))).getSelectBody();
+        Expression expression = select.getSelectItems().get(0).getExpression();
+        assertTrue(expression instanceof StringValue);
+        assertEquals("not an identifier", ((StringValue) expression).getValue());
+        assertEquals("SELECT \"not an identifier\"", select.toString());
+        // empty string and doubled quotes take the single-quote treatment
+        assertEquals("SELECT \"\"", CCJSqlParserUtil
+                .parse("SELECT \"\"", p -> p.withDoubleQuotedStrings(true)).toString());
+        assertEquals("SELECT \"a\"\"b\"", CCJSqlParserUtil
+                .parse("SELECT \"a\"\"b\"", p -> p.withDoubleQuotedStrings(true)).toString());
+        // identifier positions: a `"..."` token follows the existing
+        // string-as-table branch (`FROM 'file.csv'`), the same leniency
+        // single quotes already have; MySQL itself would error here
+        assertEquals("SELECT * FROM \"t\"", CCJSqlParserUtil
+                .parse("SELECT * FROM \"t\"", p -> p.withDoubleQuotedStrings(true)).toString());
+    }
+
+    @Test
+    public void testDoubleQuotedStringsPreset() throws Exception {
+        // MYSQL and MARIADB presets carry the switch (default sql_mode reading)
+        for (AbstractJSqlParser.Dialect dialect : new AbstractJSqlParser.Dialect[] {
+                AbstractJSqlParser.Dialect.MYSQL, AbstractJSqlParser.Dialect.MARIADB}) {
+            PlainSelect select = (PlainSelect) ((Select) CCJSqlParserUtil
+                    .parse("SELECT \"abc\"", p -> p.withDialect(dialect))).getSelectBody();
+            assertTrue(select.getSelectItems().get(0).getExpression() instanceof StringValue);
+        }
+        // the identifier-default dialects keep the quoted identifier reading
+        PlainSelect select = (PlainSelect) ((Select) CCJSqlParserUtil.parse("SELECT \"abc\"",
+                p -> p.withDialect(AbstractJSqlParser.Dialect.SQLSERVER))).getSelectBody();
+        assertTrue(select.getSelectItems().get(0).getExpression() instanceof Column);
     }
 }


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What

Double quoted string literals behind a feature switch, item 1 of #2512:

```java
CCJSqlParserUtil.parse("SELECT \"not an identifier\"", p -> p.withDoubleQuotedStrings(true))
// -> StringValue "not an identifier"; a Column when off
```

## Why

One lexeme, two readings, inventoried across the dialects JSqlParser models and the popular engines, every row verified against the vendor docs:

| `"..."` reads as | dialects |
| --- | --- |
| string literal | MySQL, MariaDB (default sql_mode; ANSI_QUOTES flips back), BigQuery, Databricks (Spark SQL), Hive (these three quote identifiers with backticks) |
| identifier | ANSI SQL, PostgreSQL, Oracle, SQL Server (QUOTED_IDENTIFIER ON), H2, Exasol, Snowflake, Redshift, ClickHouse, DuckDB, Trino, Db2 |

SQLite is the documented exception: identifier by the standard, with its double-quoted-string "misfeature" fallback when nothing matches, which a parser should not replicate. Master always produced the identifier reading, so the string side silently got a Column where their dialect has a string value.

## How

The `S_QUOTED_IDENTIFIER` token action rewrites the token kind to the string literal token when the feature is on, the same place the square bracket quotation machinery lives (#677 style, no grammar changes). `StringValue` strips double quotes and keeps them for round-trip through its existing `quoteStr` (the `$$` path already worked this way); the public `StringValue(String)` constructor accordingly strips a double-quoted argument the way it always stripped single-quoted ones. Backticks and brackets are untouched (first-character guard).

The `MYSQL` and `MARIADB` presets carry the switch (default sql_mode reading; under ANSI_QUOTES MySQL flips back to identifiers, so preset users wanting that reading keep the explicit switch off).

Disclosed leniency: in table positions a `"..."` token follows the existing string-as-table branch (`FROM 'file.csv'`), the same leniency single quotes already have; MySQL itself errors there.

## Testing

`CCJSqlParserUtilTest`: `testDoubleQuotedStringsFeature` (off = Column unchanged, on = StringValue with value and round-trip, empty string, doubled quotes, the string-as-table leniency), `testDoubleQuotedStringsPreset` (MYSQL/MARIADB on, SQLSERVER off). All verified failing with the token rewrite removed, with the StringValue branch removed, and with MYSQL missing the preset feature; full suite green.

## Performance

`gradle jmh`, `JSQLParserBenchmark.parseSQLStatements` on `performance.sql`, `version=latest`, 10 forks × 10 iterations (100 samples) on a 32-core host, interleaved master/branch:

| build | run 1 | run 2 |
| --- | --- | --- |
| master `94c4508` | 3.754 ± 0.023 | 3.795 ± 0.026 |
| branch (this PR) | 3.777 ± 0.024 | 3.805 ± 0.024 |

Same-window deltas are +0.6% and +0.3% with overlapping CIs, and the drift between the two master runs (3.754 -> 3.795) is larger than the master/branch delta: no regression. The residual is the one added `getAsBoolean` in the `S_QUOTED_IDENTIFIER` action, paid per quoted identifier token only.

Implements item 1 of #2512.

