### PR TITLE
feat(parser): add BIGQUERY, DATABRICKS and SNOWFLAKE dialect presets

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
+++ b/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
@@ -37,7 +37,15 @@ public abstract class AbstractJSqlParser<P> {
                         Feature.allowHashLineComments,
                         Feature.allowDoubleQuotedStrings), SQLSERVER(AdjacentStringLiterals.OFF,
                                 Feature.allowSquareBracketQuotation), POSTGRESQL(
-                                        AdjacentStringLiterals.NEWLINE), H2, EXASOL;
+                                        AdjacentStringLiterals.NEWLINE), H2, EXASOL, BIGQUERY(
+                                                AdjacentStringLiterals.WHITESPACE,
+                                                Feature.allowDoubleQuotedStrings,
+                                                Feature.allowHashLineComments,
+                                                Feature.allowBackslashEscapeCharacter), DATABRICKS(
+                                                        AdjacentStringLiterals.WHITESPACE,
+                                                        Feature.allowDoubleQuotedStrings,
+                                                        Feature.allowBackslashEscapeCharacter), SNOWFLAKE(
+                                                                Feature.allowBackslashEscapeCharacter);
 
         private final Set<Feature> lexerFeatures;
         private final AdjacentStringLiterals adjacentStringLiterals;

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -319,7 +319,7 @@ Additionally there are Features to control the Parser's effort at the cost of th
                 .withBackslashEscapeCharacter(true)
     );
 
-Instead of turning the individual Parser Features on one by one, a ``Dialect`` preset selects the features of that database dialect: ``withDialect(Dialect.MYSQL)`` turns on ``withBackslashEscapeCharacter``, ``withHashLineComments`` and ``withDoubleQuotedStrings`` (MySQL and MariaDB syntax, the latter for the default sql_mode), ``withDialect(Dialect.SQLSERVER)`` turns on ``withSquareBracketQuotation``. ``withDialect(Dialect.POSTGRESQL)`` and ``withDialect(Dialect.ANSI_SQL)`` turn on the newline rule for adjacent String Literals. Features set explicitly after the dialect preset win over the preset.
+Instead of turning the individual Parser Features on one by one, a ``Dialect`` preset selects the features of that database dialect: ``withDialect(Dialect.MYSQL)`` turns on ``withBackslashEscapeCharacter``, ``withHashLineComments`` and ``withDoubleQuotedStrings`` (MySQL and MariaDB syntax, the latter for the default sql_mode), ``withDialect(Dialect.SQLSERVER)`` turns on ``withSquareBracketQuotation``. ``withDialect(Dialect.POSTGRESQL)`` and ``withDialect(Dialect.ANSI_SQL)`` turn on the newline rule for adjacent String Literals. ``withDialect(Dialect.BIGQUERY)`` and ``withDialect(Dialect.DATABRICKS)`` turn on ``withDoubleQuotedStrings`` and ``withBackslashEscapeCharacter`` plus the any-whitespace rule for adjacent String Literals, the BigQuery preset additionally ``withHashLineComments``; ``withDialect(Dialect.SNOWFLAKE)`` turns on ``withBackslashEscapeCharacter`` only, keeping double quotes as quoted identifiers. Features set explicitly after the dialect preset win over the preset.
 
 .. code-block:: java
 

--- a/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
@@ -642,18 +642,50 @@ public class CCJSqlParserUtilTest {
     }
 
     @Test
+    public void testDialectPresetsWarehouses() throws Exception {
+        // BIGQUERY: double quoted strings, # line comments and backslash
+        // escapes (GoogleSQL "Lexical structure and syntax", identifiers are
+        // backticked), backticks stay unconditional
+        assertEquals("SELECT `col` FROM t WHERE a = 'x\\'yz' AND b = 42", CCJSqlParserUtil
+                .parse("SELECT `col` FROM t WHERE a = 'x\\'yz' AND b = 42#24",
+                        p -> p.withDialect(AbstractJSqlParser.Dialect.BIGQUERY))
+                .toString());
+        // DATABRICKS: double quoted strings and backslash escapes (Spark
+        // "Literals"), `#` stays the #2507 operator
+        assertEquals("SELECT \"a\" FROM t WHERE x = 'it\\'s'", CCJSqlParserUtil
+                .parse("SELECT \"a\" FROM t WHERE x = 'it\\'s'",
+                        p -> p.withDialect(AbstractJSqlParser.Dialect.DATABRICKS))
+                .toString());
+        assertEquals("SELECT 42 # 24", CCJSqlParserUtil.parse("SELECT 42 # 24",
+                p -> p.withDialect(AbstractJSqlParser.Dialect.DATABRICKS)).toString());
+        // SNOWFLAKE: backslash escape sequences ("String & binary data
+        // types"), `#` stays the operator
+        assertEquals("SELECT col FROM t WHERE a = 'x\\'yz'", CCJSqlParserUtil
+                .parse("SELECT col FROM t WHERE a = 'x\\'yz'",
+                        p -> p.withDialect(AbstractJSqlParser.Dialect.SNOWFLAKE))
+                .toString());
+        assertEquals("SELECT 42 # 24", CCJSqlParserUtil.parse("SELECT 42 # 24",
+                p -> p.withDialect(AbstractJSqlParser.Dialect.SNOWFLAKE)).toString());
+    }
+
+    @Test
     public void testDoubleQuotedStringsPreset() throws Exception {
-        // MYSQL and MARIADB presets carry the switch (default sql_mode reading)
+        // the string-default dialects: MYSQL and MARIADB (default sql_mode),
+        // BIGQUERY and DATABRICKS (string literals, identifiers are backticked)
         for (AbstractJSqlParser.Dialect dialect : new AbstractJSqlParser.Dialect[] {
-                AbstractJSqlParser.Dialect.MYSQL, AbstractJSqlParser.Dialect.MARIADB}) {
+                AbstractJSqlParser.Dialect.MYSQL, AbstractJSqlParser.Dialect.MARIADB,
+                AbstractJSqlParser.Dialect.BIGQUERY, AbstractJSqlParser.Dialect.DATABRICKS}) {
             PlainSelect select = (PlainSelect) ((Select) CCJSqlParserUtil
                     .parse("SELECT \"abc\"", p -> p.withDialect(dialect))).getSelectBody();
             assertTrue(select.getSelectItems().get(0).getExpression() instanceof StringValue);
         }
         // the identifier-default dialects keep the quoted identifier reading
-        PlainSelect select = (PlainSelect) ((Select) CCJSqlParserUtil.parse("SELECT \"abc\"",
-                p -> p.withDialect(AbstractJSqlParser.Dialect.SQLSERVER))).getSelectBody();
-        assertTrue(select.getSelectItems().get(0).getExpression() instanceof Column);
+        for (AbstractJSqlParser.Dialect dialect : new AbstractJSqlParser.Dialect[] {
+                AbstractJSqlParser.Dialect.SQLSERVER, AbstractJSqlParser.Dialect.SNOWFLAKE}) {
+            PlainSelect select = (PlainSelect) ((Select) CCJSqlParserUtil.parse("SELECT \"abc\"",
+                    p -> p.withDialect(dialect))).getSelectBody();
+            assertTrue(select.getSelectItems().get(0).getExpression() instanceof Column);
+        }
     }
 
     @Test
@@ -717,6 +749,15 @@ public class CCJSqlParserUtilTest {
                         p -> p.withDoubleQuotedStrings(true).withAdjacentStringLiterals(
                                 AbstractJSqlParser.AdjacentStringLiterals.WHITESPACE))
                         .toString());
+        // the BigQuery and Databricks presets carry it, the Snowflake preset
+        // does not (no adjacent-literal concatenation documented)
+        for (AbstractJSqlParser.Dialect dialect : new AbstractJSqlParser.Dialect[] {
+                AbstractJSqlParser.Dialect.BIGQUERY, AbstractJSqlParser.Dialect.DATABRICKS}) {
+            assertEquals("SELECT 'ab'", CCJSqlParserUtil.parse("SELECT 'a' 'b'",
+                    p -> p.withDialect(dialect)).toString());
+        }
+        assertEquals("SELECT 'a' 'b'", CCJSqlParserUtil.parse("SELECT 'a' 'b'",
+                p -> p.withDialect(AbstractJSqlParser.Dialect.SNOWFLAKE)).toString());
     }
 
     @Test


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What

Three warehouse presets, following up on the four warehouses named in #2512:

```java
CCJSqlParserUtil.parse("SELECT `col` FROM t WHERE a = 'x\\'yz' AND b = 42#24",
        p -> p.withDialect(Dialect.BIGQUERY))
// -> SELECT `col` FROM t WHERE a = 'x\'yz' AND b = 42
```

| preset | `"` | `#` | `\` | adjacent literals |
| --- | --- | --- | --- | --- |
| BIGQUERY | string literal | line comment | escape sequences | WHITESPACE |
| DATABRICKS | string literal | the #2507 operator | escape sequences | WHITESPACE |
| SNOWFLAKE | quoted identifier | the operator | escape sequences | OFF (alias) |

## Why

Every row is taken from the vendor docs, and Redshift, the fourth warehouse surveyed, matches the defaults on every switch and gains no entry.

- GoogleSQL, lexical structure: "Both string and bytes literals must be quoted, either with single (`'`) or double (`\"`) quotation marks", `#` single-line comments, "Backslashes (`\`) introduce escape sequences", literal chunking where "the literal value is the concatenation of all these parts" across any whitespace ("Quoted identifiers don't concatenate"); identifiers are backticked.
- Spark, literals: the syntax `[ r ] { 'char [ ... ]' | "char [ ... ]" } [ ... ]`, the escape table, "Chains of string literals are coalesced into a single string literal". The Databricks KB adds that double quoted identifiers need the non-default `doubleQuotedIdentifiers` conf, so the default reading is the string one, the same preset decision as MySQL and its ANSI_QUOTES mode in #2513. `#` is not a Spark comment.
- Snowflake, string and binary data types: "A backslash escape sequence is a sequence of characters that begins with a backslash (`\`)", the double quote "is used (as needed) for delimiting object identifiers"; no adjacent-literal concatenation documented.
- Redshift: delimited identifiers for `"`, PG-style `--` comments, and no AWS docs sentence found for backslash escapes or adjacent literals (community evidence points to escapes, unverified), so every row stays with the default and no empty preset entry is added.

Sources: [GoogleSQL lexical structure](https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical), [Spark literals](https://spark.apache.org/docs/latest/sql-ref-literals.html), [Databricks KB, double quoted identifiers](https://kb.databricks.com/dbsql/using-double-quotes-in-a-query-causes-a-syntax-error), [Snowflake string and binary data types](https://docs.snowflake.com/en/sql-reference/data-types-text), [Redshift names](https://docs.aws.amazon.com/redshift/latest/dg/r_names.html).

## How

Enum entries only; `withDialect` is data driven since #2511 and unchanged. Stacked on #2514 for the WHITESPACE mode, the diff shrinks automatically once it merges.

## Testing

`CCJSqlParserUtilTest`: `testDialectPresetsWarehouses` (BigQuery backticks + escape + `42#24` swallowed as comment, Databricks double quoted string + escape + `#` stays the operator, Snowflake escape + `#` stays the operator), `testDoubleQuotedStringsPreset` extended (string reading for BigQuery and Databricks, identifier guard for Snowflake), `testAdjacentStringLiteralsWhitespace` extended (the warehouse presets carry the mode, Snowflake stays the alias reading). All verified failing with a wrong row added or a right row removed (Databricks `#` on, Snowflake `"` on, BigQuery `#` off, WHITESPACE turned into NEWLINE); full suite green.
