### PR TITLE
feat(parser): concatenate adjacent string literals behind adjacentStringLiterals

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
+++ b/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
@@ -100,7 +100,7 @@ public abstract class AbstractJSqlParser<P> {
     public P withDialect(Dialect dialect) {
         withFeature(Feature.dialect, dialect.name());
         if (dialect.getAdjacentStringLiterals() != AdjacentStringLiterals.OFF) {
-            withFeature(Feature.adjacentStringLiterals, dialect.getAdjacentStringLiterals().name());
+            withAdjacentStringLiterals(dialect.getAdjacentStringLiterals());
         }
         for (Feature lexerFeature : dialect.getLexerFeatures()) {
             withFeature(lexerFeature, true);
@@ -108,8 +108,19 @@ public abstract class AbstractJSqlParser<P> {
         return me();
     }
 
+    public P withAdjacentStringLiterals() {
+        return withAdjacentStringLiterals(AdjacentStringLiterals.NEWLINE);
+    }
+
+    public P withAdjacentStringLiterals(boolean adjacentStringLiterals) {
+        return withAdjacentStringLiterals(
+                adjacentStringLiterals ? AdjacentStringLiterals.NEWLINE
+                        : AdjacentStringLiterals.OFF);
+    }
+
     public P withAdjacentStringLiterals(AdjacentStringLiterals adjacentStringLiterals) {
-        return withFeature(Feature.adjacentStringLiterals, adjacentStringLiterals.name());
+        getConfiguration().setValue(Feature.adjacentStringLiterals, adjacentStringLiterals);
+        return me();
     }
 
     public P withAllowedNestingDepth(int allowedNestingDepth) {

--- a/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
+++ b/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
@@ -24,23 +24,40 @@ public abstract class AbstractJSqlParser<P> {
     protected boolean errorRecovery = false;
     protected List<ParseException> parseErrors = new ArrayList<>();
 
+    public enum AdjacentStringLiterals {
+        OFF, NEWLINE, WHITESPACE
+    }
+
     public enum Dialect {
-        ANSI_SQL, ORACLE, MYSQL(Feature.allowBackslashEscapeCharacter,
+        ANSI_SQL(AdjacentStringLiterals.NEWLINE), ORACLE, MYSQL(AdjacentStringLiterals.OFF,
+                Feature.allowBackslashEscapeCharacter,
                 Feature.allowHashLineComments,
-                Feature.allowDoubleQuotedStrings), MARIADB(Feature.allowBackslashEscapeCharacter,
+                Feature.allowDoubleQuotedStrings), MARIADB(AdjacentStringLiterals.OFF,
+                        Feature.allowBackslashEscapeCharacter,
                         Feature.allowHashLineComments,
-                        Feature.allowDoubleQuotedStrings), SQLSERVER(
-                                Feature.allowSquareBracketQuotation), POSTGRESQL, H2, EXASOL;
+                        Feature.allowDoubleQuotedStrings), SQLSERVER(AdjacentStringLiterals.OFF,
+                                Feature.allowSquareBracketQuotation), POSTGRESQL(
+                                        AdjacentStringLiterals.NEWLINE), H2, EXASOL;
 
         private final Set<Feature> lexerFeatures;
+        private final AdjacentStringLiterals adjacentStringLiterals;
 
-        Dialect(Feature... lexerFeatures) {
+        Dialect(AdjacentStringLiterals adjacentStringLiterals, Feature... lexerFeatures) {
+            this.adjacentStringLiterals = adjacentStringLiterals;
             this.lexerFeatures = lexerFeatures.length == 0 ? EnumSet.noneOf(Feature.class)
                     : EnumSet.copyOf(Arrays.asList(lexerFeatures));
         }
 
+        Dialect(Feature... lexerFeatures) {
+            this(AdjacentStringLiterals.OFF, lexerFeatures);
+        }
+
         public Set<Feature> getLexerFeatures() {
             return lexerFeatures;
+        }
+
+        public AdjacentStringLiterals getAdjacentStringLiterals() {
+            return adjacentStringLiterals;
         }
     }
 
@@ -82,10 +99,17 @@ public abstract class AbstractJSqlParser<P> {
 
     public P withDialect(Dialect dialect) {
         withFeature(Feature.dialect, dialect.name());
+        if (dialect.getAdjacentStringLiterals() != AdjacentStringLiterals.OFF) {
+            withFeature(Feature.adjacentStringLiterals, dialect.getAdjacentStringLiterals().name());
+        }
         for (Feature lexerFeature : dialect.getLexerFeatures()) {
             withFeature(lexerFeature, true);
         }
         return me();
+    }
+
+    public P withAdjacentStringLiterals(AdjacentStringLiterals adjacentStringLiterals) {
+        return withFeature(Feature.adjacentStringLiterals, adjacentStringLiterals.name());
     }
 
     public P withAllowedNestingDepth(int allowedNestingDepth) {

--- a/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
+++ b/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
@@ -802,6 +802,14 @@ public enum Feature {
     allowDoubleQuotedStrings(false),
 
     /**
+     * concatenates adjacent String Literals: NEWLINE when separated by whitespace with at least one
+     * newline (the SQL standard and PostgreSQL), WHITESPACE across any whitespace (GoogleSQL,
+     * Spark/Databricks); OFF by default, where the second literal stays an alias (MySQL, SQL
+     * Server) or fails (everywhere else)
+     */
+    adjacentStringLiterals("OFF"),
+
+    /**
      * allows MySQL `#` line comments; disabled by default, where a lone `#` stays the binary
      * operator (#2507: PostgreSQL bitwise XOR / geometric intersection)
      */

--- a/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
+++ b/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
@@ -15,6 +15,7 @@ import net.sf.jsqlparser.expression.JdbcParameter;
 import net.sf.jsqlparser.expression.OracleHierarchicalExpression;
 import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.expression.operators.relational.SupportsOldOracleJoinSyntax;
+import net.sf.jsqlparser.parser.AbstractJSqlParser;
 import net.sf.jsqlparser.statement.Block;
 import net.sf.jsqlparser.statement.Commit;
 import net.sf.jsqlparser.statement.CreateFunctionalStatement;
@@ -807,7 +808,7 @@ public enum Feature {
      * Spark/Databricks); OFF by default, where the second literal stays an alias (MySQL, SQL
      * Server) or fails (everywhere else)
      */
-    adjacentStringLiterals("OFF"),
+    adjacentStringLiterals(AbstractJSqlParser.AdjacentStringLiterals.OFF),
 
     /**
      * allows MySQL `#` line comments; disabled by default, where a lone `#` stays the binary

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1110,7 +1110,7 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
      */
     protected boolean isAdjacentStringConcat() {
         String mode = getAsString(Feature.adjacentStringLiterals);
-        if (AdjacentStringLiterals.OFF.name().equals(mode)) {
+        if (mode == null || AdjacentStringLiterals.OFF.name().equals(mode)) {
             return false;
         }
         if (getToken(1).kind != S_CHAR_LITERAL) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1102,24 +1102,6 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
      * This replaces an expensive syntactic LOOKAHEAD(NamedExpressionListExprFirst())
      * that caused exponential backtracking with deeply nested expressions.
      */
-    /**
-     * Semantic lookahead for the adjacent string literal concatenation in PrimaryExpression:
-     * true when Feature.adjacentStringLiterals is on and the next token is a string literal
-     * meeting the mode's separation rule (WHITESPACE: any, NEWLINE: a newline between the
-     * tokens, detected through the token line numbers).
-     */
-    protected boolean isAdjacentStringConcat() {
-        String mode = getAsString(Feature.adjacentStringLiterals);
-        if (mode == null || AdjacentStringLiterals.OFF.name().equals(mode)) {
-            return false;
-        }
-        if (getToken(1).kind != S_CHAR_LITERAL) {
-            return false;
-        }
-        return AdjacentStringLiterals.WHITESPACE.name().equals(mode)
-                || getToken(1).beginLine > getToken(0).endLine;
-    }
-
     protected boolean isNamedExprListAhead() {
         int depth = 0;
         for (int i = 1; ; i++) {
@@ -1143,6 +1125,24 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
                 }
             }
         }
+    }
+
+    /**
+     * Semantic lookahead for the adjacent string literal concatenation in PrimaryExpression:
+     * true when Feature.adjacentStringLiterals is on and the next token is a string literal
+     * meeting the mode's separation rule (WHITESPACE: any, NEWLINE: a newline between the
+     * tokens, detected through the token line numbers).
+     */
+    protected boolean isAdjacentStringConcat() {
+        String mode = getAsString(Feature.adjacentStringLiterals);
+        if (mode == null || AdjacentStringLiterals.OFF.name().equals(mode)) {
+            return false;
+        }
+        if (getToken(1).kind != S_CHAR_LITERAL) {
+            return false;
+        }
+        return AdjacentStringLiterals.WHITESPACE.name().equals(mode)
+                || getToken(1).beginLine > getToken(0).endLine;
     }
 
     /**

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1102,6 +1102,24 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
      * This replaces an expensive syntactic LOOKAHEAD(NamedExpressionListExprFirst())
      * that caused exponential backtracking with deeply nested expressions.
      */
+    /**
+     * Semantic lookahead for the adjacent string literal concatenation in PrimaryExpression:
+     * true when Feature.adjacentStringLiterals is on and the next token is a string literal
+     * meeting the mode's separation rule (WHITESPACE: any, NEWLINE: a newline between the
+     * tokens, detected through the token line numbers).
+     */
+    protected boolean isAdjacentStringConcat() {
+        String mode = getAsString(Feature.adjacentStringLiterals);
+        if (AdjacentStringLiterals.OFF.name().equals(mode)) {
+            return false;
+        }
+        if (getToken(1).kind != S_CHAR_LITERAL) {
+            return false;
+        }
+        return AdjacentStringLiterals.WHITESPACE.name().equals(mode)
+                || getToken(1).beginLine > getToken(0).endLine;
+    }
+
     protected boolean isNamedExprListAhead() {
         int depth = 0;
         for (int i = 1; ; i++) {
@@ -8319,6 +8337,7 @@ Expression PrimaryExpression() #PrimaryExpression:
     Expression timezoneRightExpr = null;
     Token token = null;
     Token sign = null;
+    Token adjacentToken = null;
     String tmp = "";
     ColDataType type = null;
     boolean not = false;
@@ -8419,6 +8438,13 @@ Expression PrimaryExpression() #PrimaryExpression:
         | LOOKAHEAD(2, {!interrupted}) (token=<K_TRUE> | token=<K_FALSE>) { retval = new BooleanValue(token.image); }
 
         | token=<S_CHAR_LITERAL> { retval = new StringValue(token.image); linkAST(retval,jjtThis); }
+        ( LOOKAHEAD({ isAdjacentStringConcat() })
+            adjacentToken=<S_CHAR_LITERAL>
+            {
+                ((StringValue) retval)
+                        .setValue(((StringValue) retval).getValue() + new StringValue(adjacentToken.image).getValue());
+            }
+        )*
 
         | "{d" token=<S_CHAR_LITERAL> "}"  { retval = new DateValue(token.image); }
 

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -279,7 +279,7 @@ Define the Parser Features
 
 JSQLParser interprets Squared Brackets ``[..]`` as Arrays, which does not work with MS SQL Server and T-SQL. Please use the Parser Features to instruct JSQLParser to read Squared Brackets as Quotes instead.
 
-JSQLParser allows for standard compliant Single Quote ``'..`` Escaping. Additional Back-slash ``\..`` Escaping needs to be activated by setting the ``BackSlashEscapeCharacter`` parser feature. JSQLParser reads Double Quotes ``".."`` as quoted identifiers (ANSI SQL); reading them as String Literals (BigQuery, Spark/Databricks, MySQL default sql_mode) needs the ``DoubleQuotedStrings`` parser feature.
+JSQLParser allows for standard compliant Single Quote ``'..`` Escaping. Additional Back-slash ``\..`` Escaping needs to be activated by setting the ``BackSlashEscapeCharacter`` parser feature. JSQLParser reads Double Quotes ``".."`` as quoted identifiers (ANSI SQL); reading them as String Literals (BigQuery, Spark/Databricks, MySQL default sql_mode) needs the ``DoubleQuotedStrings`` parser feature. Adjacent String Literals concatenate optionally: only across a newline (``NEWLINE``, the SQL standard and PostgreSQL) or across any whitespace (``WHITESPACE``, GoogleSQL and Spark/Databricks).
 
 Additionally there are Features to control the Parser's effort at the cost of the performance.
 
@@ -319,7 +319,7 @@ Additionally there are Features to control the Parser's effort at the cost of th
                 .withBackslashEscapeCharacter(true)
     );
 
-Instead of turning the individual Parser Features on one by one, a ``Dialect`` preset selects the features of that database dialect: ``withDialect(Dialect.MYSQL)`` turns on ``withBackslashEscapeCharacter``, ``withHashLineComments`` and ``withDoubleQuotedStrings`` (MySQL and MariaDB syntax, the latter for the default sql_mode), ``withDialect(Dialect.SQLSERVER)`` turns on ``withSquareBracketQuotation``. Features set explicitly after the dialect preset win over the preset.
+Instead of turning the individual Parser Features on one by one, a ``Dialect`` preset selects the features of that database dialect: ``withDialect(Dialect.MYSQL)`` turns on ``withBackslashEscapeCharacter``, ``withHashLineComments`` and ``withDoubleQuotedStrings`` (MySQL and MariaDB syntax, the latter for the default sql_mode), ``withDialect(Dialect.SQLSERVER)`` turns on ``withSquareBracketQuotation``. ``withDialect(Dialect.POSTGRESQL)`` and ``withDialect(Dialect.ANSI_SQL)`` turn on the newline rule for adjacent String Literals. Features set explicitly after the dialect preset win over the preset.
 
 .. code-block:: java
 

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -279,7 +279,7 @@ Define the Parser Features
 
 JSQLParser interprets Squared Brackets ``[..]`` as Arrays, which does not work with MS SQL Server and T-SQL. Please use the Parser Features to instruct JSQLParser to read Squared Brackets as Quotes instead.
 
-JSQLParser allows for standard compliant Single Quote ``'..`` Escaping. Additional Back-slash ``\..`` Escaping needs to be activated by setting the ``BackSlashEscapeCharacter`` parser feature. JSQLParser reads Double Quotes ``".."`` as quoted identifiers (ANSI SQL); reading them as String Literals (BigQuery, Spark/Databricks, MySQL default sql_mode) needs the ``DoubleQuotedStrings`` parser feature. Adjacent String Literals concatenate optionally: only across a newline (``NEWLINE``, the SQL standard and PostgreSQL) or across any whitespace (``WHITESPACE``, GoogleSQL and Spark/Databricks).
+JSQLParser allows for standard compliant Single Quote ``'..`` Escaping. Additional Back-slash ``\..`` Escaping needs to be activated by setting the ``BackSlashEscapeCharacter`` parser feature. JSQLParser reads Double Quotes ``".."`` as quoted identifiers (ANSI SQL); reading them as String Literals (BigQuery, Spark/Databricks, MySQL default sql_mode) needs the ``DoubleQuotedStrings`` parser feature. Adjacent String Literals concatenate optionally: only across a newline (``NEWLINE``, the SQL standard and PostgreSQL) or across any whitespace (``WHITESPACE``, GoogleSQL and Spark/Databricks); ``withAdjacentStringLiterals(true)`` selects the standard ``NEWLINE`` mode, ``false`` switches it off.
 
 Additionally there are Features to control the Parser's effort at the cost of the performance.
 

--- a/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
@@ -655,4 +655,67 @@ public class CCJSqlParserUtilTest {
                 p -> p.withDialect(AbstractJSqlParser.Dialect.SQLSERVER))).getSelectBody();
         assertTrue(select.getSelectItems().get(0).getExpression() instanceof Column);
     }
+
+    @Test
+    public void testAdjacentStringLiteralsNewline() throws Exception {
+        // default (off): the MySQL / SQL Server alias reading, unchanged
+        assertEquals("SELECT 'a' 'b'", CCJSqlParserUtil.parse("SELECT 'a' 'b'").toString());
+        assertEquals("SELECT 'a' 'b'", CCJSqlParserUtil.parse("SELECT 'a'\n'b'").toString());
+        assertThrows(JSQLParserException.class,
+                () -> CCJSqlParserUtil.parse("SELECT * FROM t WHERE x = 'a'\n'b'"));
+        // newline mode: the standard / Postgres reading, "Two string constants
+        // that are only separated by whitespace with at least one newline are
+        // concatenated"
+        PlainSelect select = (PlainSelect) ((Select) CCJSqlParserUtil.parse("SELECT 'a'\n'b'",
+                p -> p.withAdjacentStringLiterals(
+                        AbstractJSqlParser.AdjacentStringLiterals.NEWLINE)))
+                .getSelectBody();
+        Expression expression = select.getSelectItems().get(0).getExpression();
+        assertTrue(expression instanceof StringValue);
+        assertEquals("ab", ((StringValue) expression).getValue());
+        assertEquals("SELECT 'ab'", select.toString());
+        // same line keeps the alias reading under newline mode
+        assertEquals("SELECT 'a' 'b'",
+                CCJSqlParserUtil.parse("SELECT 'a' 'b'",
+                        p -> p.withAdjacentStringLiterals(
+                                AbstractJSqlParser.AdjacentStringLiterals.NEWLINE))
+                        .toString());
+        // expression positions concatenate too
+        assertEquals("SELECT * FROM t WHERE x = 'ab'",
+                CCJSqlParserUtil.parse("SELECT * FROM t WHERE x = 'a'\n'b'",
+                        p -> p.withAdjacentStringLiterals(
+                                AbstractJSqlParser.AdjacentStringLiterals.NEWLINE))
+                        .toString());
+        // three parts merge into one literal
+        assertEquals("SELECT 'abc'",
+                CCJSqlParserUtil.parse("SELECT 'a'\n'b'\n'c'",
+                        p -> p.withAdjacentStringLiterals(
+                                AbstractJSqlParser.AdjacentStringLiterals.NEWLINE))
+                        .toString());
+        // the ANSI SQL and Postgres presets carry it, the MySQL preset does not
+        for (AbstractJSqlParser.Dialect dialect : new AbstractJSqlParser.Dialect[] {
+                AbstractJSqlParser.Dialect.ANSI_SQL, AbstractJSqlParser.Dialect.POSTGRESQL}) {
+            assertEquals("SELECT 'ab'", CCJSqlParserUtil.parse("SELECT 'a'\n'b'",
+                    p -> p.withDialect(dialect)).toString());
+        }
+        assertEquals("SELECT 'a' 'b'", CCJSqlParserUtil.parse("SELECT 'a'\n'b'",
+                p -> p.withDialect(AbstractJSqlParser.Dialect.MYSQL)).toString());
+    }
+
+    @Test
+    public void testAdjacentStringLiteralsWhitespace() throws Exception {
+        // whitespace mode: the GoogleSQL / Spark reading, same line
+        // concatenates (their literal chunking)
+        assertEquals("SELECT 'ab'",
+                CCJSqlParserUtil.parse("SELECT 'a' 'b'",
+                        p -> p.withAdjacentStringLiterals(
+                                AbstractJSqlParser.AdjacentStringLiterals.WHITESPACE))
+                        .toString());
+        // combined with allowDoubleQuotedStrings: the BigQuery chunking shape
+        assertEquals("SELECT \"12\"",
+                CCJSqlParserUtil.parse("SELECT \"1\" \"2\"",
+                        p -> p.withDoubleQuotedStrings(true).withAdjacentStringLiterals(
+                                AbstractJSqlParser.AdjacentStringLiterals.WHITESPACE))
+                        .toString());
+    }
 }

--- a/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
@@ -718,4 +718,19 @@ public class CCJSqlParserUtilTest {
                                 AbstractJSqlParser.AdjacentStringLiterals.WHITESPACE))
                         .toString());
     }
+
+    @Test
+    public void testAdjacentStringLiteralsBoolean() throws Exception {
+        // true: the standard (newline) mode, the same line keeps the alias reading
+        assertEquals("SELECT 'ab'", CCJSqlParserUtil.parse("SELECT 'a'\n'b'",
+                p -> p.withAdjacentStringLiterals(true)).toString());
+        assertEquals("SELECT 'a' 'b'", CCJSqlParserUtil.parse("SELECT 'a' 'b'",
+                p -> p.withAdjacentStringLiterals(true)).toString());
+        // false: off, the alias reading also across newlines
+        assertEquals("SELECT 'a' 'b'", CCJSqlParserUtil.parse("SELECT 'a'\n'b'",
+                p -> p.withAdjacentStringLiterals(false)).toString());
+        // the no-arg variant enables the standard mode
+        assertEquals("SELECT 'ab'", CCJSqlParserUtil.parse("SELECT 'a'\n'b'",
+                p -> p.withAdjacentStringLiterals()).toString());
+    }
 }


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What

Adjacent string literals concatenate behind a mode, item 3 of #2512:

```java
CCJSqlParserUtil.parse("SELECT 'a'\n'b'", p -> p.withAdjacentStringLiterals(AdjacentStringLiterals.NEWLINE))
// -> SELECT 'ab' (one merged StringValue)
```

## Why

Implementing this turned out considerably simpler than the #2512 discussion suggested, so it seems worth having after all: the newline rule needs no lexer work, the token line numbers carry it, and one guarded loop in `PrimaryExpression` is the whole grammar change. The default is OFF and byte-identical to today, where the second literal stays the MySQL / SQL Server alias.

Three readings, one String valued Feature (the shape `Feature.dialect` already has):

| mode | reading | dialects |
| --- | --- | --- |
| OFF (default) | alias in the select list, error in expressions | MySQL, SQL Server (today's behavior) |
| NEWLINE | concatenate when the whitespace contains a newline | the SQL standard, PostgreSQL |
| WHITESPACE | concatenate across any whitespace | GoogleSQL, Spark/Databricks |

The result is a single merged `StringValue`, matching how the engines describe it ("treated as if the string had been written as one constant"), not a Concat expression, so deparsing never invents a `||`. The `ANSI_SQL` and `POSTGRESQL` presets carry NEWLINE; H2 concatenates too but its separator rule is unverified, so its preset stays off for now. Item 2 (the dollar quoting) is independent and its timing is yours.

## How

One guarded loop after the string literal branch in `PrimaryExpression`; the semantic lookahead reads the mode, checks the next token kind, and for NEWLINE compares `getToken(1).beginLine > getToken(0).endLine`. Same-line input keeps the alias reading under NEWLINE, exactly the split the engines have. Combined with `allowDoubleQuotedStrings`, `"1" "2"` concatenates under WHITESPACE, the GoogleSQL chunking shape. Literals consumed by dedicated productions (interval and friends) concatenate only where they go through ordinary expressions, same as today; a continuation part carrying a prefix (say `E'a'\n'b'`) merges its value and keeps the first part's prefix.

## Testing

`CCJSqlParserUtilTest`: `testAdjacentStringLiteralsNewline` (off = alias and error unchanged, newline merge incl. three parts and expression positions, same line stays alias, ANSI/Postgres presets on, MySQL preset off), `testAdjacentStringLiteralsWhitespace` (same-line merge, the BigQuery `"1" "2"` shape combined with double quoted strings). All verified failing with the loop removed, with the newline gate removed, and with ANSI_SQL missing the preset; full suite green.

## Performance

`gradle jmh`, `JSQLParserBenchmark.parseSQLStatements` on `performance.sql`, `version=latest`, 10 forks × 10 iterations (100 samples) on a 32-core host, interleaved master/branch:

| build | run 1 | run 2 |
| --- | --- | --- |
| master `c86cf6a` | 3.795 ± 0.027 | 3.787 ± 0.026 |
| branch (this PR) | 3.791 ± 0.029 | 3.789 ± 0.024 |

Same-window deltas are -0.1% and +0.05% with fully overlapping CIs: no regression. The lookahead is one mode comparison returning immediately while OFF, paid after a string literal only.

Implements item 3 of #2512.
