### PR TITLE
fix: collect tables from all SELECT and DML trailing clauses in TablesNamesFinder

### DIFF
--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -154,10 +154,14 @@ import net.sf.jsqlparser.statement.select.FromItemVisitor;
 import net.sf.jsqlparser.statement.select.FunctionAllColumns;
 import net.sf.jsqlparser.statement.select.Join;
 import net.sf.jsqlparser.statement.select.LateralSubSelect;
+import net.sf.jsqlparser.statement.select.LateralView;
 import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.ParenthesedFromItem;
 import net.sf.jsqlparser.statement.select.ParenthesedSelect;
+import net.sf.jsqlparser.statement.select.Pivot;
 import net.sf.jsqlparser.statement.select.PivotQuery;
+import net.sf.jsqlparser.statement.select.PivotVisitor;
+import net.sf.jsqlparser.statement.select.PivotXml;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.select.SelectItem;
@@ -165,6 +169,7 @@ import net.sf.jsqlparser.statement.select.SelectItemVisitor;
 import net.sf.jsqlparser.statement.select.SelectVisitor;
 import net.sf.jsqlparser.statement.select.SetOperationList;
 import net.sf.jsqlparser.statement.select.TableFunction;
+import net.sf.jsqlparser.statement.select.UnPivot;
 import net.sf.jsqlparser.statement.select.TableStatement;
 import net.sf.jsqlparser.statement.select.Values;
 import net.sf.jsqlparser.statement.select.WithItem;
@@ -187,7 +192,7 @@ import net.sf.jsqlparser.statement.upsert.Upsert;
 public class TablesNamesFinder<Void>
         implements SelectVisitor<Void>, FromItemVisitor<Void>, ExpressionVisitor<Void>,
         SelectItemVisitor<Void>, StatementVisitor<Void>, MergeOperationVisitor<Void>,
-        PipeOperatorVisitor<Void, Void> {
+        PipeOperatorVisitor<Void, Void>, PivotVisitor<Void> {
 
     private Set<String> tables;
     private boolean allowColumnProcessing = false;
@@ -330,6 +335,20 @@ public class TablesNamesFinder<Void>
             }
         }
         select.getSelect().accept((SelectVisitor<?>) this, context);
+        visitOrderBy(select.getOrderByElements(), context);
+        if (select.getPivot() != null) {
+            select.getPivot().accept(this, context);
+        }
+        if (select.getUnPivot() != null) {
+            select.getUnPivot().accept(this, context);
+        }
+        visitLimit(select.getLimit(), context);
+        if (select.getOffset() != null) {
+            select.getOffset().getOffset().accept(this, context);
+        }
+        if (select.getFetch() != null) {
+            select.getFetch().getExpression().accept(this, context);
+        }
         return null;
     }
 
@@ -346,6 +365,11 @@ public class TablesNamesFinder<Void>
                 withItem.accept((SelectVisitor<?>) this, context);
             }
         }
+        if (plainSelect.getDistinct() != null) {
+            visitSelectItems(plainSelect.getDistinct().getOnSelectItems(), context);
+        }
+        visitTables(plainSelect.getIntoTables(), context);
+
         if (plainSelect.getSelectItems() != null) {
             for (SelectItem<?> item : plainSelect.getSelectItems()) {
                 item.accept(this, context);
@@ -356,6 +380,12 @@ public class TablesNamesFinder<Void>
             plainSelect.getFromItem().accept(this, context);
         }
 
+        if (plainSelect.getLateralViews() != null) {
+            for (LateralView lateralView : plainSelect.getLateralViews()) {
+                lateralView.getGeneratorFunction().accept(this, context);
+            }
+        }
+
         visitJoins(plainSelect.getJoins(), context);
         if (plainSelect.getPreWhere() != null) {
             plainSelect.getPreWhere().accept(this, context);
@@ -364,13 +394,46 @@ public class TablesNamesFinder<Void>
             plainSelect.getWhere().accept(this, context);
         }
 
+        visitPreferringClause(plainSelect.getPreferringClause(), context);
+        visit(plainSelect.getGroupBy(), context);
+
         if (plainSelect.getHaving() != null) {
             plainSelect.getHaving().accept(this, context);
+        }
+
+        if (plainSelect.getQualify() != null) {
+            plainSelect.getQualify().accept(this, context);
         }
 
         if (plainSelect.getOracleHierarchical() != null) {
             plainSelect.getOracleHierarchical().accept(this, context);
         }
+
+        if (plainSelect.getWindowDefinitions() != null) {
+            for (WindowDefinition windowDefinition : plainSelect.getWindowDefinitions()) {
+                visitExpressions(windowDefinition.getPartitionExpressionList(), context);
+                visitOrderBy(windowDefinition.getOrderByElements(), context);
+            }
+        }
+
+        if (plainSelect.getPivot() != null) {
+            plainSelect.getPivot().accept(this, context);
+        }
+        if (plainSelect.getUnPivot() != null) {
+            plainSelect.getUnPivot().accept(this, context);
+        }
+
+        visitOrderBy(plainSelect.getOrderByElements(), context);
+        visitLimit(plainSelect.getLimit(), context);
+        visitLimit(plainSelect.getLimitBy(), context);
+        if (plainSelect.getOffset() != null) {
+            plainSelect.getOffset().getOffset().accept(this, context);
+        }
+        if (plainSelect.getFetch() != null) {
+            plainSelect.getFetch().getExpression().accept(this, context);
+        }
+        visitUpdateSets(plainSelect.getSettings(), context);
+        visitFromItem(plainSelect.getIntoTempTable(), context);
         return null;
     }
 
@@ -430,6 +493,12 @@ public class TablesNamesFinder<Void>
         String tableWholeName = extractTableName(table);
         if (!otherItemNames.contains(tableWholeName)) {
             tables.add(tableWholeName);
+        }
+        if (table.getPivot() != null) {
+            table.getPivot().accept(this, context);
+        }
+        if (table.getUnPivot() != null) {
+            table.getUnPivot().accept(this, context);
         }
         return null;
     }
@@ -883,6 +952,14 @@ public class TablesNamesFinder<Void>
         for (Select selectBody : list.getSelects()) {
             selectBody.accept((SelectVisitor<?>) this, context);
         }
+        visitOrderBy(list.getOrderByElements(), context);
+        visitLimit(list.getLimit(), context);
+        if (list.getOffset() != null) {
+            list.getOffset().getOffset().accept(this, context);
+        }
+        if (list.getFetch() != null) {
+            list.getFetch().getExpression().accept(this, context);
+        }
         return null;
     }
 
@@ -938,6 +1015,36 @@ public class TablesNamesFinder<Void>
         for (PipeOperator pipeOperator : fromQuery.getPipeOperators()) {
             pipeOperator.accept(this, null);
         }
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(Pivot pivot, S context) {
+        visitSelectItems(pivot.getFunctionItems(), context);
+        visitExpressions(pivot.getForColumns(), context);
+        visitSelectItems(pivot.getSingleInItems(), context);
+        visitSelectItems(pivot.getMultiInItems(), context);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(PivotXml pivotXml, S context) {
+        visit((Pivot) pivotXml, context);
+        if (pivotXml.getInSelect() != null) {
+            pivotXml.getInSelect().accept((SelectVisitor<?>) this, context);
+        }
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(UnPivot unpivot, S context) {
+        for (Column column : unpivot.getUnPivotClause()) {
+            column.accept(this, context);
+        }
+        for (Column column : unpivot.getUnPivotForClause()) {
+            column.accept(this, context);
+        }
+        visitSelectItems(unpivot.getUnPivotInClause(), context);
         return null;
     }
 
@@ -1220,6 +1327,8 @@ public class TablesNamesFinder<Void>
         if (delete.getWhere() != null) {
             delete.getWhere().accept(this, context);
         }
+        visitOrderBy(delete.getOrderByElements(), context);
+        visitLimit(delete.getLimit(), context);
         visitOutputClause(delete.getOutputClause(), context);
         visitReturningClause(delete.getReturningClause(), context);
         return null;
@@ -1279,6 +1388,8 @@ public class TablesNamesFinder<Void>
         if (update.getWhere() != null) {
             update.getWhere().accept(this, context);
         }
+        visitOrderBy(update.getOrderByElements(), context);
+        visitLimit(update.getLimit(), context);
         visitOutputClause(update.getOutputClause(), context);
         visitReturningClause(update.getReturningClause(), context);
         return null;
@@ -1790,6 +1901,14 @@ public class TablesNamesFinder<Void>
     @Override
     public <S> Void visit(Values values, S context) {
         values.getExpressions().accept(this, context);
+        visitOrderBy(values.getOrderByElements(), context);
+        visitLimit(values.getLimit(), context);
+        if (values.getOffset() != null) {
+            values.getOffset().getOffset().accept(this, context);
+        }
+        if (values.getFetch() != null) {
+            values.getFetch().getExpression().accept(this, context);
+        }
         return null;
     }
 

--- a/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
@@ -907,4 +907,163 @@ public class TablesNamesFinderTest {
                 "MY_TABLE2");
     }
 
+    @Test
+    void testSelectIntoTables() throws JSQLParserException {
+        String sqlStr = "SELECT * INTO MY_TABLE1 FROM MY_TABLE2";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testSelectIntoTempTable() throws JSQLParserException {
+        String sqlStr = "SELECT * FROM MY_TABLE2 INTO TEMP MY_TABLE1";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testGroupBySubquery() throws JSQLParserException {
+        String sqlStr =
+                "SELECT A FROM MY_TABLE1 GROUP BY A, (SELECT B FROM MY_TABLE2)";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testGroupByGroupingSetsSubquery() throws JSQLParserException {
+        String sqlStr =
+                "SELECT A FROM MY_TABLE1 GROUP BY GROUPING SETS ((A, (SELECT B FROM MY_TABLE2)), (C))";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testSelectQualifySubquery() throws JSQLParserException {
+        String sqlStr = "SELECT * FROM MY_TABLE1 QUALIFY (SELECT B FROM MY_TABLE2) = 1";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testWindowDefinitionSubquery() throws JSQLParserException {
+        String sqlStr =
+                "SELECT * FROM MY_TABLE1 WINDOW W AS (PARTITION BY (SELECT B FROM MY_TABLE2))";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testSelectOrderBySubquery() throws JSQLParserException {
+        String sqlStr = "SELECT A FROM MY_TABLE1 ORDER BY A, (SELECT B FROM MY_TABLE2)";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testSelectLimitSubquery() throws JSQLParserException {
+        String sqlStr = "SELECT A FROM MY_TABLE1 LIMIT (SELECT B FROM MY_TABLE2)";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testSelectLimitBySubquery() throws JSQLParserException {
+        String sqlStr = "SELECT A FROM MY_TABLE1 LIMIT 2 BY (SELECT B FROM MY_TABLE2)";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testSelectOffsetSubquery() throws JSQLParserException {
+        String sqlStr =
+                "SELECT A FROM MY_TABLE1 LIMIT 1 OFFSET (SELECT B FROM MY_TABLE2)";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testSelectFetchSubquery() throws JSQLParserException {
+        String sqlStr =
+                "SELECT A FROM MY_TABLE1 OFFSET 1 ROWS FETCH NEXT (SELECT B FROM MY_TABLE2) ROWS ONLY";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testSelectDistinctOnSubquery() throws JSQLParserException {
+        String sqlStr = "SELECT DISTINCT ON ((SELECT B FROM MY_TABLE2)) A FROM MY_TABLE1";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testLateralViewSubquery() throws JSQLParserException {
+        String sqlStr =
+                "SELECT * FROM MY_TABLE1 LATERAL VIEW EXPLODE(ARRAY((SELECT B FROM MY_TABLE2))) V AS X";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testTablePivotXmlSubquery() throws JSQLParserException {
+        String sqlStr =
+                "SELECT * FROM MY_TABLE1 PIVOT XML (SUM(X) FOR Y IN (SELECT Z FROM MY_TABLE2))";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testTablePivotSimple() throws JSQLParserException {
+        String sqlStr = "SELECT * FROM MY_TABLE1 PIVOT (SUM(X) FOR Y IN ('a', 'b'))";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1");
+    }
+
+    @Test
+    void testParenthesedOrderByLimitSubquery() throws JSQLParserException {
+        String sqlStr =
+                "(SELECT A FROM MY_TABLE1) ORDER BY (SELECT B FROM MY_TABLE2) LIMIT (SELECT C FROM MY_TABLE3)";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2", "MY_TABLE3");
+    }
+
+    @Test
+    void testSetOperationOrderByLimitSubquery() throws JSQLParserException {
+        String sqlStr =
+                "SELECT A FROM MY_TABLE1 UNION SELECT B FROM MY_TABLE2 ORDER BY (SELECT C FROM MY_TABLE3) LIMIT (SELECT D FROM MY_TABLE4)";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2", "MY_TABLE3", "MY_TABLE4");
+    }
+
+    @Test
+    void testSelectSettingsSubquery() throws JSQLParserException {
+        String sqlStr =
+                "SELECT A FROM MY_TABLE1 SETTINGS X = (SELECT B FROM MY_TABLE2)";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testValuesOrderByLimitSubquery() throws JSQLParserException {
+        String sqlStr =
+                "VALUES (1), (2) ORDER BY (SELECT A FROM MY_TABLE1) LIMIT (SELECT B FROM MY_TABLE2)";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testDeleteOrderByLimitSubquery() throws JSQLParserException {
+        String sqlStr =
+                "DELETE FROM MY_TABLE1 WHERE A = 1 ORDER BY (SELECT B FROM MY_TABLE2) LIMIT 2";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
+    @Test
+    void testUpdateOrderByLimitSubquery() throws JSQLParserException {
+        String sqlStr =
+                "UPDATE MY_TABLE1 SET A = 1 ORDER BY (SELECT B FROM MY_TABLE2) LIMIT 2";
+        assertThat(TablesNamesFinder.findTables(sqlStr)).containsExactlyInAnyOrder("MY_TABLE1",
+                "MY_TABLE2");
+    }
+
 }


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What

`TablesNamesFinder` now traverses all Expression- and Table-bearing clauses of the SELECT family and the DML trailing clauses it previously skipped, so tables located in those clauses are collected instead of silently dropped.

## Why

`TablesNamesFinder` is the public helper for table extraction (SQL analysis, auditing, firewalls); a silently incomplete result is the worst failure mode for those consumers. All shapes in #2516 parse fine today and return incomplete table sets. This continues the family fixed by #2478 / #2479 (piped queries, DML side clauses, analytic clauses).

## How

- `PlainSelect`: DISTINCT ON items, INTO tables, LATERAL VIEW generator functions, PREFERRING, GROUP BY (incl. GROUPING SETS), QUALIFY, WINDOW definitions, PIVOT / UNPIVOT, ORDER BY, LIMIT / LIMIT BY, OFFSET, FETCH, SETTINGS, INTO TEMP target.
- `ParenthesedSelect`, `SetOperationList`, `Values`: the ORDER BY / LIMIT / OFFSET / FETCH clauses they carry themselves.
- `Delete`, `Update`: their ORDER BY and LIMIT clauses (MySQL single-table DML).
- Attached PIVOT / UNPIVOT / PIVOT XML (incl. the `PIVOT XML ... IN (SELECT ...)` subquery) is reached via the newly implemented `PivotVisitor`, the same mechanism as `MergeOperationVisitor` / `PipeOperationVisitor` in #2479.

All traversals reuse the `ExpressionVisitor` / `FromItemVisitor` default helpers (`visitOrderBy`, `visitLimit`, `visit(GroupByElement)`, `visitUpdateSets`, `visitPreferringClause`, `visitTables`, `visitFromItem`) already used by `SelectVisitorAdapter` and `StatementVisitorAdapter`. Two `SelectVisitorAdapter` `@todo`s (`windowDefinitions`, `lateralViews`) are covered too, because both can carry subqueries.

## Root cause

The finder's visit methods traversed only a subset of the Expression- and Table-bearing children; the adapters already covered most of these clauses, the finder did not.

## Testing

- 21 new tests in `TablesNamesFinderTest`, one per shape from #2516: each failed on master before the change and passes with it. Two mutants verified (removing the INTO traversal and the Table pivot traversal makes their tests fail).
- Local run: `gradlew test --tests TablesNamesFinderTest` -> 106 passed.
- Not covered on purpose: clauses that cannot hold tables (MySQL `INTO OUTFILE/DUMPFILE` fields, `TOP`, Oracle hint, procedure analyse, KSQL window, OPTION clause).

## Verification of the original issue

```java
TablesNamesFinder.findTables("SELECT a FROM t GROUP BY a, (SELECT b FROM u)");
// before: [t]    after: [t, u]
```

With this change every shape in the #2516 matrix returns the complete table set.

Fixes #2516
