### PR TITLE
fix(parser): model ALTER COLUMN nullability actions

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -41,6 +41,7 @@ public class AlterExpression implements Serializable {
     private String columnOldName;
     private List<ColumnDataType> colDataTypeList;
     private List<ColumnDropNotNull> columnDropNotNullList;
+    private List<ColumnSetNotNull> columnSetNotNullList;
     private List<ColumnDropDefault> columnDropDefaultList;
     private List<ColumnSetDefault> columnSetDefaultList;
     private List<ColumnSetVisibility> columnSetVisibilityList;
@@ -382,6 +383,13 @@ public class AlterExpression implements Serializable {
         columnDropNotNullList.add(columnDropNotNull);
     }
 
+    public void addColSetNotNull(ColumnSetNotNull columnSetNotNull) {
+        if (columnSetNotNullList == null) {
+            columnSetNotNullList = new ArrayList<>();
+        }
+        columnSetNotNullList.add(columnSetNotNull);
+    }
+
     public List<ColumnDropDefault> getColumnDropDefaultList() {
         return columnDropDefaultList;
     }
@@ -525,6 +533,10 @@ public class AlterExpression implements Serializable {
 
     public List<ColumnDropNotNull> getColumnDropNotNullList() {
         return columnDropNotNullList;
+    }
+
+    public List<ColumnSetNotNull> getColumnSetNotNullList() {
+        return columnSetNotNullList;
     }
 
     public void addParameters(String... params) {
@@ -1134,6 +1146,9 @@ public class AlterExpression implements Serializable {
             if (colDataTypeList.size() > 1) {
                 b.append(")");
             }
+        } else if (getColumnSetNotNullList() != null) {
+            b.append("COLUMN ");
+            b.append(PlainSelect.getStringList(columnSetNotNullList));
         } else if (getColumnDropNotNullList() != null) {
             b.append("COLUMN ");
             b.append(PlainSelect.getStringList(columnDropNotNullList));
@@ -1464,6 +1479,24 @@ public class AlterExpression implements Serializable {
         @Override
         public String toString() {
             return columnName + " DROP" + (withNot ? " NOT " : " ") + "NULL";
+        }
+    }
+
+    public static final class ColumnSetNotNull implements Serializable {
+
+        private final String columnName;
+
+        public ColumnSetNotNull(String columnName) {
+            this.columnName = columnName;
+        }
+
+        public String getColumnName() {
+            return columnName;
+        }
+
+        @Override
+        public String toString() {
+            return columnName + " SET NOT NULL";
         }
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/AlterValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/AlterValidator.java
@@ -17,6 +17,7 @@ import net.sf.jsqlparser.statement.alter.Alter;
 import net.sf.jsqlparser.statement.alter.AlterExpression;
 import net.sf.jsqlparser.statement.alter.AlterExpression.ColumnDataType;
 import net.sf.jsqlparser.statement.alter.AlterExpression.ColumnDropNotNull;
+import net.sf.jsqlparser.statement.alter.AlterExpression.ColumnSetNotNull;
 import net.sf.jsqlparser.statement.alter.AlterOperation;
 import net.sf.jsqlparser.util.validation.ValidationCapability;
 import net.sf.jsqlparser.util.validation.ValidationUtil;
@@ -45,6 +46,11 @@ public class AlterValidator extends AbstractValidator<Alter> {
             if (e.getColumnDropNotNullList() != null) {
                 validateOptionalColumnNames(c, ValidationUtil.map(e.getColumnDropNotNullList(),
                         ColumnDropNotNull::getColumnName));
+            }
+
+            if (e.getColumnSetNotNullList() != null) {
+                validateOptionalColumnNames(c, ValidationUtil.map(e.getColumnSetNotNullList(),
+                        ColumnSetNotNull::getColumnName));
             }
 
             if (e.getColDataTypeList() != null) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -12213,13 +12213,15 @@ Truncate Truncate():
 
 /**
  * Parses common column-level changes shared between the COLUMN-prefixed and bare forms:
- * DROP DEFAULT, SET DEFAULT, SET VISIBLE/INVISIBLE, and bracketed multi-column definitions.
+ * DROP DEFAULT, SET DEFAULT, SET NOT NULL, SET VISIBLE/INVISIBLE, and bracketed multi-column
+ * definitions.
  */
 void AlterExpressionColumnChanges(AlterExpression alterExp):
 {
     AlterExpression.ColumnDataType alterExpressionColumnDataType = null;
     AlterExpression.ColumnDropDefault alterExpressionColumnDropDefault = null;
     AlterExpression.ColumnSetDefault alterExpressionColumnSetDefault = null;
+    AlterExpression.ColumnSetNotNull alterExpressionColumnSetNotNull = null;
     AlterExpression.ColumnSetVisibility alterExpressionColumnSetVisibility = null;
 }
 {
@@ -12229,6 +12231,9 @@ void AlterExpressionColumnChanges(AlterExpression alterExp):
         |
         LOOKAHEAD(3) alterExpressionColumnSetDefault = AlterExpressionColumnSetDefault()
             { alterExp.addColSetDefault(alterExpressionColumnSetDefault); }
+        |
+        LOOKAHEAD(4) alterExpressionColumnSetNotNull = AlterExpressionColumnSetNotNull()
+            { alterExp.addColSetNotNull(alterExpressionColumnSetNotNull); }
         |
         LOOKAHEAD(3) alterExpressionColumnSetVisibility = AlterExpressionColumnSetVisibility()
             { alterExp.addColSetVisibility(alterExpressionColumnSetVisibility); }
@@ -12284,6 +12289,19 @@ AlterExpression.ColumnDropNotNull AlterExpressionColumnDropNotNull():
     <K_NULL>
     {
         return new AlterExpression.ColumnDropNotNull(columnName, withNot);
+    }
+}
+
+AlterExpression.ColumnSetNotNull AlterExpressionColumnSetNotNull():
+{
+    String columnName = null;
+}
+{
+    columnName = RelObjectName()
+    <K_SET>
+    <K_NOT> <K_NULL>
+    {
+        return new AlterExpression.ColumnSetNotNull(columnName);
     }
 }
 
@@ -12926,11 +12944,11 @@ AlterExpression AlterExpressionAddAlterModify():
             (
                 LOOKAHEAD(3) AlterExpressionColumnChanges(alterExp)
                 |
-                LOOKAHEAD(2) alterExpressionColumnDataType = AlterExpressionColumnDataType()
-                    { alterExp.addColDataType(alterExpressionColumnDataType); }
-                |
                 LOOKAHEAD(3) alterExpressionColumnDropNotNull = AlterExpressionColumnDropNotNull()
                     { alterExp.addColDropNotNull( alterExpressionColumnDropNotNull);}
+                |
+                LOOKAHEAD(2) alterExpressionColumnDataType = AlterExpressionColumnDataType()
+                    { alterExp.addColDataType(alterExpressionColumnDataType); }
             )
         )
         |

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -644,8 +644,23 @@ public class AlterTest {
 
     @Test
     public void testAlterTableAlterColumnDropNotNullIssue918() throws JSQLParserException {
-        assertSqlCanBeParsedAndDeparsed(
+        Alter alter = (Alter) assertSqlCanBeParsedAndDeparsed(
                 "ALTER TABLE \"user_table_t\" ALTER COLUMN name DROP NOT NULL");
+        AlterExpression expression = alter.getAlterExpressions().get(0);
+
+        assertNull(expression.getColDataTypeList());
+        assertEquals("name", expression.getColumnDropNotNullList().get(0).getColumnName());
+        assertTrue(expression.getColumnDropNotNullList().get(0).isWithNot());
+    }
+
+    @Test
+    public void testAlterTableAlterColumnSetNotNull() throws JSQLParserException {
+        Alter alter = (Alter) assertSqlCanBeParsedAndDeparsed(
+                "ALTER TABLE user_table ALTER COLUMN name SET NOT NULL");
+        AlterExpression expression = alter.getAlterExpressions().get(0);
+
+        assertNull(expression.getColDataTypeList());
+        assertEquals("name", expression.getColumnSetNotNullList().get(0).getColumnName());
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/statement/builder/ReflectionModelTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/builder/ReflectionModelTest.java
@@ -141,6 +141,7 @@ public class ReflectionModelTest {
             new net.sf.jsqlparser.statement.alter.AlterExpression(),
             new net.sf.jsqlparser.statement.alter.AlterExpression.ColumnDataType(false),
             new net.sf.jsqlparser.statement.alter.AlterExpression.ColumnDropNotNull("name"),
+            new net.sf.jsqlparser.statement.alter.AlterExpression.ColumnSetNotNull("name"),
             new net.sf.jsqlparser.statement.merge.MergeInsert(),
             new net.sf.jsqlparser.statement.alter.DeferrableConstraint(),
             new net.sf.jsqlparser.statement.alter.EnableConstraint(),

--- a/src/test/java/net/sf/jsqlparser/util/validation/validator/AlterValidatorTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/validation/validator/AlterValidatorTest.java
@@ -151,4 +151,10 @@ public class AlterValidatorTest extends ValidationTestAsserts {
                 DatabaseType.DATABASES);
     }
 
+    @Test
+    public void testAlterTableAlterColumnSetNotNull() throws JSQLParserException {
+        validateNoErrors("ALTER TABLE user_table ALTER COLUMN name SET NOT NULL", 1,
+                DatabaseType.DATABASES);
+    }
+
 }


### PR DESCRIPTION
## What

- Add a dedicated `AlterExpression.ColumnSetNotNull` AST model for `ALTER COLUMN ... SET NOT NULL`.
- Match the existing `ColumnDropNotNull` production before the generic column-data-type production.
- Preserve both actions through `AlterExpression.toString()`.
- Validate the affected column name in `AlterValidator`.
- Add AST, parse/deparse, validation, and reflection coverage.

## Why

Both statements currently parse, but their ASTs are not reliable:

```sql
ALTER TABLE test_table ALTER COLUMN name SET NOT NULL;
ALTER TABLE test_table ALTER COLUMN name DROP NOT NULL;
```

`SET NOT NULL` is represented as a column data type named `SET` with `[NOT, NULL]` in its raw column specs. `DROP NOT NULL` is also consumed by the generic column-data-type branch even though a dedicated `ColumnDropNotNull` model already exists. Consumers therefore have to inspect and reconstruct raw tokens instead of using the AST.

This change gives both PostgreSQL nullability actions explicit AST representations without changing unrelated column option parsing.

PostgreSQL grammar reference: https://www.postgresql.org/docs/current/sql-altertable.html

## Testing

- `./gradlew check`
- Added parse/deparse and AST assertions for both actions.
- Added validator coverage for `SET NOT NULL`.
- Added the new model to `ReflectionModelTest`.

## AI assistance

OpenAI Codex was used to trace the grammar branch selection, prepare the AST/deparser/validator changes, and run validation. The generated change and tests were reviewed against the PostgreSQL documentation.
