### PR TITLE
fix(parser): model PostgreSQL CREATE INDEX clauses

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
@@ -12,9 +12,11 @@ package net.sf.jsqlparser.statement.create.index;
 import static java.util.stream.Collectors.joining;
 
 import java.util.*;
+import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.schema.*;
 import net.sf.jsqlparser.statement.*;
 import net.sf.jsqlparser.statement.create.table.*;
+import net.sf.jsqlparser.statement.select.PlainSelect;
 
 public class CreateIndex implements Statement {
 
@@ -25,6 +27,11 @@ public class CreateIndex implements Statement {
     private boolean usingIfNotExists = false;
     private boolean concurrently;
     private boolean only;
+    private List<String> includeColumns;
+    private Boolean nullsDistinct;
+    private List<Index.Option> storageParameters;
+    private String tableSpace;
+    private Expression where;
 
     public boolean isIndexTypeBeforeOn() {
         return indexTypeBeforeOn;
@@ -57,6 +64,46 @@ public class CreateIndex implements Statement {
 
     public void setOnly(boolean only) {
         this.only = only;
+    }
+
+    public List<String> getIncludeColumns() {
+        return includeColumns;
+    }
+
+    public void setIncludeColumns(List<String> includeColumns) {
+        this.includeColumns = includeColumns;
+    }
+
+    public Boolean getNullsDistinct() {
+        return nullsDistinct;
+    }
+
+    public void setNullsDistinct(Boolean nullsDistinct) {
+        this.nullsDistinct = nullsDistinct;
+    }
+
+    public List<Index.Option> getStorageParameters() {
+        return storageParameters;
+    }
+
+    public void setStorageParameters(List<Index.Option> storageParameters) {
+        this.storageParameters = storageParameters;
+    }
+
+    public String getTableSpace() {
+        return tableSpace;
+    }
+
+    public void setTableSpace(String tableSpace) {
+        this.tableSpace = tableSpace;
+    }
+
+    public Expression getWhere() {
+        return where;
+    }
+
+    public void setWhere(Expression where) {
+        this.where = where;
     }
 
     @Override
@@ -135,6 +182,8 @@ public class CreateIndex implements Statement {
 
             buffer.append(")");
 
+            appendPostgreSqlTail(buffer);
+
             if (tailParameters != null) {
                 for (String param : tailParameters) {
                     buffer.append(" ").append(param);
@@ -143,6 +192,25 @@ public class CreateIndex implements Statement {
         }
 
         return buffer.toString();
+    }
+
+    private void appendPostgreSqlTail(StringBuilder buffer) {
+        if (includeColumns != null) {
+            buffer.append(" INCLUDE (").append(String.join(", ", includeColumns)).append(")");
+        }
+        if (nullsDistinct != null) {
+            buffer.append(" NULLS ").append(nullsDistinct ? "DISTINCT" : "NOT DISTINCT");
+        }
+        if (storageParameters != null) {
+            buffer.append(" WITH ")
+                    .append(PlainSelect.getStringList(storageParameters, true, true));
+        }
+        if (tableSpace != null) {
+            buffer.append(" TABLESPACE ").append(tableSpace);
+        }
+        if (where != null) {
+            buffer.append(" WHERE ").append(where);
+        }
     }
 
     public CreateIndex withTable(Table table) {
@@ -167,6 +235,31 @@ public class CreateIndex implements Statement {
 
     public CreateIndex withOnly(boolean only) {
         setOnly(only);
+        return this;
+    }
+
+    public CreateIndex withIncludeColumns(List<String> includeColumns) {
+        setIncludeColumns(includeColumns);
+        return this;
+    }
+
+    public CreateIndex withNullsDistinct(Boolean nullsDistinct) {
+        setNullsDistinct(nullsDistinct);
+        return this;
+    }
+
+    public CreateIndex withStorageParameters(List<Index.Option> storageParameters) {
+        setStorageParameters(storageParameters);
+        return this;
+    }
+
+    public CreateIndex withTableSpace(String tableSpace) {
+        setTableSpace(tableSpace);
+        return this;
+    }
+
+    public CreateIndex withWhere(Expression where) {
+        setWhere(where);
         return this;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
@@ -200,9 +200,22 @@ public class Index implements Serializable {
     }
 
     public static class ColumnParams implements Serializable {
+        public enum SortOrder {
+            ASC, DESC
+        }
+
+        public enum NullOrdering {
+            FIRST, LAST
+        }
+
         public final String columnName;
         public final List<String> params;
         private final Expression expression;
+        private String collation;
+        private String operatorClass;
+        private List<Option> operatorClassParameters;
+        private SortOrder sortOrder;
+        private NullOrdering nullOrdering;
 
         public ColumnParams(String columnName) {
             this.columnName = columnName;
@@ -244,10 +257,159 @@ public class Index implements Serializable {
             return expression != null;
         }
 
+        public String getCollation() {
+            return collation;
+        }
+
+        public void setCollation(String collation) {
+            this.collation = collation;
+        }
+
+        public String getOperatorClass() {
+            return operatorClass;
+        }
+
+        public void setOperatorClass(String operatorClass) {
+            this.operatorClass = operatorClass;
+        }
+
+        public List<Option> getOperatorClassParameters() {
+            return operatorClassParameters;
+        }
+
+        public void setOperatorClassParameters(List<Option> operatorClassParameters) {
+            this.operatorClassParameters = operatorClassParameters;
+        }
+
+        public SortOrder getSortOrder() {
+            return sortOrder;
+        }
+
+        public void setSortOrder(SortOrder sortOrder) {
+            this.sortOrder = sortOrder;
+        }
+
+        public NullOrdering getNullOrdering() {
+            return nullOrdering;
+        }
+
+        public void setNullOrdering(NullOrdering nullOrdering) {
+            this.nullOrdering = nullOrdering;
+        }
+
+        public ColumnParams withCollation(String collation) {
+            setCollation(collation);
+            return this;
+        }
+
+        public ColumnParams withOperatorClass(String operatorClass) {
+            setOperatorClass(operatorClass);
+            return this;
+        }
+
+        public ColumnParams withOperatorClassParameters(List<Option> operatorClassParameters) {
+            setOperatorClassParameters(operatorClassParameters);
+            return this;
+        }
+
+        public ColumnParams withSortOrder(SortOrder sortOrder) {
+            setSortOrder(sortOrder);
+            return this;
+        }
+
+        public ColumnParams withNullOrdering(NullOrdering nullOrdering) {
+            setNullOrdering(nullOrdering);
+            return this;
+        }
+
         @Override
         public String toString() {
-            String head = expression != null ? "(" + expression + ")" : columnName;
-            return head + (params != null ? " " + String.join(" ", params) : "");
+            StringBuilder builder = new StringBuilder(
+                    expression != null ? "(" + expression + ")" : columnName);
+            if (params != null) {
+                builder.append(" ").append(String.join(" ", params));
+            }
+            if (collation != null && !hasParam("COLLATE")) {
+                builder.append(" COLLATE ").append(collation);
+            }
+            if (operatorClass != null && !hasParam(operatorClass)) {
+                builder.append(" ").append(operatorClass);
+                if (operatorClassParameters != null && !operatorClassParameters.isEmpty()) {
+                    builder.append(" ")
+                            .append(PlainSelect.getStringList(
+                                    operatorClassParameters, true, true));
+                }
+            }
+            if (sortOrder != null && !hasParam(sortOrder.name())) {
+                builder.append(" ").append(sortOrder);
+            }
+            if (nullOrdering != null && !hasParam("NULLS")) {
+                builder.append(" NULLS ").append(nullOrdering);
+            }
+            return builder.toString();
+        }
+
+        private boolean hasParam(String expected) {
+            return params != null && params.stream().anyMatch(expected::equalsIgnoreCase);
+        }
+    }
+
+    /** A named PostgreSQL index option with an optional value. */
+    public static class Option implements Serializable {
+        private String name;
+        private Expression value;
+        private boolean useEquals;
+
+        public Option() {}
+
+        public Option(String name, Expression value, boolean useEquals) {
+            this.name = name;
+            this.value = value;
+            this.useEquals = useEquals;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Expression getValue() {
+            return value;
+        }
+
+        public void setValue(Expression value) {
+            this.value = value;
+        }
+
+        public boolean isUseEquals() {
+            return useEquals;
+        }
+
+        public void setUseEquals(boolean useEquals) {
+            this.useEquals = useEquals;
+        }
+
+        public Option withName(String name) {
+            setName(name);
+            return this;
+        }
+
+        public Option withValue(Expression value) {
+            setValue(value);
+            return this;
+        }
+
+        public Option withUseEquals(boolean useEquals) {
+            setUseEquals(useEquals);
+            return this;
+        }
+
+        @Override
+        public String toString() {
+            return value == null ? name : name + (useEquals ? " = " : " ") + value;
         }
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
@@ -326,12 +326,27 @@ public class Index implements Serializable {
         public String toString() {
             StringBuilder builder = new StringBuilder(
                     expression != null ? "(" + expression + ")" : columnName);
+            appendParams(builder);
+            appendCollation(builder);
+            appendOperatorClass(builder);
+            appendSortOrder(builder);
+            appendNullOrdering(builder);
+            return builder.toString();
+        }
+
+        private void appendParams(StringBuilder builder) {
             if (params != null) {
                 builder.append(" ").append(String.join(" ", params));
             }
+        }
+
+        private void appendCollation(StringBuilder builder) {
             if (collation != null && !hasParam("COLLATE")) {
                 builder.append(" COLLATE ").append(collation);
             }
+        }
+
+        private void appendOperatorClass(StringBuilder builder) {
             if (operatorClass != null && !hasParam(operatorClass)) {
                 builder.append(" ").append(operatorClass);
                 if (operatorClassParameters != null && !operatorClassParameters.isEmpty()) {
@@ -340,13 +355,18 @@ public class Index implements Serializable {
                                     operatorClassParameters, true, true));
                 }
             }
+        }
+
+        private void appendSortOrder(StringBuilder builder) {
             if (sortOrder != null && !hasParam(sortOrder.name())) {
                 builder.append(" ").append(sortOrder);
             }
+        }
+
+        private void appendNullOrdering(StringBuilder builder) {
             if (nullOrdering != null && !hasParam("NULLS")) {
                 builder.append(" NULLS ").append(nullOrdering);
             }
-            return builder.toString();
         }
 
         private boolean hasParam(String expected) {

--- a/src/main/java/net/sf/jsqlparser/util/deparser/CreateIndexDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/CreateIndexDeParser.java
@@ -13,6 +13,7 @@ import static java.util.stream.Collectors.joining;
 
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.table.Index;
+import net.sf.jsqlparser.statement.select.PlainSelect;
 
 public class CreateIndexDeParser extends AbstractDeParser<CreateIndex> {
 
@@ -64,6 +65,25 @@ public class CreateIndexDeParser extends AbstractDeParser<CreateIndex> {
                     .map(Index.ColumnParams::toString)
                     .collect(joining(", ")));
             builder.append(")");
+        }
+
+        if (createIndex.getIncludeColumns() != null) {
+            builder.append(" INCLUDE (")
+                    .append(String.join(", ", createIndex.getIncludeColumns())).append(")");
+        }
+        if (createIndex.getNullsDistinct() != null) {
+            builder.append(" NULLS ")
+                    .append(createIndex.getNullsDistinct() ? "DISTINCT" : "NOT DISTINCT");
+        }
+        if (createIndex.getStorageParameters() != null) {
+            builder.append(" WITH ").append(PlainSelect.getStringList(
+                    createIndex.getStorageParameters(), true, true));
+        }
+        if (createIndex.getTableSpace() != null) {
+            builder.append(" TABLESPACE ").append(createIndex.getTableSpace());
+        }
+        if (createIndex.getWhere() != null) {
+            builder.append(" WHERE ").append(createIndex.getWhere());
         }
 
         if (createIndex.getTailParameters() != null) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -11200,35 +11200,84 @@ List<Index.ColumnParams> ColumnNamesWithParamsList() : {
 
 Index.ColumnParams IndexColumnWithParams(): {
     String columnName = null;
-    // the options collected for this key part, and the result of a single CreateParameter()
     List<String> columnParams = new ArrayList<String>();
     List<String> parameter = null;
     Expression expression = null;
+    String collation = null;
+    Token operatorClass = null;
+    List<Index.Option> operatorClassParameters = null;
+    Token sortOrder = null;
+    Token nullOrdering = null;
     Index.ColumnParams column = null;
 }
 {
     (
         columnName=RelObjectName()
-        // MySQL allows a key part to carry a prefix length and a direction, e.g. "c1(20) DESC",
-        // so more than one parameter has to be collected here.
-        ( LOOKAHEAD(2) parameter = CreateParameter() { columnParams.addAll(parameter); } )*
-        {
-            // ColumnParams renders a separating space for a non-null list, so a key part
-            // without options has to be given null rather than an empty list.
-            column = new Index.ColumnParams(columnName,
-                    columnParams.isEmpty() ? null : columnParams);
-        }
         |
         "(" expression=Expression() ")"
-        ( LOOKAHEAD(2) parameter = CreateParameter() { columnParams.addAll(parameter); } )*
-        {
-            column = new Index.ColumnParams(expression,
-                    columnParams.isEmpty() ? null : columnParams);
-        }
     )
+    // MySQL prefix lengths precede all PostgreSQL key attributes.
+    [ LOOKAHEAD("(") parameter=CreateParameter() { columnParams.addAll(parameter); } ]
+    [ LOOKAHEAD(2) <K_COLLATE> collation=RelObjectName()
+        { columnParams.add("COLLATE"); columnParams.add(collation); } ]
+    [ LOOKAHEAD(2) (operatorClass=<S_IDENTIFIER> | operatorClass=<S_QUOTED_IDENTIFIER>)
+        [ LOOKAHEAD(2) operatorClassParameters=PostgreSqlIndexOptions() ]
+        {
+            columnParams.add(operatorClass.image);
+            if (operatorClassParameters != null) {
+                columnParams.add(PlainSelect.getStringList(
+                        operatorClassParameters, true, true));
+            }
+        }
+    ]
+    [ LOOKAHEAD(2) (sortOrder=<K_ASC> | sortOrder=<K_DESC>)
+        { columnParams.add(sortOrder.image); } ]
+    [ LOOKAHEAD(2) <K_NULLS> (nullOrdering=<K_FIRST> | nullOrdering=<K_LAST>)
+        { columnParams.add("NULLS"); columnParams.add(nullOrdering.image); } ]
+    ( LOOKAHEAD(2) parameter=CreateParameter() { columnParams.addAll(parameter); } )*
     {
+        column = expression != null
+                ? new Index.ColumnParams(expression,
+                        columnParams.isEmpty() ? null : columnParams)
+                : new Index.ColumnParams(columnName,
+                        columnParams.isEmpty() ? null : columnParams);
+        column.setCollation(collation);
+        if (operatorClass != null) {
+            column.setOperatorClass(operatorClass.image);
+            column.setOperatorClassParameters(operatorClassParameters);
+        }
+        if (sortOrder != null) {
+            column.setSortOrder(Index.ColumnParams.SortOrder.valueOf(
+                    sortOrder.image.toUpperCase(Locale.ROOT)));
+        }
+        if (nullOrdering != null) {
+            column.setNullOrdering(Index.ColumnParams.NullOrdering.valueOf(
+                    nullOrdering.image.toUpperCase(Locale.ROOT)));
+        }
         return column;
     }
+}
+
+Index.Option PostgreSqlIndexOption():
+{
+    String name = null;
+    Expression value = null;
+    boolean useEquals = false;
+}
+{
+    name=RelObjectName() [ "=" { useEquals = true; } ] value=Expression()
+    { return new Index.Option(name, value, useEquals); }
+}
+
+List<Index.Option> PostgreSqlIndexOptions():
+{
+    List<Index.Option> options = new ArrayList<Index.Option>();
+    Index.Option option = null;
+}
+{
+    "(" option=PostgreSqlIndexOption() { options.add(option); }
+    ( "," option=PostgreSqlIndexOption() { options.add(option); } )* ")"
+    { return options; }
 }
 
 List<Index.ColumnParams> IndexColumnsWithParamsList() : {
@@ -11268,6 +11317,10 @@ CreateIndex CreateIndex():
     Table table = null;
     List<Index.ColumnParams> colNames;
     List<String> includeColumns;
+    Boolean nullsDistinct = null;
+    List<Index.Option> storageParameters = null;
+    String tableSpace = null;
+    Expression where = null;
     String indexType;
     Index index = null;
     List<String> parameter = new ArrayList<String>();
@@ -11306,8 +11359,21 @@ CreateIndex CreateIndex():
     )
     colNames = IndexColumnsWithParamsList()
     [ <K_INCLUDE> includeColumns=ColumnsNamesList()
-        { tailParameters.add("INCLUDE (" + String.join(", ", includeColumns) + ")"); }
+        { createIndex.setIncludeColumns(includeColumns); }
     ]
+    [ LOOKAHEAD(3) <K_NULLS> [ <K_NOT> { nullsDistinct = false; } ] <K_DISTINCT>
+        {
+            if (nullsDistinct == null) {
+                nullsDistinct = true;
+            }
+            createIndex.setNullsDistinct(nullsDistinct);
+        }
+    ]
+    [ LOOKAHEAD(2) <K_WITH> storageParameters=PostgreSqlIndexOptions()
+        { createIndex.setStorageParameters(storageParameters); } ]
+    [ LOOKAHEAD(2) <K_TABLESPACE> tableSpace=RelObjectName()
+        { createIndex.setTableSpace(tableSpace); } ]
+    [ LOOKAHEAD(2) <K_WHERE> where=Expression() { createIndex.setWhere(where); } ]
     ( LOOKAHEAD(2)  parameter=CreateParameter() { tailParameters.addAll(parameter); } )*
     {
         index.setColumns(colNames);

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTest.java
@@ -19,7 +19,9 @@ import java.io.StringReader;
 import java.util.List;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
+import net.sf.jsqlparser.parser.AbstractJSqlParser.Dialect;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
+import net.sf.jsqlparser.statement.create.table.Index;
 import org.junit.jupiter.api.Test;
 
 public class CreateIndexTest {
@@ -191,6 +193,8 @@ public class CreateIndexTest {
         assertEquals(2, params.size());
         assertEquals("(20)", params.get(0));
         assertEquals("DESC", params.get(1));
+        assertEquals(Index.ColumnParams.SortOrder.DESC,
+                createIndex.getIndex().getColumns().get(0).getSortOrder());
 
         assertSqlCanBeParsedAndDeparsed("CREATE INDEX i03 ON t (c1 (20) DESC)");
         assertSqlCanBeParsedAndDeparsed("CREATE INDEX i04 ON t (c1 (20) ASC, c2 (10) DESC)");
@@ -239,5 +243,56 @@ public class CreateIndexTest {
     public void testCreateMultiValuedIndexIssue2490() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed(
                 "CREATE INDEX i20 ON t ((CAST(data -> '$.zips' AS UNSIGNED ARRAY)))");
+    }
+
+    @Test
+    public void testPostgreSqlIndexKeyAttributesIssue2525() throws JSQLParserException {
+        String orderSql = "CREATE INDEX pg_idx_sort ON pg_index_test "
+                + "(id DESC NULLS FIRST)";
+        CreateIndex ordered = (CreateIndex) assertSqlCanBeParsedAndDeparsed(
+                orderSql, true, parser -> parser.withDialect(Dialect.POSTGRESQL));
+        Index.ColumnParams orderedKey = ordered.getIndex().getColumns().get(0);
+        assertEquals(Index.ColumnParams.SortOrder.DESC, orderedKey.getSortOrder());
+        assertEquals(Index.ColumnParams.NullOrdering.FIRST, orderedKey.getNullOrdering());
+
+        String operatorClassSql = "CREATE INDEX pg_idx_collate ON pg_index_test "
+                + "(email COLLATE \"C\" text_pattern_ops)";
+        CreateIndex operatorClassIndex = (CreateIndex) assertSqlCanBeParsedAndDeparsed(
+                operatorClassSql, true, parser -> parser.withDialect(Dialect.POSTGRESQL));
+        Index.ColumnParams operatorClassKey =
+                operatorClassIndex.getIndex().getColumns().get(0);
+        assertEquals("\"C\"", operatorClassKey.getCollation());
+        assertEquals("text_pattern_ops", operatorClassKey.getOperatorClass());
+
+        String optionSql = "CREATE INDEX pg_idx_opclass ON pg_index_test "
+                + "(email text_pattern_ops (example = 1))";
+        CreateIndex optionIndex = (CreateIndex) assertSqlCanBeParsedAndDeparsed(
+                optionSql, true, parser -> parser.withDialect(Dialect.POSTGRESQL));
+        Index.Option option = optionIndex.getIndex().getColumns().get(0)
+                .getOperatorClassParameters().get(0);
+        assertEquals("example", option.getName());
+        assertEquals("1", option.getValue().toString());
+        assertTrue(option.isUseEquals());
+    }
+
+    @Test
+    public void testPostgreSqlIndexTrailingClausesIssue2525() throws JSQLParserException {
+        String includeSql = "CREATE UNIQUE INDEX pg_idx_nulls ON pg_index_test (email) "
+                + "INCLUDE (payload) NULLS NOT DISTINCT";
+        CreateIndex include = (CreateIndex) assertSqlCanBeParsedAndDeparsed(
+                includeSql, true, parser -> parser.withDialect(Dialect.POSTGRESQL));
+        assertEquals(List.of("payload"), include.getIncludeColumns());
+        assertEquals(Boolean.FALSE, include.getNullsDistinct());
+
+        String trailingSql = "CREATE INDEX pg_idx_with ON pg_index_test (id) "
+                + "WITH (fillfactor = 80) TABLESPACE pg_default WHERE active";
+        CreateIndex trailing = (CreateIndex) assertSqlCanBeParsedAndDeparsed(
+                trailingSql, true, parser -> parser.withDialect(Dialect.POSTGRESQL));
+        Index.Option fillfactor = trailing.getStorageParameters().get(0);
+        assertEquals("fillfactor", fillfactor.getName());
+        assertEquals("80", fillfactor.getValue().toString());
+        assertTrue(fillfactor.isUseEquals());
+        assertEquals("pg_default", trailing.getTableSpace());
+        assertEquals("active", trailing.getWhere().toString());
     }
 }


### PR DESCRIPTION
## Summary

- model key collation, operator class and parameters, sort order, and null ordering
- add structured `INCLUDE`, `NULLS [NOT] DISTINCT`, storage parameters, tablespace, and predicate fields
- update the `CREATE INDEX` deparser
- continue mirroring key tokens in the legacy flat parameter list for compatibility

## Testing

- `./gradlew check`

Fixes #2525

## AI assistance

OpenAI Codex assisted with the implementation and test coverage. The changes were manually reviewed and verified against PostgreSQL syntax.