### PR TITLE
Support PostgreSQL CREATE INDEX header variants

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
@@ -23,6 +23,8 @@ public class CreateIndex implements Statement {
     private List<String> tailParameters;
     private boolean indexTypeBeforeOn = false;
     private boolean usingIfNotExists = false;
+    private boolean concurrently;
+    private boolean only;
 
     public boolean isIndexTypeBeforeOn() {
         return indexTypeBeforeOn;
@@ -39,6 +41,22 @@ public class CreateIndex implements Statement {
     public CreateIndex setUsingIfNotExists(boolean usingIfNotExists) {
         this.usingIfNotExists = usingIfNotExists;
         return this;
+    }
+
+    public boolean isConcurrently() {
+        return concurrently;
+    }
+
+    public void setConcurrently(boolean concurrently) {
+        this.concurrently = concurrently;
+    }
+
+    public boolean isOnly() {
+        return only;
+    }
+
+    public void setOnly(boolean only) {
+        this.only = only;
     }
 
     @Override
@@ -82,17 +100,24 @@ public class CreateIndex implements Statement {
         }
 
         buffer.append("INDEX ");
+        if (concurrently) {
+            buffer.append("CONCURRENTLY ");
+        }
         if (usingIfNotExists) {
             buffer.append("IF NOT EXISTS ");
         }
-        buffer.append(index.getName());
-
-        if (index.getUsing() != null && isIndexTypeBeforeOn()) {
-            buffer.append(" USING ");
-            buffer.append(index.getUsing());
+        if (index.getName() != null) {
+            buffer.append(index.getName()).append(" ");
         }
 
-        buffer.append(" ON ");
+        if (index.getUsing() != null && isIndexTypeBeforeOn()) {
+            buffer.append("USING ").append(index.getUsing()).append(" ");
+        }
+
+        buffer.append("ON ");
+        if (only) {
+            buffer.append("ONLY ");
+        }
         buffer.append(table.getFullyQualifiedName());
 
         if (index.getUsing() != null && !isIndexTypeBeforeOn()) {
@@ -132,6 +157,16 @@ public class CreateIndex implements Statement {
 
     public CreateIndex withTailParameters(List<String> tailParameters) {
         this.setTailParameters(tailParameters);
+        return this;
+    }
+
+    public CreateIndex withConcurrently(boolean concurrently) {
+        setConcurrently(concurrently);
+        return this;
+    }
+
+    public CreateIndex withOnly(boolean only) {
+        setOnly(only);
         return this;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/CreateIndexDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/CreateIndexDeParser.java
@@ -32,18 +32,25 @@ public class CreateIndexDeParser extends AbstractDeParser<CreateIndex> {
         }
 
         builder.append("INDEX ");
+        if (createIndex.isConcurrently()) {
+            builder.append("CONCURRENTLY ");
+        }
         if (createIndex.isUsingIfNotExists()) {
             builder.append("IF NOT EXISTS ");
         }
-        builder.append(index.getName());
+        if (index.getName() != null) {
+            builder.append(index.getName()).append(" ");
+        }
 
         String using = index.getUsing();
         if (using != null && createIndex.isIndexTypeBeforeOn()) {
-            builder.append(" USING ");
-            builder.append(using);
+            builder.append("USING ").append(using).append(" ");
         }
 
-        builder.append(" ON ");
+        builder.append("ON ");
+        if (createIndex.isOnly()) {
+            builder.append("ONLY ");
+        }
         builder.append(createIndex.getTable().getFullyQualifiedName());
 
         if (using != null && !createIndex.isIndexTypeBeforeOn()) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -11173,11 +11173,20 @@ CreateIndex CreateIndex():
     [ parameter=CreateParameter() ]
 
     <K_INDEX>
+    [ LOOKAHEAD({ getToken(1).kind == K_CONCURRENTLY })
+        <K_CONCURRENTLY> { createIndex.setConcurrently(true); } ]
     [ LOOKAHEAD(2) <K_IF> <K_NOT> <K_EXISTS> { createIndex.setUsingIfNotExists(true);} ]
-    index = Index() { index.setType(parameter.isEmpty() ? null : parameter.get(0)); }
+    [ LOOKAHEAD({ getToken(1).kind != K_ON && getToken(1).kind != K_USING })
+        index = Index() ]
+    {
+        if (index == null) {
+            index = new Index();
+        }
+        index.setType(parameter.isEmpty() ? null : parameter.get(0));
+    }
     (
         LOOKAHEAD(3)(
-            <K_ON> table=Table()
+            <K_ON> [ <K_ONLY> { createIndex.setOnly(true); } ] table=Table()
             [ indexType=UsingIndexType() { index.setUsing(indexType); } ]
         )
         |
@@ -11187,7 +11196,7 @@ CreateIndex CreateIndex():
                     createIndex.setIndexTypeBeforeOn(true);
                 }
             ]
-            <K_ON> table=Table()
+            <K_ON> [ <K_ONLY> { createIndex.setOnly(true); } ] table=Table()
         )
     )
     colNames = IndexColumnsWithParamsList()

--- a/src/test/java/net/sf/jsqlparser/statement/create/PostgreSQLCreateIndexTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/PostgreSQLCreateIndexTest.java
@@ -1,0 +1,58 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.statement.create.index.CreateIndex;
+import org.junit.jupiter.api.Test;
+
+/** PostgreSQL {@code CREATE INDEX} syntax verified against PostgreSQL 18.6. */
+public class PostgreSQLCreateIndexTest {
+
+    @Test
+    public void testCreateIndexConcurrently() throws JSQLParserException {
+        String sql = "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS pg_idx_email "
+                + "ON pg_index_test USING btree (email)";
+
+        CreateIndex createIndex = (CreateIndex) assertSqlCanBeParsedAndDeparsed(sql);
+
+        assertTrue(createIndex.isConcurrently());
+        assertTrue(createIndex.isUsingIfNotExists());
+        assertFalse(createIndex.isOnly());
+        assertEquals("pg_idx_email", createIndex.getIndex().getName());
+    }
+
+    @Test
+    public void testCreateIndexWithOmittedNameAndOnly() throws JSQLParserException {
+        String sql = "CREATE INDEX ON ONLY pg_index_test USING btree (id DESC)";
+
+        CreateIndex createIndex = (CreateIndex) assertSqlCanBeParsedAndDeparsed(sql);
+
+        assertNull(createIndex.getIndex().getName());
+        assertTrue(createIndex.isOnly());
+        assertFalse(createIndex.isConcurrently());
+    }
+
+    @Test
+    public void testCreateNamedIndexOnOnlyTable() throws JSQLParserException {
+        String sql = "CREATE INDEX pg_idx_only ON ONLY pg_index_test (id)";
+
+        CreateIndex createIndex = (CreateIndex) assertSqlCanBeParsedAndDeparsed(sql);
+
+        assertEquals("pg_idx_only", createIndex.getIndex().getName());
+        assertTrue(createIndex.isOnly());
+    }
+}


### PR DESCRIPTION
## What

- Parse PostgreSQL `CREATE INDEX CONCURRENTLY`.
- Allow the PostgreSQL index name to be omitted.
- Parse `ON ONLY table_name`.
- Expose `concurrently` and `only` as explicit `CreateIndex` properties.
- Preserve all variants in both `CreateIndex.toString()` and `CreateIndexDeParser`.

## Why

These server-valid PostgreSQL header forms currently fail before the index key is reached. They are part of the documented PostgreSQL 18 `CREATE INDEX` grammar: https://www.postgresql.org/docs/18/sql-createindex.html

## Testing

- `./gradlew check --no-daemon --no-build-cache -Dorg.gradle.vfs.watch=false`
- Added three parser/deparser and AST tests in `PostgreSQLCreateIndexTest`.
- Executed the same three statements successfully on PostgreSQL 18.6, including the concurrent build outside a transaction block.

Fixes #2524. The separate key and trailing-clause scope remains in #2525.

## AI assistance

OpenAI Codex was used to audit the grammar, draft the implementation, and run validation. The changes and tests were reviewed against the PostgreSQL 18 documentation and a PostgreSQL 18.6 server.