### PR TITLE
fix(parser): preserve unique index comments in ALTER TABLE

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -13306,20 +13306,30 @@ AlterExpression AlterExpressionAddAlterModify():
         LOOKAHEAD(3) AlterExpressionColumnChanges(alterExp)
         |
         (
-            <K_UNIQUE>
+            <K_UNIQUE> { index = new Index().withType("UNIQUE"); }
             (
                 (
-                    <K_KEY> { alterExp.setUk(true); }
-                    | <K_INDEX> { alterExp.setUk(false); }
+                    tk2=<K_KEY> { alterExp.setUk(true); }
+                    | tk2=<K_INDEX> { alterExp.setUk(false); }
                 )
-                [ (tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER>) { alterExp.setUkName(tk.image); } ]
+                [ (tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER>) {
+                    sk3 = tk.image;
+                    alterExp.setUkName(sk3);
+                } ]
                 |
                 (tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER>) {
+                    sk3 = tk.image;
                     alterExp.setUkTypeSpecified(false);
-                    alterExp.setUkName(tk.image);
+                    alterExp.setUkName(sk3);
                 }
             )?
-            columnNames=ColumnsNamesList() { alterExp.setUkColumns(columnNames); }
+            columnNames=ColumnsNamesList() {
+                alterExp.setUkColumns(columnNames);
+                index.withIndexKeyword(tk2 != null ? tk2.image : null)
+                        .withName(sk3)
+                        .withColumnsNames(columnNames);
+                alterExp.setIndex(index);
+            }
             [
                 AlterExpressionUsingIndex(alterExp)
             ]

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -599,6 +599,28 @@ public class AlterTest {
     }
 
     @Test
+    public void testAlterTableAddUniqueIndexWithCommentIssue2503() throws Exception {
+        String sql = "ALTER TABLE `wxp_dm`.`xqgl_req_report` "
+                + "ADD UNIQUE INDEX `index2` (`report_name` ASC) USING BTREE COMMENT '唯一索引'";
+
+        Alter alter = (Alter) assertSqlCanBeParsedAndDeparsed(sql);
+        AlterExpression alterExpression = alter.getAlterExpressions().get(0);
+        Index index = alterExpression.getIndex();
+
+        assertNotNull(index);
+        assertEquals("UNIQUE", index.getType());
+        assertEquals("INDEX", index.getIndexKeyword());
+        assertEquals("`index2`", index.getName());
+        assertEquals(List.of("`report_name` ASC"), index.getColumnsNames());
+        assertEquals("'唯一索引'", index.getCommentText());
+
+        // Keep the legacy fields populated for existing consumers.
+        assertEquals("`index2`", alterExpression.getUkName());
+        assertEquals(List.of("`report_name` ASC"), alterExpression.getUkColumns());
+        assertEquals(List.of("USING", "BTREE"), alterExpression.getParameters());
+    }
+
+    @Test
     public void testIssue259() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed(
                 "ALTER TABLE feature_v2 ADD COLUMN third_user_id int (10) unsigned DEFAULT '0' COMMENT '第三方用户id' after kdt_id");


### PR DESCRIPTION
## Summary

- build the structured `Index` node for MySQL `ALTER TABLE ... ADD UNIQUE INDEX`
- retain key-part ordering, `USING`, and `COMMENT` clauses during parsing and deparsing
- keep the existing unique-key compatibility fields populated

## Testing

- `./gradlew check`

Fixes #2503

## AI assistance

OpenAI Codex assisted with the implementation and test coverage. The changes were manually reviewed and verified.