### PR TITLE
fix: memoize long-chain predicate walks behind a size threshold

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -347,15 +347,55 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
      * from column references like col, schema.col, a.b.c.col.
      *
      * Replaces LOOKAHEAD(16) on Function() with a targeted O(chain-length) check.
+     * Long chains are memoized per start token: the phase-2 lookahead routines
+     * re-evaluate the same walk many times per position and each chain part
+     * would walk the very same suffix again, which makes long chains parse in
+     * quadratic time. Chains up to CHAIN_CACHE_THRESHOLD parts skip the cache
+     * entirely, keeping the normal short-name path allocation- and map-free.
      */
+    private static final int CHAIN_CACHE_THRESHOLD = 8;
+
+    // Sentinel returned by the chain walks when the non-filling pass ran past
+    // CHAIN_CACHE_THRESHOLD delimiter/part pairs and the caller must retry
+    // through the per-token cache.
+    private static final int LONG_CHAIN = -1;
+
+    private final Map<Token, Boolean> isFunctionAheadCache = new HashMap<Token, Boolean>();
+
     protected boolean isFunctionAhead() {
+        int r = isFunctionAheadWalk(false);
+        if (r != LONG_CHAIN) {
+            return r == 1;
+        }
+        Token key = getToken(1);
+        Boolean cached = isFunctionAheadCache.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        boolean result = isFunctionAheadWalk(true) == 1;
+        isFunctionAheadCache.put(key, result);
+        return result;
+    }
+
+    // True when a fresh evaluation started at this token would pass all
+    // first-token guards and run the same chain walk.
+    private boolean isFunctionAheadChainStartEligible(Token t) {
+        return !t.image.equals("{") && t.kind != K_APPROXIMATE && !isNonFunctionKeyword(t)
+                && t.kind != S_LONG && t.kind != S_DOUBLE && t.kind != S_HEX
+                && t.kind != S_CHAR_LITERAL && t.kind != OPENING_BRACKET
+                && t.kind != CLOSING_BRACKET && t.kind != EOF;
+    }
+
+    // Returns 1 for true, 0 for false, or LONG_CHAIN when the walk exceeded
+    // CHAIN_CACHE_THRESHOLD delimiter/part pairs (only in the non-filling pass).
+    private int isFunctionAheadWalk(boolean fill) {
       try {
         int i = 1;
         Token t = getToken(i);
 
         // JDBC escape function: {fn ...} — must check for FN keyword
         if (t.image.equals("{")) {
-            return getToken(2).kind == K_FN;
+            return getToken(2).kind == K_FN ? 1 : 0;
         }
 
         // Optional APPROXIMATE keyword
@@ -367,22 +407,30 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
         // Exclude tokens that have their own dedicated branches
         // after Function() in PrimaryExpression
         if (isNonFunctionKeyword(t)) {
-            return false;
+            return 0;
         }
 
         // First token must not be a literal, bracket, or EOF
         if (t.kind == S_LONG || t.kind == S_DOUBLE || t.kind == S_HEX
                 || t.kind == S_CHAR_LITERAL || t.kind == OPENING_BRACKET
                 || t.kind == CLOSING_BRACKET || t.kind == EOF) {
-            return false;
+            return 0;
         }
         i++;
 
         // Walk through dotted name chain
+        int delimiters = 0;
+        List<Token> chainParts = fill ? new ArrayList<Token>() : null;
         while (true) {
             t = getToken(i);
             if (t.image.equals(".") || t.image.equals("..")
                     || t.image.equals("...") || t.image.equals(":")) {
+                if (!fill && ++delimiters > CHAIN_CACHE_THRESHOLD) {
+                    return LONG_CHAIN;
+                }
+                if (fill) {
+                    chainParts.add(getToken(i + 1));
+                }
                 i++;  // skip delimiter
                 i++;  // skip next name part
             } else {
@@ -390,20 +438,23 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
             }
         }
 
-        // Must be followed by (
-        if (getToken(i).kind != OPENING_BRACKET) {
-            return false;
-        }
+        // Must be followed by (, and not by the Oracle join syntax column(+)
+        boolean result = getToken(i).kind == OPENING_BRACKET
+                && !(getToken(i + 1).image.equals("+")
+                        && getToken(i + 2).kind == CLOSING_BRACKET);
 
-        // Exclude Oracle join syntax: column(+)
-        if (getToken(i + 1).image.equals("+")
-                && getToken(i + 2).kind == CLOSING_BRACKET) {
-            return false;
+        // Each eligible chain part would walk the same remaining suffix and
+        // obtain the same answer, so memoize them all in one pass.
+        if (fill) {
+            for (Token part : chainParts) {
+                if (isFunctionAheadChainStartEligible(part)) {
+                    isFunctionAheadCache.put(part, result);
+                }
+            }
         }
-
-        return true;
+        return result ? 1 : 0;
       } catch (TokenMgrException e) {
-        return false;
+        return 0;
       }
     }
 
@@ -736,8 +787,30 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
     /**
      * Scans ahead through a dotted identifier chain and checks if '*' follows.
      * Identifies table.* patterns for AllTableColumns.
+     * Long chains are memoized per start token like {@link #isFunctionAhead()}
+     * (one walk fills every eligible chain part); short chains skip the cache.
      */
+    private final Map<Token, Boolean> isAllTableColumnsAheadCache =
+            new HashMap<Token, Boolean>();
+
     protected boolean isAllTableColumnsAhead() {
+        int r = isAllTableColumnsWalk(false);
+        if (r != LONG_CHAIN) {
+            return r == 1;
+        }
+        Token key = getToken(1);
+        Boolean cached = isAllTableColumnsAheadCache.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        boolean result = isAllTableColumnsWalk(true) == 1;
+        isAllTableColumnsAheadCache.put(key, result);
+        return result;
+    }
+
+    // Returns 1 for true, 0 for false, or LONG_CHAIN when the walk exceeded
+    // CHAIN_CACHE_THRESHOLD delimiter/part pairs (only in the non-filling pass).
+    private int isAllTableColumnsWalk(boolean fill) {
         int i = 1;
         Token t = getToken(i);
 
@@ -745,15 +818,23 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
         if (t.kind == S_LONG || t.kind == S_DOUBLE || t.kind == S_HEX
                 || t.kind == S_CHAR_LITERAL || t.kind == OPENING_BRACKET
                 || t.kind == CLOSING_BRACKET || t.kind == EOF) {
-            return false;
+            return 0;
         }
         i++;
 
         // Walk through dotted name chain
+        int delimiters = 0;
+        List<Token> chainParts = fill ? new ArrayList<Token>() : null;
         while (true) {
             t = getToken(i);
             if (t.image.equals(".") || t.image.equals("..")
                     || t.image.equals("...")) {
+                if (!fill && ++delimiters > CHAIN_CACHE_THRESHOLD) {
+                    return LONG_CHAIN;
+                }
+                if (fill) {
+                    chainParts.add(getToken(i + 1));
+                }
                 i++;  // skip delimiter
                 i++;  // skip next part (could be "*")
             } else {
@@ -764,7 +845,21 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
         // It's AllTableColumns if the chain ended on "*"
         // i.e., the last name part we skipped over was "*"
         // Back up: the last token consumed was at (i-1)
-        return getToken(i - 1).image.equals("*");
+        boolean result = getToken(i - 1).image.equals("*");
+
+        // Each chain part that would pass the name-like guard walks the same
+        // remaining suffix and obtains the same answer.
+        if (fill) {
+            for (Token part : chainParts) {
+                if (part.kind == S_LONG || part.kind == S_DOUBLE || part.kind == S_HEX
+                        || part.kind == S_CHAR_LITERAL || part.kind == OPENING_BRACKET
+                        || part.kind == CLOSING_BRACKET || part.kind == EOF) {
+                    continue;
+                }
+                isAllTableColumnsAheadCache.put(part, result);
+            }
+        }
+        return result ? 1 : 0;
     }
 
     /**

--- a/src/test/java/net/sf/jsqlparser/parser/LongChainPredicateTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/LongChainPredicateTest.java
@@ -1,0 +1,94 @@
+package net.sf.jsqlparser.parser;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.sf.jsqlparser.expression.Function;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.select.AllTableColumns;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.Select;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the threshold-gated chain-walk memoization in isFunctionAhead() /
+ * isAllTableColumnsAhead(): chains on both sides of CHAIN_CACHE_THRESHOLD and inside the memoized
+ * path must keep the exact same AST shapes as the plain walk. The speed-up itself is
+ * constant-factor only and is carried by the measured numbers, not by a CI timing assertion.
+ */
+public class LongChainPredicateTest {
+
+    private static String chain(int innerDelimiters, String last) {
+        // innerDelimiters = dots between s0..sN (chain length before the last part)
+        StringBuilder sb = new StringBuilder("s0");
+        for (int i = 1; i <= innerDelimiters; i++) {
+            sb.append(".s").append(i);
+        }
+        return sb.append(".").append(last).toString();
+    }
+
+    private Object firstExpression(String sql) throws Exception {
+        Select select = (Select) CCJSqlParserUtil.parse(sql);
+        return ((PlainSelect) select).getSelectItems().get(0).getExpression();
+    }
+
+    @Test
+    void functionOnShortChainFastPath() throws Exception {
+        // total 8 delimiters: the walk stays inside the plain non-cached path
+        String sql = "SELECT " + chain(7, "f(1)") + " FROM t";
+        assertSqlCanBeParsedAndDeparsed(sql);
+        assertTrue(firstExpression(sql) instanceof Function,
+                "8-delimiter chain ending in ( must stay a Function");
+    }
+
+    @Test
+    void functionOnLongChainMemoPath() throws Exception {
+        // total 9 delimiters: the walk aborts past the threshold and goes through the cache
+        String sql = "SELECT " + chain(8, "f(1)") + " FROM t";
+        assertSqlCanBeParsedAndDeparsed(sql);
+        assertTrue(firstExpression(sql) instanceof Function,
+                "9-delimiter chain ending in ( must stay a Function on the memoized path");
+    }
+
+    @Test
+    void columnOnShortChainFastPath() throws Exception {
+        String sql = "SELECT " + chain(7, "col") + " FROM t";
+        assertSqlCanBeParsedAndDeparsed(sql);
+        assertTrue(firstExpression(sql) instanceof Column);
+        assertFalse(firstExpression(sql) instanceof Function);
+    }
+
+    @Test
+    void columnOnLongChainMemoPath() throws Exception {
+        String sql = "SELECT " + chain(8, "col") + " FROM t";
+        assertSqlCanBeParsedAndDeparsed(sql);
+        assertTrue(firstExpression(sql) instanceof Column);
+        assertFalse(firstExpression(sql) instanceof Function);
+    }
+
+    @Test
+    void columnOnVeryLongChainMemoPath() throws Exception {
+        String sql = "SELECT " + chain(40, "col") + " FROM t";
+        assertSqlCanBeParsedAndDeparsed(sql);
+        assertTrue(firstExpression(sql) instanceof Column);
+    }
+
+    @Test
+    void allTableColumnsAcrossThreshold() throws Exception {
+        String shortChain = "SELECT " + chain(7, "*") + " FROM t";
+        assertSqlCanBeParsedAndDeparsed(shortChain);
+        assertTrue(firstExpression(shortChain) instanceof AllTableColumns);
+
+        String longChain = "SELECT " + chain(8, "*") + " FROM t";
+        assertSqlCanBeParsedAndDeparsed(longChain);
+        assertTrue(firstExpression(longChain) instanceof AllTableColumns);
+    }
+
+    @Test
+    void oracleOuterJoinColumnPlusOnMemoPath() throws Exception {
+        // the column(+) exclusion must survive the memoized walk
+        assertSqlCanBeParsedAndDeparsed(
+                "SELECT * FROM a, b WHERE " + chain(8, "x(+)") + " = b.x");
+    }
+}


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What

Dotted-name chains longer than 8 parts are now memoized in `isFunctionAhead()` / `isAllTableColumnsAhead()`: the walk aborts past the threshold, restarts through a per-start-token cache, and one filling walk records the answer for every eligible chain part. Chains within the threshold keep the plain single walk, with no map access and no allocation.

## Why

`SELECT a.b.b...` with 8000 parts parses in ~1.8 s on master and stays super-linear; the predicates walk the whole remaining chain unbounded and the phase-2 lookahead re-evaluates them at every position. Addresses the predicate-layer share of #2519; the engine-layer share (phase-2 re-simulation, also behind the nested-parentheses family) stays open there.

## How

Threshold gate merged into the walk itself: the non-filling pass returns a `LONG_CHAIN` sentinel past 8 delimiter/part pairs and the caller retries through the cache, so short chains cost exactly one plain walk plus one counter compare. The filling pass records the result for every chain part that would pass the same first-token guards (each part walks the identical suffix). Caches die with the parser instance.

## Root cause

Unbounded O(chain) walks x O(positions) re-evaluation = quadratic predicate cost, isolated as one of two layers in #2519.

## Testing

- New `LongChainPredicateTest`: AST shapes pinned on both sides of the threshold (8/9 delimiters), a 40-part chain, `t.*` across the threshold, and the Oracle `column(+)` exclusion on the memoized path. All green before and after (behavior guard); a head-result mutant turns all 7 red.
- Local run: `gradlew test --tests LongChainPredicateTest` -> 7 passed; full suite 4979/0.
- No CI timing assertion: the improvement is constant-factor (~2.4x at 8000 parts) and no machine-independent budget separates it.
- jmh, `JSQLParserBenchmark.parseSQLStatements` on performance.sql, version=latest, 10 forks x 10 iterations (100 samples) per run, interleaved master/branch x2 on a 32-core host: master 3.769/3.767 vs branch 3.783/3.799 ms/op, CIs overlap -> no regression.

## Verification of the original issue

```java
CCJSqlParserUtil.parse("SELECT a" + ".b".repeat(8000) + " FROM t");
// before: 1847 ms   after: 775 ms  (still super-linear overall: the engine layer remains, see #2519)
```

If the fork-side phase-2 fix lands and makes this redundant, closing this PR is perfectly fine.

Related to #2519 (no Fixes: the issue tracks both families and the engine layer).
