### PR TITLE
feat(parser): add column data type fragment parser

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/CCJSqlParserUtil.java
+++ b/src/main/java/net/sf/jsqlparser/parser/CCJSqlParserUtil.java
@@ -30,6 +30,7 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.Statements;
+import net.sf.jsqlparser.statement.create.table.ColDataType;
 
 /**
  * Toolfunctions to start and use JSqlParser.
@@ -197,6 +198,61 @@ public final class CCJSqlParserUtil {
 
         return parseExpression(expression, allowPartialParse, p -> {
         });
+    }
+
+    /**
+     * Parses a column data type fragment. The complete input must represent the data type; trailing
+     * tokens are rejected.
+     *
+     * @param columnDataType the column data type fragment to parse
+     * @return the parsed column data type, or {@code null} for a null or empty input
+     * @throws JSQLParserException when the input cannot be parsed completely
+     * @see #parseColDataType(String, Consumer)
+     */
+    public static ColDataType parseColDataType(String columnDataType) throws JSQLParserException {
+        return parseColDataType(columnDataType, null);
+    }
+
+    /**
+     * Parses a column data type fragment while allowing the parser to be configured. The complete
+     * input must represent the data type; trailing tokens are rejected.
+     *
+     * @param columnDataType the column data type fragment to parse
+     * @param consumer parser configuration callback, or {@code null}
+     * @return the parsed column data type, or {@code null} for a null or empty input
+     * @throws JSQLParserException when the input cannot be parsed completely
+     */
+    public static ColDataType parseColDataType(String columnDataType,
+            Consumer<CCJSqlParser> consumer) throws JSQLParserException {
+        if (columnDataType == null || columnDataType.isEmpty()) {
+            return null;
+        }
+
+        try {
+            return parseColDataType(columnDataType, false, consumer);
+        } catch (JSQLParserException ex) {
+            return parseColDataType(columnDataType, true, consumer);
+        }
+    }
+
+    private static ColDataType parseColDataType(String columnDataType, boolean allowComplexParsing,
+            Consumer<CCJSqlParser> consumer) throws JSQLParserException {
+        CCJSqlParser parser = newParser(columnDataType)
+                .withAllowComplexParsing(allowComplexParsing);
+        if (consumer != null) {
+            consumer.accept(parser);
+        }
+
+        try {
+            ColDataType result = parser.ColDataType();
+            if (parser.getNextToken().kind != CCJSqlParserTokenManager.EOF) {
+                throw new JSQLParserException(
+                        "could only parse partial column data type " + result);
+            }
+            return result;
+        } catch (ParseException ex) {
+            throw new JSQLParserException(columnDataType, ex);
+        }
     }
 
     @SuppressWarnings("PMD.CyclomaticComplexity")

--- a/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/CCJSqlParserUtilTest.java
@@ -20,6 +20,7 @@ import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.Statements;
 import net.sf.jsqlparser.statement.UnsupportedStatement;
+import net.sf.jsqlparser.statement.create.table.ColDataType;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 import net.sf.jsqlparser.statement.select.TableStatement;
@@ -39,6 +40,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -105,6 +107,34 @@ public class CCJSqlParserUtilTest {
         Multiplication mult = (Multiplication) result;
         assertInstanceOf(LongValue.class, mult.getLeftExpression());
         assertInstanceOf(ParenthesedExpressionList.class, mult.getRightExpression());
+    }
+
+    @Test
+    public void testParseColDataType() throws Exception {
+        assertNull(CCJSqlParserUtil.parseColDataType(null));
+        assertNull(CCJSqlParserUtil.parseColDataType(""));
+
+        ColDataType arrayType = CCJSqlParserUtil.parseColDataType("integer[][]");
+        assertEquals("integer", arrayType.getDataType());
+        assertEquals(2, arrayType.getArrayData().size());
+        assertNull(arrayType.getArrayData().get(0));
+        assertNull(arrayType.getArrayData().get(1));
+
+        AtomicBoolean configured = new AtomicBoolean();
+        ColDataType enumType =
+                CCJSqlParserUtil.parseColDataType("enum('small','medium')", parser -> {
+                    configured.set(true);
+                    parser.withDialect(AbstractJSqlParser.Dialect.MYSQL);
+                });
+        assertTrue(configured.get());
+        assertEquals("enum", enumType.getDataType());
+        assertEquals(List.of("'small'", "'medium'"), enumType.getArgumentsStringList());
+    }
+
+    @Test
+    public void testParseColDataTypeRejectsTrailingTokens() {
+        assertThrows(JSQLParserException.class,
+                () -> CCJSqlParserUtil.parseColDataType("varchar(255) NOT NULL"));
     }
 
     @Test


### PR DESCRIPTION
## What

- Add `CCJSqlParserUtil.parseColDataType(String)`.
- Add a configurable overload accepting `Consumer<CCJSqlParser>` for dialect and feature settings.
- Require the complete input to be consumed, rejecting trailing column constraints or modifiers instead of returning a partial type.
- Cover PostgreSQL array dimensions, MySQL `ENUM` arguments, parser configuration, null/empty input, and partial-input rejection.

## Why

`ColDataType()` is available on the generated parser, but there is no public `CCJSqlParserUtil` entry point for applications that receive a type fragment rather than a complete DDL statement. Such applications currently need to instantiate the generated parser directly or wrap the fragment in synthetic DDL.

The strict EOF check is important for type fragments: returning `varchar(255)` from `varchar(255) NOT NULL` would silently discard meaningful input.

## API example

```java
ColDataType type = CCJSqlParserUtil.parseColDataType(
        "enum('small','medium')",
        parser -> parser.withDialect(AbstractJSqlParser.Dialect.MYSQL));
```

## Testing

- `./gradlew check`
- Added focused tests in `CCJSqlParserUtilTest`.

## AI assistance

OpenAI Codex was used to review existing parser utility conventions, prepare the API and tests, and run validation. The generated change was reviewed for strict full-input behavior and compatibility with parser configuration.
