### PR TITLE
test: fail the build when TablesNamesFinder misses a visitor dispatch method

### DIFF
--- a/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderCompletenessTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderCompletenessTest.java
@@ -1,0 +1,82 @@
+package net.sf.jsqlparser.util;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * TablesNamesFinder collects tables by dispatching through the visitor interfaces it declares. Most
+ * dispatch methods are abstract, so a missing implementation fails the build already. But the
+ * interfaces progressively gain default methods (e.g. SelectVisitor#visit(PivotQuery, context)
+ * returns null), and for those a missing TablesNamesFinder implementation compiles silently and
+ * loses the tables of that node type without any test failing.
+ *
+ * This test fails the build when a declared visitor interface has a dispatch method visit(Node,
+ * context) for an AST node that is not implemented in the TablesNamesFinder class hierarchy (it
+ * resolves to an interface default instead). It does not catch empty-shell implementations (an
+ * override that visits nothing) nor visitor families the finder does not declare at all: both
+ * remain manual review duties.
+ */
+public class TablesNamesFinderCompletenessTest {
+
+    // GroupByElement: ExpressionVisitor's default forwards the group-by expressions and the
+    // grouping sets to the visitor, TablesNamesFinder relies on it from visit(PlainSelect).
+    private static final Set<String> INHERITED_DISPATCH_NODES =
+            Set.of("net.sf.jsqlparser.statement.select.GroupByElement");
+
+    @Test
+    void testImplementsEveryDispatchMethodOfEveryDeclaredVisitorInterface()
+            throws NoSuchMethodException {
+        Class<?>[] visitorInterfaces = TablesNamesFinder.class.getInterfaces();
+        assertTrue(visitorInterfaces.length >= 8, "TablesNamesFinder must keep declaring the"
+                + " visitor families it dispatches through (currently 8), dropping one shrinks"
+                + " the completeness walk silently.");
+
+        List<String> gaps = new ArrayList<>();
+        List<String> interfacesWithoutDispatch = new ArrayList<>();
+        for (Class<?> visitorInterface : visitorInterfaces) {
+            int dispatchMethods = 0;
+            for (Method dispatch : visitorInterface.getMethods()) {
+                if (!dispatch.getName().equals("visit") || dispatch.getParameterCount() != 2) {
+                    continue;
+                }
+                Class<?> nodeType = dispatch.getParameterTypes()[0];
+                // skips bulk dispatch helpers carrying a java.util collection
+                if (!nodeType.getName().startsWith("net.sf.jsqlparser.")) {
+                    continue;
+                }
+                if (INHERITED_DISPATCH_NODES.contains(nodeType.getName())) {
+                    continue;
+                }
+                dispatchMethods++;
+                Method implementation = TablesNamesFinder.class.getMethod(dispatch.getName(),
+                        dispatch.getParameterTypes());
+                if (implementation.getDeclaringClass().isInterface()) {
+                    gaps.add(visitorInterface.getSimpleName() + "#" + dispatch.getName() + "("
+                            + nodeType.getSimpleName() + ", context)");
+                }
+            }
+            if (dispatchMethods == 0) {
+                interfacesWithoutDispatch.add(visitorInterface.getSimpleName());
+            }
+        }
+
+        assertTrue(interfacesWithoutDispatch.isEmpty(),
+                () -> "No guarded dispatch method found for: "
+                        + String.join(", ", interfacesWithoutDispatch) + ". Either the reflection"
+                        + " walk lost the dispatch methods (filters too narrow, the completeness"
+                        + " check would pass vacuously) or the interface is not a dispatch"
+                        + " interface and must not be declared by TablesNamesFinder.");
+        assertTrue(gaps.isEmpty(), () -> "TablesNamesFinder must implement every dispatch"
+                + " method of the visitor interfaces it declares, otherwise the tables of that"
+                + " node type are silently not collected. Missing:\n" + String.join("\n", gaps)
+                + "\nImplement visit(Node, context) in TablesNamesFinder, or - when the"
+                + " inherited default already forwards every child - document the node in"
+                + " INHERITED_DISPATCH_NODES.");
+    }
+}


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What
Adds `TablesNamesFinderCompletenessTest`: it fails the build when a visitor interface declared by `TablesNamesFinder` gains a dispatch method `visit(Node, context)` that is not implemented in the `TablesNamesFinder` class hierarchy (it resolves to an interface default instead).

## Why
`TablesNamesFinder` dispatches through 8 visitor interfaces. Most `visit(Node, context)` methods are abstract, so a missing implementation fails compilation. But the interfaces progressively gain default methods (`SelectVisitor#visit(PivotQuery, context)` returns null, `ExpressionVisitor#visit(GroupByElement, context)` traverses), and for a default declared by a single interface a missing implementation compiles silently and loses the tables of that node type without any test failing.

Demonstrated on master by mutation: turning `StatementVisitor#visit(Analyze, context)` into a `return null` default and dropping the finder override compiles, keeps the whole test suite green (no existing test collects tables from `ANALYZE`), and `findTables("ANALYZE mytab")` silently returns `[]`.

After #2479 and #2517 the finder implements all 214 dispatch methods; this test pins that state for the interfaces it declares.

## How
- Enumerates the declared visitor interfaces and their `visit(Node, context)` methods by reflection and asserts each resolves to an implementation in the `TablesNamesFinder` class hierarchy (not to an interface default); interfaces declared later are covered automatically.
- Dispatch helpers carrying a `java.util` collection (e.g. `MergeOperationVisitor#visit(Collection<MergeOperation>, context)`) are skipped: bulk dispatch, not an AST node.
- `INHERITED_DISPATCH_NODES` documents the deliberate exception: `ExpressionVisitor`'s `visit(GroupByElement, context)` default already forwards the group-by expressions and the grouping sets, the finder relies on it from `visit(PlainSelect)`.
- The walk guards itself against becoming vacuous: it fails when a declared interface exposes no guarded dispatch method at all (filters too narrow) and when the finder stops declaring one of the 8 visitor families.

## Testing
- New test `TablesNamesFinderCompletenessTest#testImplementsEveryDispatchMethodOfEveryDeclaredVisitorInterface`: green on master (214 dispatch methods verified).
- Mutation 1 (`visit(Analyze, context)` turned into a default + finder override dropped): `findTables("ANALYZE mytab")` returns `[]`, the existing suite stays green, the new test fails naming `StatementVisitor#visit(Analyze, context)`.
- Mutation 2 (allowlist entry removed): the test fails naming `ExpressionVisitor#visit(GroupByElement, context)`, the allowlist is load-bearing.
- Mutation 3 (collection filter removed): the test fails naming `MergeOperationVisitor#visit(Collection, context)`, the filter is load-bearing.
- Mutation 4 (walk matches no dispatch method): the test fails through the vacuousness assertion naming all declared interfaces, the guard cannot silently degrade to always-green.
- 本地验证：`./gradlew check`（5081 tests, 0 failures）。
- 未覆盖的边界/风险：interface-level gaps only. Empty-shell implementations (an override that visits nothing, the #2478 shape) and visitor families the finder does not declare at all are not detected: both remain manual review duties. Methods declared by two interfaces at once (e.g. `visit(PivotQuery, context)`) are compiler-enforced through the unrelated-defaults rule and only belt-and-braces here.
