### PR TITLE
fix: prevent bare partition columns from inheriting the previous item's value

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4065,7 +4065,7 @@ List<Partition> Partitions():
     (
         LOOKAHEAD(2) (
             ","
-            tableColumn=Column() [ "=" valueExpression=Expression() ]
+            tableColumn=Column() { valueExpression = null; } [ "=" valueExpression=Expression() ]
             { partitions.add( new Partition (tableColumn, valueExpression)); }
         )
     )*

--- a/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
@@ -966,6 +966,58 @@ public class InsertTest {
         assertFalse(insert.isOverwrite());
     }
 
+    @Test
+    // a dynamic partition column without a value must not inherit the value of a
+    // preceding static partition column (#2500)
+    void testInsertMixedStaticAndDynamicPartitions() throws JSQLParserException {
+        String sqlStr =
+                "INSERT OVERWRITE TABLE t PARTITION (dtime = '2024-04-03', region) SELECT * FROM a";
+        Insert insert = (Insert) assertSqlCanBeParsedAndDeparsed(sqlStr);
+        assertEquals(2, insert.getPartitions().size());
+        assertEquals("dtime", insert.getPartitions().get(0).getColumn().getColumnName());
+        assertEquals("'2024-04-03'", insert.getPartitions().get(0).getValue().toString());
+        assertEquals("region", insert.getPartitions().get(1).getColumn().getColumnName());
+        assertNull(insert.getPartitions().get(1).getValue());
+
+        sqlStr =
+                "INSERT OVERWRITE TABLE t PARTITION (region, dtime = '2024-04-03') SELECT * FROM a";
+        insert = (Insert) assertSqlCanBeParsedAndDeparsed(sqlStr);
+        assertEquals(2, insert.getPartitions().size());
+        assertEquals("region", insert.getPartitions().get(0).getColumn().getColumnName());
+        assertNull(insert.getPartitions().get(0).getValue());
+        assertEquals("dtime", insert.getPartitions().get(1).getColumn().getColumnName());
+        assertEquals("'2024-04-03'", insert.getPartitions().get(1).getValue().toString());
+
+        sqlStr = "INSERT OVERWRITE TABLE t PARTITION"
+                + " (dtime = '2024-04-03', region, dept) SELECT * FROM a";
+        insert = (Insert) assertSqlCanBeParsedAndDeparsed(sqlStr);
+        assertEquals(3, insert.getPartitions().size());
+        assertEquals("dtime", insert.getPartitions().get(0).getColumn().getColumnName());
+        assertEquals("'2024-04-03'", insert.getPartitions().get(0).getValue().toString());
+        assertEquals("region", insert.getPartitions().get(1).getColumn().getColumnName());
+        assertNull(insert.getPartitions().get(1).getValue());
+        assertEquals("dept", insert.getPartitions().get(2).getColumn().getColumnName());
+        assertNull(insert.getPartitions().get(2).getValue());
+
+        sqlStr = "INSERT OVERWRITE TABLE t PARTITION (a, b = '1', c) SELECT * FROM a";
+        insert = (Insert) assertSqlCanBeParsedAndDeparsed(sqlStr);
+        assertEquals(3, insert.getPartitions().size());
+        assertEquals("a", insert.getPartitions().get(0).getColumn().getColumnName());
+        assertNull(insert.getPartitions().get(0).getValue());
+        assertEquals("b", insert.getPartitions().get(1).getColumn().getColumnName());
+        assertEquals("'1'", insert.getPartitions().get(1).getValue().toString());
+        assertEquals("c", insert.getPartitions().get(2).getColumn().getColumnName());
+        assertNull(insert.getPartitions().get(2).getValue());
+
+        sqlStr = "INSERT INTO TABLE t PARTITION (dtime = 20240403, region) SELECT * FROM a";
+        insert = (Insert) assertSqlCanBeParsedAndDeparsed(sqlStr);
+        assertEquals(2, insert.getPartitions().size());
+        assertEquals("dtime", insert.getPartitions().get(0).getColumn().getColumnName());
+        assertEquals("20240403", insert.getPartitions().get(0).getValue().toString());
+        assertNull(insert.getPartitions().get(1).getValue());
+        assertFalse(insert.isOverwrite());
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
             "INSERT INTO mytable (foo) OVERRIDING SYSTEM VALUE VALUES (1)",


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What

A bare (dynamic) partition column no longer inherits the value expression of the preceding item in a mixed `INSERT ... PARTITION (...)` list; it keeps `null` again, as before #2323.

## Why

With a static item followed by a bare one, the deparser output silently turned the dynamic column into a constant assignment, changing the statement's semantics for Hive mixed static/dynamic partition writes (#2500).

## How

`Partitions()` declares one `valueExpression` for the whole production and the optional `"=" Expression()` unit leaves the previous item's value in place when skipped. The list loop arm now resets `valueExpression = null` before the optional unit, the same idiom already used by `DeclareType`, `Alias` and `ColumnsNamesList` for their list items. No AST, deparser or visitor change: `Partition` already renders a bare column when the value is `null`.

## Root cause

Production-level `valueExpression` in `Partitions()` is shared across list items and was not reset when an item skipped the optional value (introduced with #2323).

## Testing

- New `InsertTest#testInsertMixedStaticAndDynamicPartitions` covers the full #2500 combination table: static -> bare, bare -> static, static -> bare -> bare, bare -> static -> bare, and `INSERT INTO` with a numeric value. All wrong rows fail on master and pass with the change; the two correct rows are pinned as guards. Two mutants verified: removing the reset and misplacing it after the optional unit both turn the test red.
- Local run: `gradlew test --tests InsertTest` -> 79 passed.
- No jmh run: `performance.sql` contains no `PARTITION` clause, the changed action is not reached by the benchmark.

## Verification of the original issue

```java
Insert insert = (Insert) CCJSqlParserUtil.parse(
        "INSERT OVERWRITE TABLE t PARTITION (dtime = '20220403', region) SELECT code, region FROM src");
// before: dtime -> '20220403', region -> '20220403'  (wrong)
// after:  dtime -> '20220403', region -> null        (correct)
```

Fixes #2500
