### PR TITLE
Support MySQL CHECK constraint enforcement

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/create/table/CheckConstraint.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/CheckConstraint.java
@@ -21,6 +21,8 @@ public class CheckConstraint extends NamedConstraint {
 
     private Expression expression;
 
+    private Boolean enforced;
+
     public Table getTable() {
         return table;
     }
@@ -37,6 +39,14 @@ public class CheckConstraint extends NamedConstraint {
         this.expression = expression;
     }
 
+    public Boolean getEnforced() {
+        return enforced;
+    }
+
+    public void setEnforced(Boolean enforced) {
+        this.enforced = enforced;
+    }
+
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder();
@@ -44,6 +54,9 @@ public class CheckConstraint extends NamedConstraint {
             b.append("CONSTRAINT ").append(getName()).append(" ");
         }
         b.append("CHECK (").append(expression).append(")");
+        if (enforced != null) {
+            b.append(enforced ? " ENFORCED" : " NOT ENFORCED");
+        }
         return b.toString();
     }
 
@@ -54,6 +67,11 @@ public class CheckConstraint extends NamedConstraint {
 
     public CheckConstraint withExpression(Expression expression) {
         this.setExpression(expression);
+        return this;
+    }
+
+    public CheckConstraint withEnforced(Boolean enforced) {
+        setEnforced(enforced);
         return this;
     }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -11833,11 +11833,17 @@ void ReferentialActionsOnIndex(ForeignKeyIndex fkIndex):
 CheckConstraint CheckConstraintSpec(String constraintName):
 {
     Expression exp = null;
+    Boolean enforced = null;
 }
 {
     <K_CHECK> ( LOOKAHEAD(2) "(" exp = Expression() ")" )*
+    [
+        [ <K_NOT> { enforced = false; } ]
+        <K_ENFORCED> { if (enforced == null) { enforced = true; } }
+    ]
     {
-        return new CheckConstraint().withName(constraintName).withExpression(exp);
+        return new CheckConstraint().withName(constraintName).withExpression(exp)
+                .withEnforced(enforced);
     }
 }
 

--- a/src/test/java/net/sf/jsqlparser/statement/create/MySQLCreateTableConstraintTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/MySQLCreateTableConstraintTest.java
@@ -1,0 +1,39 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.statement.create.table.CheckConstraint;
+import net.sf.jsqlparser.statement.create.table.CreateTable;
+import org.junit.jupiter.api.Test;
+
+/** MySQL {@code CREATE TABLE} constraint syntax verified against MySQL 8.4.11. */
+public class MySQLCreateTableConstraintTest {
+
+    @Test
+    public void testCheckConstraintEnforcement() throws JSQLParserException {
+        String sql = "CREATE TABLE mysql_check_enforcement (score INT, "
+                + "CONSTRAINT chk_positive CHECK (score >= 0) ENFORCED, "
+                + "CONSTRAINT chk_cap CHECK (score < 100) NOT ENFORCED)";
+
+        CreateTable createTable = (CreateTable) assertSqlCanBeParsedAndDeparsed(sql);
+
+        CheckConstraint positive = (CheckConstraint) createTable.getIndexes().get(0);
+        assertEquals(Boolean.TRUE, positive.getEnforced());
+        assertEquals("chk_positive", positive.getName());
+
+        CheckConstraint cap = (CheckConstraint) createTable.getIndexes().get(1);
+        assertEquals(Boolean.FALSE, cap.getEnforced());
+        assertEquals("chk_cap", cap.getName());
+    }
+}


### PR DESCRIPTION
Fixes #2526.

## What

- Parse optional `ENFORCED` and `NOT ENFORCED` clauses after MySQL table-level `CHECK` constraints.
- Preserve the tri-state syntax on `CheckConstraint` through nullable `Boolean getEnforced()`: `null` when omitted, `true` for `ENFORCED`, and `false` for `NOT ENFORCED`.
- Deparse the explicit clause losslessly.
- Add a focused AST and parse/deparse regression test.

## Server validation

The exact test statement was executed successfully on MySQL 8.4.11. `information_schema.TABLE_CONSTRAINTS` reported `chk_positive` as `ENFORCED = YES` and `chk_cap` as `ENFORCED = NO`.

MySQL grammar reference: https://dev.mysql.com/doc/refman/8.4/en/create-table.html

## Testing

- `./gradlew clean test --tests net.sf.jsqlparser.statement.create.MySQLCreateTableConstraintTest --tests net.sf.jsqlparser.statement.create.CreateTableTest --tests net.sf.jsqlparser.statement.alter.AlterTest --no-daemon --no-build-cache -Dorg.gradle.vfs.watch=false`
- `./gradlew spotlessApply check --no-daemon --no-build-cache -Dorg.gradle.vfs.watch=false`

Both completed successfully.

## AI assistance

OpenAI Codex was used to assemble and execute the parser/server comparison and prepare this change. The syntax was checked against the MySQL 8.4 documentation and an actual MySQL 8.4.11 server.