### PR TITLE
fix(parser): allow VERSION in ALTER column clauses

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2140,6 +2140,7 @@ Token KeywordOrIdentifier():
       | tk = <K_STRING>
       | tk = <K_DATA>
       | tk = <K_TYPE>
+      | tk = <K_VERSION>
     )
     { return tk; }
 }
@@ -11942,7 +11943,7 @@ List<String> CreateParameter():
         |
         (
             //@todo: implement a proper identifier
-            (tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER> | tk=<K_NAME>)
+            (tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER> | tk=<K_NAME> | tk=<K_VERSION>)
             { retval+=tk.image; }
 
             [

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -649,6 +649,15 @@ public class AlterTest {
     }
 
     @Test
+    public void testAlterTableVersionColumn() throws JSQLParserException {
+        assertSqlCanBeParsedAndDeparsed(
+                "ALTER TABLE test_table DROP COLUMN version, DROP COLUMN other_column");
+        assertSqlCanBeParsedAndDeparsed(
+                "ALTER TABLE test_table ALTER COLUMN version TYPE VARCHAR(32) "
+                        + "USING version::VARCHAR(32)");
+    }
+
+    @Test
     public void testAlterTableRenameColumn() throws JSQLParserException {
         // With Column Keyword
         String sql = "ALTER TABLE \"test_table\" RENAME COLUMN \"test_column\" TO \"test_c\"";


### PR DESCRIPTION
## What

- Allow the non-reserved `VERSION` keyword to be used as a column identifier in the restricted `KeywordOrIdentifier` production used by `ALTER TABLE`.
- Allow `VERSION` in `CreateParameter`, which currently captures PostgreSQL `USING` expressions attached to `ALTER COLUMN ... TYPE`.
- Add parse/deparse regressions for `DROP COLUMN version` and `ALTER COLUMN version TYPE ... USING version::...`.

## Why

`VERSION` is already declared as a non-reserved keyword, but two narrower legacy productions do not accept it. As a result, valid PostgreSQL statements such as these fail on the current `master` branch:

```sql
ALTER TABLE test_table DROP COLUMN version, DROP COLUMN other_column;
ALTER TABLE test_table ALTER COLUMN version TYPE VARCHAR(32) USING version::VARCHAR(32);
```

PostgreSQL allows non-reserved keywords to be used as identifiers. This change is intentionally limited to the two productions exercised by these statements and introduces no new JavaCC choice conflicts.

PostgreSQL keyword reference: https://www.postgresql.org/docs/current/sql-keywords-appendix.html

## Testing

- `./gradlew check`
- Added both statements to `AlterTest` and verified parse/deparse round trips.

## AI assistance

OpenAI Codex was used to identify the regression from a PostgreSQL ALTER corpus, prepare the focused grammar change, and run validation. The generated change and tests were reviewed against the PostgreSQL documentation.
