### PR TITLE
Support structured MySQL table definitions

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -1163,6 +1163,10 @@ public class AlterExpression implements Serializable {
                 b.append("IF EXISTS ");
             }
             b.append(constraintName);
+        } else if (index != null) {
+            // The structured index is canonical. Legacy PK/UK/FK fields may also be populated for
+            // source compatibility, but cannot represent names, expressions, or index options.
+            b.append(index);
         } else if (pkColumns != null) {
             b.append("PRIMARY KEY (").append(PlainSelect.getStringList(pkColumns)).append(')');
         } else if (ukColumns != null) {
@@ -1195,8 +1199,6 @@ public class AlterExpression implements Serializable {
                     .append(PlainSelect.getStringList(fkSourceColumns))
                     .append(")");
             referentialActions.forEach(b::append);
-        } else if (index != null) {
-            b.append(index);
         }
 
         if (getConstraints() != null && !getConstraints().isEmpty()) {

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/CheckConstraint.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/CheckConstraint.java
@@ -23,6 +23,10 @@ public class CheckConstraint extends NamedConstraint {
 
     private Boolean enforced;
 
+    public CheckConstraint() {
+        setKind(Kind.CHECK);
+    }
+
     public Table getTable() {
         return table;
     }

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/ColDataType.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/ColDataType.java
@@ -28,6 +28,14 @@ public class ColDataType implements Serializable {
         SIGNED, UNSIGNED
     }
 
+    public enum TypeModifier {
+        SIGNED, UNSIGNED, ZEROFILL
+    }
+
+    public enum NationalCharacterType {
+        CHAR, VARCHAR
+    }
+
     private String dataType;
     private List<String> argumentsStringList;
     private String characterSet;
@@ -37,6 +45,8 @@ public class ColDataType implements Serializable {
     private boolean zerofill;
     private Integer precision;
     private Integer scale;
+    private List<TypeModifier> typeModifiers;
+    private NationalCharacterType nationalCharacterType;
 
     public ColDataType() {
         // empty constructor
@@ -120,6 +130,58 @@ public class ColDataType implements Serializable {
         this.zerofill = zerofill;
     }
 
+    /** Returns MySQL numeric modifiers in their original order, including repetitions. */
+    public List<TypeModifier> getTypeModifiers() {
+        return typeModifiers;
+    }
+
+    public void setTypeModifiers(List<TypeModifier> typeModifiers) {
+        this.typeModifiers = typeModifiers;
+        signedness = null;
+        zerofill = false;
+        if (typeModifiers != null) {
+            for (TypeModifier modifier : typeModifiers) {
+                updateEffectiveModifier(modifier);
+            }
+        }
+    }
+
+    public void addTypeModifier(TypeModifier typeModifier) {
+        if (typeModifiers == null) {
+            typeModifiers = new ArrayList<>();
+        }
+        typeModifiers.add(typeModifier);
+        updateEffectiveModifier(typeModifier);
+    }
+
+    private void updateEffectiveModifier(TypeModifier modifier) {
+        switch (modifier) {
+            case SIGNED:
+                signedness = Signedness.SIGNED;
+                break;
+            case UNSIGNED:
+                signedness = Signedness.UNSIGNED;
+                break;
+            case ZEROFILL:
+                zerofill = true;
+                break;
+            default:
+                break;
+        }
+    }
+
+    public NationalCharacterType getNationalCharacterType() {
+        return nationalCharacterType;
+    }
+
+    public void setNationalCharacterType(NationalCharacterType nationalCharacterType) {
+        this.nationalCharacterType = nationalCharacterType;
+    }
+
+    public boolean isNational() {
+        return nationalCharacterType != null;
+    }
+
     /**
      * The first numeric type parameter, e.g. {@code 255} for {@code VARCHAR(255)} or {@code 10} for
      * {@code DECIMAL(10, 2)}. {@code MAX} is reported as {@link Integer#MAX_VALUE}. Returns
@@ -161,8 +223,10 @@ public class ColDataType implements Serializable {
                 + (argumentsStringList != null
                         ? " " + PlainSelect.getStringList(argumentsStringList, true, true)
                         : "")
-                + (signedness != null ? " " + signedness : "")
-                + (zerofill ? " ZEROFILL" : "")
+                + (typeModifiers != null && !typeModifiers.isEmpty()
+                        ? " " + PlainSelect.getStringList(typeModifiers, false, false)
+                        : (signedness != null ? " " + signedness : "")
+                                + (zerofill ? " ZEROFILL" : ""))
                 + arraySpec.toString()
                 + (characterSet != null ? " CHARACTER SET " + characterSet : "");
     }
@@ -199,6 +263,16 @@ public class ColDataType implements Serializable {
 
     public ColDataType withZerofill(boolean zerofill) {
         setZerofill(zerofill);
+        return this;
+    }
+
+    public ColDataType withTypeModifiers(List<TypeModifier> typeModifiers) {
+        setTypeModifiers(typeModifiers);
+        return this;
+    }
+
+    public ColDataType withNationalCharacterType(NationalCharacterType nationalCharacterType) {
+        setNationalCharacterType(nationalCharacterType);
         return this;
     }
 
@@ -254,7 +328,9 @@ public class ColDataType implements Serializable {
                 && Objects.equals(intervalQualifier, that.intervalQualifier)
                 && Objects.equals(arrayData, that.arrayData)
                 && signedness == that.signedness
-                && zerofill == that.zerofill;
+                && zerofill == that.zerofill
+                && Objects.equals(typeModifiers, that.typeModifiers)
+                && nationalCharacterType == that.nationalCharacterType;
     }
 
     @Override
@@ -266,6 +342,8 @@ public class ColDataType implements Serializable {
         result = 31 * result + Objects.hashCode(arrayData);
         result = 31 * result + Objects.hashCode(signedness);
         result = 31 * result + Boolean.hashCode(zerofill);
+        result = 31 * result + Objects.hashCode(typeModifiers);
+        result = 31 * result + Objects.hashCode(nationalCharacterType);
         return result;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/ColumnDefinition.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/ColumnDefinition.java
@@ -22,11 +22,12 @@ import java.util.Optional;
 /**
  * Globally used definition class for columns.
  */
-public class ColumnDefinition implements ImportColumn, Serializable {
+public class ColumnDefinition implements ImportColumn, TableElement, Serializable {
 
     private String columnName;
     private ColDataType colDataType;
     private List<String> columnSpecs;
+    private List<ColumnOption> columnOptions;
 
     public ColumnDefinition() {}
 
@@ -46,6 +47,47 @@ public class ColumnDefinition implements ImportColumn, Serializable {
 
     public void setColumnSpecs(List<String> list) {
         columnSpecs = list;
+        columnOptions = null;
+    }
+
+    /**
+     * Returns column options in source order, including structured references and MySQL
+     * {@code SERIAL DEFAULT VALUE}.
+     */
+    public List<ColumnOption> getColumnOptions() {
+        return columnOptions;
+    }
+
+    public void setColumnOptions(List<ColumnOption> columnOptions) {
+        this.columnOptions = columnOptions;
+    }
+
+    public boolean isSerialDefaultValue() {
+        return columnOptions != null && columnOptions.stream()
+                .anyMatch(option -> option.getKind() == ColumnOption.Kind.SERIAL_DEFAULT_VALUE);
+    }
+
+    public ForeignKeyReference getForeignKeyReference() {
+        if (columnOptions == null) {
+            return null;
+        }
+        return columnOptions.stream()
+                .filter(option -> option.getKind() == ColumnOption.Kind.REFERENCE)
+                .map(ColumnOption::getForeignKeyReference)
+                .findFirst()
+                .orElse(null);
+    }
+
+    public ColumnDefinition withColumnOptions(List<ColumnOption> columnOptions) {
+        setColumnOptions(columnOptions);
+        return this;
+    }
+
+    public ColumnDefinition addColumnOptions(ColumnOption... columnOptions) {
+        List<ColumnOption> collection =
+                Optional.ofNullable(getColumnOptions()).orElseGet(ArrayList::new);
+        Collections.addAll(collection, columnOptions);
+        return withColumnOptions(collection);
     }
 
     public ColDataType getColDataType() {
@@ -71,9 +113,11 @@ public class ColumnDefinition implements ImportColumn, Serializable {
 
     public String toStringDataTypeAndSpec() {
         return (colDataType == null ? "" : colDataType)
-                + (columnSpecs != null && !columnSpecs.isEmpty()
-                        ? " " + PlainSelect.getStringList(columnSpecs, false, false)
-                        : "");
+                + (columnOptions != null && !columnOptions.isEmpty()
+                        ? " " + PlainSelect.getStringList(columnOptions, false, false)
+                        : columnSpecs != null && !columnSpecs.isEmpty()
+                                ? " " + PlainSelect.getStringList(columnSpecs, false, false)
+                                : "");
     }
 
     public ColumnDefinition withColumnName(String columnName) {

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/ColumnOption.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/ColumnOption.java
@@ -1,0 +1,70 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.table;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+
+/** A structured option following a column data type. */
+public class ColumnOption implements Serializable {
+
+    public enum Kind {
+        SERIAL_DEFAULT_VALUE, REFERENCE, OTHER
+    }
+
+    private Kind kind = Kind.OTHER;
+    private List<String> tokens;
+    private ForeignKeyReference foreignKeyReference;
+
+    public static ColumnOption raw(List<String> tokens) {
+        ColumnOption option = new ColumnOption();
+        option.tokens = tokens;
+        return option;
+    }
+
+    public static ColumnOption raw(String... tokens) {
+        return raw(Arrays.asList(tokens));
+    }
+
+    public static ColumnOption serialDefaultValue() {
+        ColumnOption option = raw("SERIAL", "DEFAULT", "VALUE");
+        option.kind = Kind.SERIAL_DEFAULT_VALUE;
+        return option;
+    }
+
+    public static ColumnOption reference(ForeignKeyReference reference) {
+        ColumnOption option = new ColumnOption();
+        option.kind = Kind.REFERENCE;
+        option.foreignKeyReference = reference;
+        return option;
+    }
+
+    public Kind getKind() {
+        return kind;
+    }
+
+    public List<String> getTokens() {
+        return kind == Kind.REFERENCE ? Collections.singletonList(foreignKeyReference.toString())
+                : tokens;
+    }
+
+    public ForeignKeyReference getForeignKeyReference() {
+        return foreignKeyReference;
+    }
+
+    @Override
+    public String toString() {
+        return kind == Kind.REFERENCE ? foreignKeyReference.toString()
+                : PlainSelect.getStringList(tokens, false, false);
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/CreateTable.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/CreateTable.java
@@ -28,9 +28,11 @@ public class CreateTable implements Statement {
     private boolean unlogged = false;
     private List<String> createOptionsStrings;
     private List<String> tableOptionsStrings;
+    private List<TableOption> tableOptions;
     private List<ColumnDefinition> columnDefinitions;
     private List<String> columns;
     private List<Index> indexes;
+    private List<TableElement> tableElements;
     private Select select;
     private Table likeTable;
     private boolean selectParenthesis;
@@ -74,6 +76,7 @@ public class CreateTable implements Statement {
 
     public void setColumnDefinitions(List<ColumnDefinition> list) {
         columnDefinitions = list;
+        tableElements = null;
     }
 
     public List<String> getColumns() {
@@ -94,6 +97,31 @@ public class CreateTable implements Statement {
 
     public void setTableOptionsStrings(List<String> tableOptionsStrings) {
         this.tableOptionsStrings = tableOptionsStrings;
+        tableOptions = null;
+    }
+
+    /** Returns typed table options in source order. */
+    public List<TableOption> getTableOptions() {
+        return tableOptions;
+    }
+
+    public void setTableOptions(List<TableOption> tableOptions) {
+        this.tableOptions = tableOptions;
+        if (tableOptions == null) {
+            tableOptionsStrings = null;
+            return;
+        }
+        tableOptionsStrings = new ArrayList<>();
+        for (TableOption option : tableOptions) {
+            tableOptionsStrings.addAll(option.getTokens());
+        }
+    }
+
+    /** Returns the first option of the requested kind, if present. */
+    public Optional<TableOption> getTableOption(TableOption.Kind kind) {
+        return Optional.ofNullable(tableOptions).orElseGet(Collections::emptyList).stream()
+                .filter(option -> option.getKind() == kind)
+                .findFirst();
     }
 
     public List<String> getCreateOptionsStrings() {
@@ -115,6 +143,46 @@ public class CreateTable implements Statement {
 
     public void setIndexes(List<Index> list) {
         indexes = list;
+        tableElements = null;
+    }
+
+    /**
+     * Returns columns, constraints, and indexes in the order in which they were declared.
+     */
+    public List<TableElement> getTableElements() {
+        return tableElements;
+    }
+
+    public void setTableElements(List<TableElement> tableElements) {
+        this.tableElements = tableElements;
+        if (tableElements == null) {
+            columnDefinitions = null;
+            indexes = null;
+            return;
+        }
+        columnDefinitions = new ArrayList<>();
+        indexes = new ArrayList<>();
+        for (TableElement element : tableElements) {
+            if (element instanceof ColumnDefinition) {
+                columnDefinitions.add((ColumnDefinition) element);
+            } else if (element instanceof Index) {
+                indexes.add((Index) element);
+            }
+        }
+    }
+
+    /** Returns table elements of a requested AST type while preserving their declaration order. */
+    public <E extends TableElement> List<E> getTableElements(Class<E> type) {
+        if (tableElements == null) {
+            return Collections.emptyList();
+        }
+        List<E> result = new ArrayList<>();
+        for (TableElement element : tableElements) {
+            if (type.isInstance(element)) {
+                result.add(type.cast(element));
+            }
+        }
+        return result;
     }
 
     public Select getSelect() {
@@ -233,7 +301,11 @@ public class CreateTable implements Statement {
             b.append(" ");
             b.append(PlainSelect.getStringList(columns, true, true));
         }
-        if (columnDefinitions != null && !columnDefinitions.isEmpty()) {
+        if (tableElements != null && !tableElements.isEmpty()) {
+            b.append(" (");
+            b.append(PlainSelect.getStringList(tableElements, true, false));
+            b.append(")");
+        } else if (columnDefinitions != null && !columnDefinitions.isEmpty()) {
             b.append(" (");
             b.append(PlainSelect.getStringList(columnDefinitions, true, false));
             if (indexes != null && !indexes.isEmpty()) {
@@ -245,7 +317,9 @@ public class CreateTable implements Statement {
     }
 
     private void appendTableOptions(StringBuilder b) {
-        String options = PlainSelect.getStringList(tableOptionsStrings, false, false);
+        String options = tableOptions != null
+                ? PlainSelect.getStringList(tableOptions, false, false)
+                : PlainSelect.getStringList(tableOptionsStrings, false, false);
         if (options != null && options.length() > 0) {
             b.append(" ").append(options);
         }
@@ -333,6 +407,11 @@ public class CreateTable implements Statement {
         return this;
     }
 
+    public CreateTable withTableOptions(List<TableOption> tableOptions) {
+        this.setTableOptions(tableOptions);
+        return this;
+    }
+
     public CreateTable withColumnDefinitions(List<ColumnDefinition> columnDefinitions) {
         this.setColumnDefinitions(columnDefinitions);
         return this;
@@ -345,6 +424,11 @@ public class CreateTable implements Statement {
 
     public CreateTable withIndexes(List<Index> indexes) {
         this.setIndexes(indexes);
+        return this;
+    }
+
+    public CreateTable withTableElements(List<TableElement> tableElements) {
+        this.setTableElements(tableElements);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/ForeignKeyIndex.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/ForeignKeyIndex.java
@@ -28,21 +28,58 @@ public class ForeignKeyIndex extends NamedConstraint {
     private Table table;
     private List<String> referencedColumnNames;
     private Set<ReferentialAction> referentialActions = new LinkedHashSet<>(2);
+    private ForeignKeyReference reference;
+
+    public ForeignKeyReference getReference() {
+        if (reference == null) {
+            reference = new ForeignKeyReference();
+            reference.setTable(table);
+            reference.setReferencedColumnNames(referencedColumnNames);
+            for (ReferentialAction action : referentialActions) {
+                reference.setReferentialAction(action.getType(), action.getAction());
+            }
+        }
+        return reference;
+    }
+
+    public void setReference(ForeignKeyReference reference) {
+        this.reference = reference;
+        if (reference != null) {
+            table = reference.getTable();
+            referencedColumnNames = reference.getReferencedColumnNames();
+            referentialActions.clear();
+            referentialActions.addAll(reference.getReferentialActions());
+        }
+    }
+
+    public ForeignKeyReference.MatchType getMatchType() {
+        return reference != null ? reference.getMatchType() : null;
+    }
+
+    public void setMatchType(ForeignKeyReference.MatchType matchType) {
+        getReference().setMatchType(matchType);
+    }
 
     public Table getTable() {
-        return table;
+        return reference != null ? reference.getTable() : table;
     }
 
     public void setTable(Table table) {
         this.table = table;
+        if (reference != null) {
+            reference.setTable(table);
+        }
     }
 
     public List<String> getReferencedColumnNames() {
-        return referencedColumnNames;
+        return reference != null ? reference.getReferencedColumnNames() : referencedColumnNames;
     }
 
     public void setReferencedColumnNames(List<String> referencedColumnNames) {
         this.referencedColumnNames = referencedColumnNames;
+        if (reference != null) {
+            reference.setReferencedColumnNames(referencedColumnNames);
+        }
     }
 
     /**
@@ -70,6 +107,9 @@ public class ForeignKeyIndex extends NamedConstraint {
      * @return
      */
     public ReferentialAction getReferentialAction(Type type) {
+        if (reference != null) {
+            return reference.getReferentialAction(type);
+        }
         return referentialActions.stream().filter(ra -> type.equals(ra.getType())).findFirst()
                 .orElse(null);
     }
@@ -77,6 +117,10 @@ public class ForeignKeyIndex extends NamedConstraint {
     private void setReferentialAction(Type type, Action action, boolean set) {
         ReferentialAction found = getReferentialAction(type);
         if (set) {
+            if (reference != null) {
+                reference.setReferentialAction(type, action);
+                return;
+            }
             if (found == null) {
                 referentialActions.add(new ReferentialAction(type, action));
             } else {
@@ -84,6 +128,9 @@ public class ForeignKeyIndex extends NamedConstraint {
             }
         } else if (found != null) {
             referentialActions.remove(found);
+            if (reference != null) {
+                reference.removeReferentialAction(type);
+            }
         }
     }
 
@@ -119,9 +166,14 @@ public class ForeignKeyIndex extends NamedConstraint {
 
     @Override
     public String toString() {
-        StringBuilder b = new StringBuilder(super.toString()).append(" REFERENCES ").append(table)
-                .append(PlainSelect.getStringList(getReferencedColumnNames(), true, true));
-        referentialActions.forEach(b::append);
+        StringBuilder b = new StringBuilder(super.toString()).append(" ");
+        if (reference != null) {
+            b.append(reference);
+        } else {
+            b.append("REFERENCES ").append(table)
+                    .append(PlainSelect.getStringList(getReferencedColumnNames(), true, true));
+            referentialActions.forEach(b::append);
+        }
         return b.toString();
     }
 
@@ -132,6 +184,16 @@ public class ForeignKeyIndex extends NamedConstraint {
 
     public ForeignKeyIndex withReferencedColumnNames(List<String> referencedColumnNames) {
         this.setReferencedColumnNames(referencedColumnNames);
+        return this;
+    }
+
+    public ForeignKeyIndex withReference(ForeignKeyReference reference) {
+        setReference(reference);
+        return this;
+    }
+
+    public ForeignKeyIndex withMatchType(ForeignKeyReference.MatchType matchType) {
+        setMatchType(matchType);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/ForeignKeyReference.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/ForeignKeyReference.java
@@ -1,0 +1,135 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.table;
+
+import java.io.Serializable;
+import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.ReferentialAction;
+import net.sf.jsqlparser.statement.ReferentialAction.Action;
+import net.sf.jsqlparser.statement.ReferentialAction.Type;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+
+/** The target and actions of a column- or table-level foreign-key reference. */
+public class ForeignKeyReference implements Serializable {
+
+    public enum MatchType {
+        FULL, PARTIAL, SIMPLE
+    }
+
+    private Table table;
+    private List<String> referencedColumnNames;
+    private MatchType matchType;
+    private final Set<ReferentialAction> referentialActions = new LinkedHashSet<>(2);
+
+    public Table getTable() {
+        return table;
+    }
+
+    public void setTable(Table table) {
+        this.table = table;
+    }
+
+    public List<String> getReferencedColumnNames() {
+        return referencedColumnNames;
+    }
+
+    public void setReferencedColumnNames(List<String> referencedColumnNames) {
+        this.referencedColumnNames = referencedColumnNames;
+    }
+
+    public MatchType getMatchType() {
+        return matchType;
+    }
+
+    public void setMatchType(MatchType matchType) {
+        this.matchType = matchType;
+    }
+
+    public Set<ReferentialAction> getReferentialActions() {
+        return referentialActions;
+    }
+
+    public ReferentialAction getReferentialAction(Type type) {
+        return referentialActions.stream().filter(action -> type.equals(action.getType()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public void setReferentialAction(Type type, Action action) {
+        ReferentialAction current = getReferentialAction(type);
+        if (current == null) {
+            referentialActions.add(new ReferentialAction(type, action));
+        } else {
+            current.setAction(action);
+        }
+    }
+
+    public void removeReferentialAction(Type type) {
+        ReferentialAction current = getReferentialAction(type);
+        if (current != null) {
+            referentialActions.remove(current);
+        }
+    }
+
+    public ForeignKeyReference withTable(Table table) {
+        setTable(table);
+        return this;
+    }
+
+    public ForeignKeyReference withReferencedColumnNames(List<String> referencedColumnNames) {
+        setReferencedColumnNames(referencedColumnNames);
+        return this;
+    }
+
+    public ForeignKeyReference withMatchType(MatchType matchType) {
+        setMatchType(matchType);
+        return this;
+    }
+
+    public ForeignKeyReference withReferentialAction(Type type, Action action) {
+        setReferentialAction(type, action);
+        return this;
+    }
+
+    public ForeignKeyReference addReferencedColumnNames(String... referencedColumnNames) {
+        List<String> collection = Optional.ofNullable(getReferencedColumnNames())
+                .orElseGet(ArrayList::new);
+        Collections.addAll(collection, referencedColumnNames);
+        return withReferencedColumnNames(collection);
+    }
+
+    public ForeignKeyReference addReferencedColumnNames(
+            Collection<String> referencedColumnNames) {
+        List<String> collection = Optional.ofNullable(getReferencedColumnNames())
+                .orElseGet(ArrayList::new);
+        collection.addAll(referencedColumnNames);
+        return withReferencedColumnNames(collection);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("REFERENCES ").append(table);
+        if (referencedColumnNames != null) {
+            builder.append(PlainSelect.getStringList(referencedColumnNames, true, true));
+        }
+        if (matchType != null) {
+            builder.append(" MATCH ").append(matchType);
+        }
+        referentialActions.forEach(builder::append);
+        return builder.toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
@@ -20,7 +20,11 @@ import java.util.Optional;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 
-public class Index implements Serializable {
+public class Index implements TableElement, Serializable {
+
+    public enum Kind {
+        PRIMARY_KEY, UNIQUE, INDEX, FULLTEXT, SPATIAL, FOREIGN_KEY, CHECK, EXCLUDE, OTHER
+    }
 
     private final List<String> name = new ArrayList<>();
     private String type;
@@ -29,10 +33,11 @@ public class Index implements Serializable {
     private List<String> idxSpec;
     private String commentText;
     private String indexKeyword;
+    private Kind kind = Kind.OTHER;
 
     public List<String> getColumnsNames() {
         return columns.stream()
-                .map(ColumnParams::getColumnName)
+                .map(ColumnParams::toString)
                 .collect(toList());
     }
 
@@ -105,6 +110,34 @@ public class Index implements Serializable {
 
     public void setType(String string) {
         type = string;
+        if (kind == Kind.OTHER && string != null) {
+            String normalized = string.toUpperCase(java.util.Locale.ROOT);
+            if (normalized.startsWith("PRIMARY")) {
+                kind = Kind.PRIMARY_KEY;
+            } else if (normalized.startsWith("UNIQUE")) {
+                kind = Kind.UNIQUE;
+            } else if (normalized.startsWith("FULLTEXT")) {
+                kind = Kind.FULLTEXT;
+            } else if (normalized.startsWith("SPATIAL")) {
+                kind = Kind.SPATIAL;
+            } else if (normalized.startsWith("FOREIGN")) {
+                kind = Kind.FOREIGN_KEY;
+            } else if (normalized.startsWith("CHECK")) {
+                kind = Kind.CHECK;
+            } else if (normalized.startsWith("EXCLUDE")) {
+                kind = Kind.EXCLUDE;
+            } else if (normalized.contains("INDEX") || normalized.contains("KEY")) {
+                kind = Kind.INDEX;
+            }
+        }
+    }
+
+    public Kind getKind() {
+        return kind;
+    }
+
+    public void setKind(Kind kind) {
+        this.kind = kind;
     }
 
     public Index withColumnsNames(List<String> list) {
@@ -156,7 +189,11 @@ public class Index implements Serializable {
     @Override
     public String toString() {
         String idxSpecText = PlainSelect.getStringList(idxSpec, false, false);
-        String keyword = (indexKeyword != null) ? " " + indexKeyword : "";
+        String keyword = indexKeyword != null
+                && (type == null || !type.toUpperCase(java.util.Locale.ROOT)
+                        .endsWith(indexKeyword.toUpperCase(java.util.Locale.ROOT)))
+                                ? " " + indexKeyword
+                                : "";
         String head =
                 (type != null ? type : "") +
                         keyword +
@@ -173,6 +210,11 @@ public class Index implements Serializable {
 
     public Index withType(String type) {
         this.setType(type);
+        return this;
+    }
+
+    public Index withKind(Kind kind) {
+        setKind(kind);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/NamedConstraint.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/NamedConstraint.java
@@ -47,7 +47,13 @@ public class NamedConstraint extends Index {
         String head = useConstraintKeyword || getName() != null
                 ? "CONSTRAINT" + (getName() != null ? " " + getName() : "") + " "
                 : "";
+        String keyword = getIndexKeyword() != null
+                && !getType().toUpperCase(java.util.Locale.ROOT)
+                        .endsWith(getIndexKeyword().toUpperCase(java.util.Locale.ROOT))
+                                ? " " + getIndexKeyword()
+                                : "";
         String tail = getType()
+                + keyword
                 + (indexName != null ? " " + indexName : "")
                 + (getUsing() != null ? " USING " + getUsing() : "")
                 + " " + PlainSelect.getStringList(getColumnsNames(), true, true) +

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/TableElement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/TableElement.java
@@ -1,0 +1,22 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.table;
+
+import java.io.Serializable;
+
+/**
+ * A column or table constraint/index declared inside a {@code CREATE TABLE} definition.
+ *
+ * <p>
+ * This common type lets callers inspect table elements in their source order without merging the
+ * legacy column and index lists themselves.
+ */
+public interface TableElement extends Serializable {
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/TableOption.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/TableOption.java
@@ -1,0 +1,132 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.table;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+
+/** A structured option following a {@code CREATE TABLE} definition. */
+public class TableOption implements Serializable {
+
+    public enum Kind {
+        ENGINE, CHARACTER_SET, COLLATE, COMMENT, AUTO_INCREMENT, OTHER
+    }
+
+    private Kind kind = Kind.OTHER;
+    private String name;
+    private String value;
+    private boolean useEquals;
+    private List<String> tokens;
+
+    public TableOption() {}
+
+    public TableOption(Kind kind, String name, String value, boolean useEquals) {
+        this.kind = kind;
+        this.name = name;
+        this.value = value;
+        this.useEquals = useEquals;
+    }
+
+    public static TableOption raw(List<String> tokens) {
+        TableOption option = new TableOption();
+        option.setTokens(tokens);
+        return option;
+    }
+
+    public static TableOption raw(String... tokens) {
+        return raw(Arrays.asList(tokens));
+    }
+
+    public Kind getKind() {
+        return kind;
+    }
+
+    public void setKind(Kind kind) {
+        this.kind = kind;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public boolean isUseEquals() {
+        return useEquals;
+    }
+
+    public void setUseEquals(boolean useEquals) {
+        this.useEquals = useEquals;
+    }
+
+    /** Returns the original token groups used by the legacy table-options API. */
+    public List<String> getTokens() {
+        if (tokens != null) {
+            return tokens;
+        }
+        List<String> result = new ArrayList<>();
+        if (name != null) {
+            Collections.addAll(result, name.trim().split("\\s+"));
+        }
+        if (useEquals) {
+            result.add("=");
+        }
+        if (value != null) {
+            result.add(value);
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    public void setTokens(List<String> tokens) {
+        this.tokens = tokens;
+    }
+
+    public TableOption withKind(Kind kind) {
+        setKind(kind);
+        return this;
+    }
+
+    public TableOption withName(String name) {
+        setName(name);
+        return this;
+    }
+
+    public TableOption withValue(String value) {
+        setValue(value);
+        return this;
+    }
+
+    public TableOption withUseEquals(boolean useEquals) {
+        setUseEquals(useEquals);
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        if (tokens != null) {
+            return PlainSelect.getStringList(tokens, false, false);
+        }
+        return name + (value != null ? (useEquals ? " = " : " ") + value : "");
+    }
+}

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1198,7 +1198,8 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
 
     private boolean isMySqlTableOptionAhead() {
         int kind = getToken(1).kind;
-        if (kind == K_ENGINE) {
+        if (kind == K_ENGINE || kind == K_COLLATE || kind == K_COMMENT
+                || kind == K_AUTO_INCREMENT) {
             return true;
         }
         if (kind == K_CHARACTER && getToken(2).kind == K_SET
@@ -1212,7 +1213,7 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
             return false;
         }
         int secondKind = getToken(2).kind;
-        return secondKind == K_CHARACTER || secondKind == K_CHAR
+        return secondKind == K_CHARACTER || secondKind == K_CHAR || secondKind == K_COLLATE
                 || secondKind == S_IDENTIFIER
                         && "CHARSET".equalsIgnoreCase(getToken(2).image);
     }
@@ -11880,7 +11881,7 @@ TableOption MySqlTableOption(): {
     String value;
     boolean useEquals = false;
     String name = "";
-    TableOption.Kind kind;
+    TableOption.Kind kind = null;
     TableOption option;
 } {
     (
@@ -11902,8 +11903,27 @@ TableOption MySqlTableOption(): {
             }
             |
             tk=<S_IDENTIFIER> { name += tk.image; }
+            |
+            tk=<K_COLLATE> {
+                name += tk.image;
+                kind = TableOption.Kind.COLLATE;
+            }
         )
-        { kind = TableOption.Kind.CHARACTER_SET; }
+        { if (kind == null) { kind = TableOption.Kind.CHARACTER_SET; } }
+        [ "=" { useEquals = true; } ]
+        value=MySqlTableOptionValue()
+        |
+        tk=<K_COMMENT> {
+            name = tk.image;
+            kind = TableOption.Kind.COMMENT;
+        }
+        [ "=" { useEquals = true; } ]
+        value=MySqlTableOptionValue()
+        |
+        tk=<K_AUTO_INCREMENT> {
+            name = tk.image;
+            kind = TableOption.Kind.AUTO_INCREMENT;
+        }
         [ "=" { useEquals = true; } ]
         value=MySqlTableOptionValue()
     )
@@ -11921,6 +11941,9 @@ String MySqlTableOptionValue(): {
         value=RelObjectName()
         | token=<K_CSV> { value = token.image; }
         | token=<K_BINARY> { value = token.image; }
+        | token=<S_CHAR_LITERAL> { value = token.image; }
+        | token=<S_LONG> { value = token.image; }
+        | token=<S_DOUBLE> { value = token.image; }
     )
     { return value; }
 }
@@ -12352,6 +12375,7 @@ CheckConstraint CheckConstraintSpec(String constraintName):
 {
     Expression exp = null;
     Boolean enforced = null;
+    CheckConstraint checkConstraint;
 }
 {
     <K_CHECK> ( LOOKAHEAD(2) "(" exp = Expression() ")" )*
@@ -12360,8 +12384,10 @@ CheckConstraint CheckConstraintSpec(String constraintName):
         <K_ENFORCED> { if (enforced == null) { enforced = true; } }
     ]
     {
-        return new CheckConstraint().withName(constraintName).withExpression(exp)
+        checkConstraint = new CheckConstraint().withName(constraintName).withExpression(exp)
                 .withEnforced(enforced);
+        checkConstraint.setKind(Index.Kind.CHECK);
+        return checkConstraint;
     }
 }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1191,6 +1191,60 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
         return false;
     }
 
+    private boolean isKeywordAhead(String keyword) {
+        Token token = getToken(1);
+        return token.image != null && keyword.equalsIgnoreCase(token.image);
+    }
+
+    private boolean isMySqlTableOptionAhead() {
+        int kind = getToken(1).kind;
+        if (kind == K_ENGINE) {
+            return true;
+        }
+        if (kind == K_CHARACTER && getToken(2).kind == K_SET
+                || kind == K_CHAR && getToken(2).kind == K_SET) {
+            return true;
+        }
+        if (kind == S_IDENTIFIER && "CHARSET".equalsIgnoreCase(getToken(1).image)) {
+            return true;
+        }
+        if (kind != K_DEFAULT) {
+            return false;
+        }
+        int secondKind = getToken(2).kind;
+        return secondKind == K_CHARACTER || secondKind == K_CHAR
+                || secondKind == S_IDENTIFIER
+                        && "CHARSET".equalsIgnoreCase(getToken(2).image);
+    }
+
+    private boolean isTableIndexAhead() {
+        switch (getToken(1).kind) {
+            case K_PRIMARY:
+            case K_UNIQUE:
+            case K_INDEX:
+            case K_KEY:
+            case K_FULLTEXT:
+            case K_SPATIAL:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private boolean isMySqlDialect() {
+        String dialect = getAsString(Feature.dialect);
+        return Dialect.MYSQL.name().equals(dialect) || Dialect.MARIADB.name().equals(dialect);
+    }
+
+    private static boolean hasStructuredColumnOption(List<ColumnOption> options) {
+        for (ColumnOption option : options) {
+            if (option.getKind() != ColumnOption.Kind.OTHER) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Lightweight lookahead for SpecialStringFunctionWithNamedParameters:
      * scans forward from the current position (just past the opening '(')
@@ -2215,7 +2269,7 @@ TOKEN:
                     }
                 }
     }
-| < S_QUOTED_IDENTIFIER: "\"" ( "\"\"" | ~["\n","\r","\""])* "\"" | ("`" (~["\n","\r","`"])+ "`") | ( "[" (~["\n","\r","]"])* "]" ) >
+| < S_QUOTED_IDENTIFIER: "\"" ( "\"\"" | ~["\n","\r","\""])* "\"" | ("`" ("``" | ~["\n","\r","`"])* "`") | ( "[" (~["\n","\r","]"])* "]" ) >
     {
         if ( !configuration.getAsBoolean(Feature.allowSquareBracketQuotation)
             && matchedToken.image.charAt(0) == '[' ) {
@@ -4876,7 +4930,7 @@ String RelObjectName() :
           | tk=<K_IIF> | tk=<K_IGNORE> | tk=<K_IN> | tk=<K_INTERVAL>
           | tk=<K_LEFT> | tk=<K_LIMIT> | tk=<K_NEXTVAL> | tk=<K_OFFSET>
           | tk=<K_ON> | tk=<K_OPTIMIZE> | tk=<K_ORDER> | tk=<K_PROCEDURE>
-          | tk=<K_PUBLIC> | tk=<K_QUALIFY> | tk=<K_RIGHT>
+          | tk=<K_PUBLIC> | tk=<K_QUALIFY> | tk=<K_RIGHT> | tk=<K_FILE>
           | tk=<K_SET> | tk=<K_SOME> | tk=<K_START> | tk=<K_TABLES>
           | tk=<K_TOP> | tk=<K_VALUE> | tk=<K_VALUES> )
     )
@@ -11425,19 +11479,46 @@ ColumnDefinition ColumnDefinition(): {
     String columnName;
     ColDataType colDataType;
     List<String> columnSpecs = new ArrayList<String>();
-    List<String> parameter;
+    List<ColumnOption> columnOptions = new ArrayList<ColumnOption>();
+    ColumnOption option;
 } {
     columnName=RelObjectName()
     colDataType=ColDataType()
-    ( LOOKAHEAD(2) parameter=ColumnDefinitionParameter() { columnSpecs.addAll(parameter); } )*
+    ( LOOKAHEAD(2) option=ColumnDefinitionOption() {
+        columnOptions.add(option);
+        columnSpecs.addAll(option.getTokens());
+    } )*
     {
         coldef = new ColumnDefinition();
         coldef.setColumnName(columnName);
         coldef.setColDataType(colDataType);
         if (columnSpecs.size() > 0)
             coldef.setColumnSpecs(columnSpecs);
+        if (hasStructuredColumnOption(columnOptions))
+            coldef.setColumnOptions(columnOptions);
         return coldef;
     }
+}
+
+ColumnOption ColumnDefinitionOption(): {
+    Token tk;
+    List<String> parameter;
+    ForeignKeyReference reference;
+    ColumnOption option;
+} {
+    (
+        LOOKAHEAD({ isKeywordAhead("SERIAL")
+                && getToken(2).kind == K_DEFAULT && getToken(3).kind == K_VALUE })
+        tk=<S_IDENTIFIER> <K_DEFAULT> <K_VALUE>
+        { option = ColumnOption.serialDefaultValue(); }
+        |
+        LOOKAHEAD(<K_REFERENCES>) reference=ForeignKeyReferenceSpec()
+        { option = ColumnOption.reference(reference); }
+        |
+        parameter=ColumnDefinitionParameter()
+        { option = ColumnOption.raw(parameter); }
+    )
+    { return option; }
 }
 
 CreateSchema CreateSchema():
@@ -11518,123 +11599,162 @@ CreateDatabase CreateDatabase():
     }
 }
 
+/** Parses PRIMARY, UNIQUE, plain, FULLTEXT, and SPATIAL indexes for CREATE and ALTER. */
+Index TableIndexSpec(boolean createContext):
+{
+    Token typeToken = null;
+    Token keywordToken = null;
+    String indexName = null;
+    String using = null;
+    List<Index.ColumnParams> columns;
+    List<String> indexOptions = new ArrayList<String>();
+    Index index;
+}
+{
+    (
+        typeToken=<K_PRIMARY> keywordToken=<K_KEY>
+        [ LOOKAHEAD({ getToken(1).kind != OPENING_BRACKET }) indexName=RelObjectName() ]
+        columns=IndexColumnsWithParamsList()
+        TableIndexOptions(createContext, indexOptions)
+        {
+            index = new NamedConstraint()
+                    .withIndexName(indexName)
+                    .withType(typeToken.image + " " + keywordToken.image)
+                    .withColumns(columns)
+                    .withIndexSpec(indexOptions);
+        }
+        |
+        typeToken=<K_UNIQUE>
+        [ LOOKAHEAD(2) (keywordToken=<K_KEY> | keywordToken=<K_INDEX>) ]
+        [ LOOKAHEAD({ getToken(1).kind != OPENING_BRACKET
+                && getToken(1).kind != K_USING }) indexName=RelObjectName() ]
+        [ using=UsingIndexType() ]
+        columns=IndexColumnsWithParamsList()
+        TableIndexOptions(createContext, indexOptions)
+        {
+            if (createContext) {
+                index = new NamedConstraint()
+                        .withIndexName(indexName)
+                        .withType(typeToken.image
+                                + (keywordToken != null ? " " + keywordToken.image : ""))
+                        .withUsing(using).withColumns(columns).withIndexSpec(indexOptions);
+            } else {
+                index = new Index().withType(typeToken.image)
+                        .withIndexKeyword(keywordToken != null ? keywordToken.image : null)
+                        .withName(indexName).withUsing(using).withColumns(columns)
+                        .withIndexSpec(indexOptions);
+            }
+        }
+        |
+        typeToken=<K_INDEX>
+        [ LOOKAHEAD({ getToken(1).kind != OPENING_BRACKET
+                && getToken(1).kind != K_USING }) indexName=RelObjectName() ]
+        [ using=UsingIndexType() ]
+        columns=IndexColumnsWithParamsList()
+        TableIndexOptions(createContext, indexOptions)
+        {
+            index = new Index().withType(createContext ? typeToken.image : null)
+                    .withIndexKeyword(typeToken.image).withKind(Index.Kind.INDEX)
+                    .withName(indexName).withUsing(using).withColumns(columns)
+                    .withIndexSpec(indexOptions);
+        }
+        |
+        typeToken=<K_KEY>
+        [ LOOKAHEAD({ getToken(1).kind != OPENING_BRACKET
+                && getToken(1).kind != K_USING }) indexName=RelObjectName() ]
+        [ using=UsingIndexType() ]
+        columns=IndexColumnsWithParamsList()
+        TableIndexOptions(createContext, indexOptions)
+        {
+            index = new Index().withType(createContext ? typeToken.image : null)
+                    .withIndexKeyword(typeToken.image).withKind(Index.Kind.INDEX)
+                    .withName(indexName).withUsing(using).withColumns(columns)
+                    .withIndexSpec(indexOptions);
+        }
+        |
+        (typeToken=<K_FULLTEXT> | typeToken=<K_SPATIAL>)
+        [ LOOKAHEAD(2) (keywordToken=<K_INDEX> | keywordToken=<K_KEY>) ]
+        [ LOOKAHEAD({ getToken(1).kind != OPENING_BRACKET }) indexName=RelObjectName() ]
+        columns=IndexColumnsWithParamsList()
+        TableIndexOptions(createContext, indexOptions)
+        {
+            index = new Index().withType(typeToken.image
+                            + (createContext && keywordToken != null
+                                    ? " " + keywordToken.image : ""))
+                    .withIndexKeyword(!createContext && keywordToken != null
+                            ? keywordToken.image : null)
+                    .withName(indexName).withColumns(columns).withIndexSpec(indexOptions);
+        }
+    )
+    { return index; }
+}
+
+void TableIndexOptions(boolean createContext, List<String> options):
+{
+    List<String> parameter;
+}
+{
+    (
+        LOOKAHEAD({ createContext })
+        ( LOOKAHEAD(2) parameter=CreateParameter() { options.addAll(parameter); } )*
+        |
+        LOOKAHEAD({ !createContext }) IndexOptionList(options)
+    )
+}
+
 /**
- * Parses a single table-level constraint inside CREATE TABLE (...).
- * Handles INDEX, PRIMARY KEY, UNIQUE, KEY, FOREIGN KEY, CHECK, EXCLUDE.
- * Returns an Index (which may be NamedConstraint, ForeignKeyIndex, CheckConstraint, ExcludeConstraint).
+ * Parses a single table-level constraint inside {@code CREATE TABLE (...)}. Index forms delegate
+ * to {@link #TableIndexSpec(boolean)} so CREATE and ALTER expose the same structured AST.
  */
 Index CreateTableConstraint():
 {
     Token tk = null;
     Token tk2 = null;
-    Token tk3 = null;
-    String sk3 = null;
-    String indexName = null;
-    String using = null;
-    boolean useConstraintKeyword = false;
-    List<Index.ColumnParams> colNames = null;
-    List<String> parameter = new ArrayList<String>();
-    List<String> idxSpec = new ArrayList<String>();
+    String constraintName = null;
     Index index = null;
     ForeignKeyIndex fkIndex = null;
-    CheckConstraint checkCs = null;
-    ExcludeConstraint excludeC = null;
-    Expression exp = null;
+    CheckConstraint checkConstraint = null;
+    ExcludeConstraint excludeConstraint = null;
+    Expression expression = null;
 }
 {
     (
-        LOOKAHEAD(4) (
-            { idxSpec.clear(); tk3=null; }
-            [ tk3=<K_UNIQUE> ]
-            tk=<K_INDEX>
-            sk3=RelObjectName()
-            colNames = IndexColumnsWithParamsList()
-            ( parameter=CreateParameter() { idxSpec.addAll(parameter); } )*
-            {
-                index = new Index().withType((tk3!=null ? tk3.image + " " : "") + tk.image).withName(sk3).withColumns(colNames).withIndexSpec(new ArrayList<String>(idxSpec));
+        LOOKAHEAD({ isTableIndexAhead() }) index=TableIndexSpec(true)
+        |
+        <K_CONSTRAINT>
+        [ LOOKAHEAD({ !isTableIndexAhead() && getToken(1).kind != K_FOREIGN
+                && getToken(1).kind != K_CHECK }) constraintName=RelObjectName() ]
+        (
+            LOOKAHEAD({ isTableIndexAhead() }) index=TableIndexSpec(true) {
+                if (index instanceof NamedConstraint) {
+                    ((NamedConstraint) index).setUseConstraintKeyword(true);
+                    index.setName(constraintName);
+                }
+            }
+            |
+            fkIndex=ForeignKeySpec(constraintName) {
+                fkIndex.setUseConstraintKeyword(true);
+                index = fkIndex;
+            }
+            |
+            checkConstraint=CheckConstraintSpec(constraintName) {
+                checkConstraint.setUseConstraintKeyword(true);
+                index = checkConstraint;
             }
         )
         |
-        LOOKAHEAD(3) (
-            {
-                index = new NamedConstraint();
-                tk2=null;
-                indexName=null;
-                using=null;
-                idxSpec.clear();
-            }
-            [ <K_CONSTRAINT> { ((NamedConstraint) index).setUseConstraintKeyword(true); }
-                [ LOOKAHEAD({ getToken(1).kind != K_PRIMARY && getToken(1).kind != K_UNIQUE })
-                    sk3=RelObjectName() {index.setName(sk3);} ]
-            ]
-            (
-                tk=<K_PRIMARY> tk2=<K_KEY>
-                |
-                tk=<K_UNIQUE> [ LOOKAHEAD(2) (tk2=<K_KEY> | tk2=<K_INDEX>) ]
-                [ LOOKAHEAD(2, { getToken(1).kind != K_USING }) indexName=RelObjectName() ]
-                [ LOOKAHEAD(2) using=UsingIndexType() ]
-            )
-            {
-                index.setType( tk.image + ( tk2!=null ? " " + tk2.image : "" ));
-                ((NamedConstraint) index).setIndexName(indexName);
-                index.setUsing(using);
-                tk2=null;
-            }
-            colNames = ColumnNamesWithParamsList()
-            ( parameter=CreateParameter() { idxSpec.addAll(parameter); } )*
-            {
-                index.withColumns(colNames).withIndexSpec(new ArrayList<String>(idxSpec));
-            }
-        )
+        fkIndex=ForeignKeySpec(null) { index = fkIndex; }
         |
-        LOOKAHEAD(3) (
-            {
-                tk=null;
-                tk3=null;
-                idxSpec.clear();
-            }
-            [ tk=<K_UNIQUE> ]
-            [ tk3=<K_FULLTEXT> | tk3=<K_SPATIAL> ] tk2=<K_KEY>
-            sk3=RelObjectName()
-            colNames = IndexColumnsWithParamsList()
-            ( parameter=CreateParameter() { idxSpec.addAll(parameter); } )*
-            {
-                index = new Index()
-                    .withType( ( tk!=null ? tk.image + " " : "") + ( tk3!=null ? tk3.image + " ":"" ) + tk2.image)
-                    .withName(sk3)
-                    .withColumns(colNames)
-                    .withIndexSpec(new ArrayList<String>(idxSpec));
-            }
-        )
+        checkConstraint=CheckConstraintSpec(null) { index = checkConstraint; }
         |
-        LOOKAHEAD(3) (
-            { sk3=null; useConstraintKeyword=false; }
-            [ <K_CONSTRAINT> { useConstraintKeyword=true; }
-                [ LOOKAHEAD({ getToken(1).kind != K_FOREIGN }) sk3=RelObjectName() ]
-            ]
-            fkIndex = ForeignKeySpec(sk3)
-            { fkIndex.setUseConstraintKeyword(useConstraintKeyword); index = fkIndex; }
-        )
-        |
-        LOOKAHEAD(3) (
-            { sk3 = null; useConstraintKeyword=false; }
-            [ <K_CONSTRAINT> { useConstraintKeyword=true; }
-                [ LOOKAHEAD({ getToken(1).kind != K_CHECK }) sk3 = RelObjectName() ]
-            ]
-            checkCs = CheckConstraintSpec(sk3)
-            { checkCs.setUseConstraintKeyword(useConstraintKeyword); index = checkCs; }
-        )
-        |
-        LOOKAHEAD(2) (
-            tk=<K_EXCLUDE> { excludeC = new ExcludeConstraint(); }
-            (tk2=<K_WHERE>
-                ("(" exp = Expression() ")")* {excludeC.setExpression(exp);})
-            { index = excludeC; }
-        )
+        tk=<K_EXCLUDE> { excludeConstraint = new ExcludeConstraint(); }
+        (tk2=<K_WHERE> ("(" expression=Expression() ")")*) {
+            excludeConstraint.setExpression(expression);
+            excludeConstraint.setKind(Index.Kind.EXCLUDE);
+            index = excludeConstraint;
+        }
     )
-    {
-        return index;
-    }
+    { return index; }
 }
 
 
@@ -11643,13 +11763,16 @@ CreateTable CreateTable(boolean isUsingOrReplace):
     CreateTable createTable = new CreateTable();
     Table table = null;
     List<ColumnDefinition> columnDefinitions = new ArrayList<ColumnDefinition>();
+    List<TableElement> tableElements = new ArrayList<TableElement>();
     List<String> tableOptions = new ArrayList<String>();
+    List<TableOption> typedTableOptions = new ArrayList<TableOption>();
     List<String> createOptions = new ArrayList<String>();
     Token tk = null;
     ColumnDefinition coldef = null;
     List<Index> indexes = new ArrayList<Index>();
     Index index = null;
     List<String> parameter = new ArrayList<String>();
+    TableOption tableOption = null;
     SpannerInterleaveIn interleaveIn = null;
     Select select = null;
     Table likeTable = null;
@@ -11681,19 +11804,25 @@ CreateTable CreateTable(boolean isUsingOrReplace):
         |
             (
                 "("
-                coldef = ColumnDefinition() { columnDefinitions.add(coldef); }
+                (
+                    LOOKAHEAD(3) index = CreateTableConstraint()
+                        { indexes.add(index); tableElements.add(index); }
+                    |
+                    coldef = ColumnDefinition()
+                        { columnDefinitions.add(coldef); tableElements.add(coldef); }
+                )
 
                 (
                     ","
                     (
                         LOOKAHEAD(3) (
                             index = CreateTableConstraint()
-                            { indexes.add(index); }
+                            { indexes.add(index); tableElements.add(index); }
                         )
                         |
                         (
                             coldef = ColumnDefinition()
-                            { columnDefinitions.add(coldef); }
+                            { columnDefinitions.add(coldef); tableElements.add(coldef); }
                         )
                     )
                 )*
@@ -11707,7 +11836,19 @@ CreateTable CreateTable(boolean isUsingOrReplace):
         { createTable.setPartitionBound(partitionBound); } ]
     ( LOOKAHEAD(2, { getToken(1).kind != K_AS
             && !(getToken(1).kind == K_PARTITION && getToken(2).kind == K_BY) })
-        parameter=CreateParameter() { tableOptions.addAll(parameter); } )*
+        (
+            LOOKAHEAD({ isMySqlTableOptionAhead() })
+            tableOption=MySqlTableOption() {
+                typedTableOptions.add(tableOption);
+                tableOptions.addAll(tableOption.getTokens());
+            }
+            |
+            parameter=CreateParameter() {
+                typedTableOptions.add(TableOption.raw(parameter));
+                tableOptions.addAll(parameter);
+            }
+        )
+    )*
     [ partitioning=CreateTablePartitioning() { createTable.setPartitioning(partitioning); } ]
 
     // see https://docs.oracle.com/cd/B19306_01/server.102/b14200/statements_7002.htm#i2126725
@@ -11721,18 +11862,67 @@ CreateTable CreateTable(boolean isUsingOrReplace):
     [ <K_COMMA> interleaveIn = SpannerInterleaveIn( ) { createTable.setSpannerInterleaveIn(interleaveIn); } ]
     {
         createTable.setTable(table);
-        if (indexes.size() > 0)
-            createTable.setIndexes(indexes);
+        if (tableElements.size() > 0)
+            createTable.setTableElements(tableElements);
         if (createOptions.size() > 0)
             createTable.setCreateOptionsStrings(createOptions);
-        if (tableOptions.size() > 0)
-            createTable.setTableOptionsStrings(tableOptions);
-        if (columnDefinitions.size() > 0)
-            createTable.setColumnDefinitions(columnDefinitions);
+        if (typedTableOptions.size() > 0)
+            createTable.setTableOptions(typedTableOptions);
         if (columns.size() > 0)
             createTable.setColumns(columns);
         return createTable;
     }
+}
+
+TableOption MySqlTableOption(): {
+    Token tk;
+    Token tk2 = null;
+    String value;
+    boolean useEquals = false;
+    String name = "";
+    TableOption.Kind kind;
+    TableOption option;
+} {
+    (
+        tk=<K_ENGINE> {
+            name = tk.image;
+            kind = TableOption.Kind.ENGINE;
+        }
+        [ "=" { useEquals = true; } ]
+        value=MySqlTableOptionValue()
+        |
+        [ tk=<K_DEFAULT> { name = tk.image + " "; } ]
+        (
+            tk=<K_CHARACTER> tk2=<K_SET> {
+                name += tk.image + " " + tk2.image;
+            }
+            |
+            tk=<K_CHAR> tk2=<K_SET> {
+                name += tk.image + " " + tk2.image;
+            }
+            |
+            tk=<S_IDENTIFIER> { name += tk.image; }
+        )
+        { kind = TableOption.Kind.CHARACTER_SET; }
+        [ "=" { useEquals = true; } ]
+        value=MySqlTableOptionValue()
+    )
+    {
+        option = new TableOption(kind, name, value, useEquals);
+        return option;
+    }
+}
+
+String MySqlTableOptionValue(): {
+    Token token;
+    String value = null;
+} {
+    (
+        value=RelObjectName()
+        | token=<K_CSV> { value = token.image; }
+        | token=<K_BINARY> { value = token.image; }
+    )
+    { return value; }
 }
 
 SpannerInterleaveIn SpannerInterleaveIn():
@@ -11840,6 +12030,10 @@ ColDataType ColDataType():
 
     int precision = -1;
     int scale = -1;
+    Token national = null;
+    Token nationalType = null;
+    Token varying = null;
+    ColDataType.TypeModifier typeModifier = null;
 }
 {
     (
@@ -11856,8 +12050,35 @@ ColDataType ColDataType():
             ")" { colDataType = new ColDataType("STRUCT"); }
         )
 		|
+		LOOKAHEAD({ isKeywordAhead("NATIONAL") }) (
+            national=<S_IDENTIFIER>
+            (nationalType=<DATA_TYPE> | nationalType=<K_CHARACTER> | nationalType=<K_CHAR>)
+            [ LOOKAHEAD({ isKeywordAhead("VARYING") }) varying=<DATA_TYPE> ]
+            {
+                type = national.image + " " + nationalType.image
+                        + (varying != null ? " " + varying.image : "");
+                colDataType.setDataType(type);
+                colDataType.setNationalCharacterType(
+                        nationalType.image.equalsIgnoreCase("VARCHAR") || varying != null
+                                ? ColDataType.NationalCharacterType.VARCHAR
+                                : ColDataType.NationalCharacterType.CHAR);
+            }
+        )
+        |
 		LOOKAHEAD(2) (
             colDataType = DataType()
+            {
+                if (isMySqlDialect()
+                        && colDataType.getDataType().toUpperCase(Locale.ROOT).startsWith("NCHAR")) {
+                    colDataType.setNationalCharacterType(
+                            colDataType.getDataType().toUpperCase(Locale.ROOT).contains("VARCHAR")
+                                    ? ColDataType.NationalCharacterType.VARCHAR
+                                    : ColDataType.NationalCharacterType.CHAR);
+                } else if (isMySqlDialect() && colDataType.getDataType().toUpperCase(Locale.ROOT)
+                        .startsWith("NVARCHAR")) {
+                    colDataType.setNationalCharacterType(ColDataType.NationalCharacterType.VARCHAR);
+                }
+            }
         )
         |
 		(
@@ -11927,11 +12148,8 @@ ColDataType ColDataType():
         )*
         ")"
     ]
-    [ LOOKAHEAD(2)
-        ( tk=<K_SIGNED> { colDataType.setSignedness(ColDataType.Signedness.SIGNED); }
-        | tk=<K_UNSIGNED> { colDataType.setSignedness(ColDataType.Signedness.UNSIGNED); } )
-    ]
-    [ LOOKAHEAD(2) <K_ZEROFILL> { colDataType.setZerofill(true); } ]
+    ( LOOKAHEAD(1) typeModifier=MySqlTypeModifier()
+        { colDataType.addTypeModifier(typeModifier); } )*
     [ LOOKAHEAD(2) ( LOOKAHEAD(2) "[" {tk=null;} [ tk=<S_LONG> ] { array.add(tk!=null?Integer.valueOf(tk.image):null); } "]" )+ { colDataType.setArrayData(array); } ]
     [ LOOKAHEAD(2) <K_CHARACTER> <K_SET> (tk=<S_IDENTIFIER> | tk=<K_BINARY>) { colDataType.setCharacterSet(tk.image); } ]
 
@@ -11952,6 +12170,19 @@ ColDataType ColDataType():
         }
         return colDataType;
     }
+}
+
+ColDataType.TypeModifier MySqlTypeModifier():
+{
+    ColDataType.TypeModifier modifier;
+}
+{
+    (
+        <K_SIGNED> { modifier = ColDataType.TypeModifier.SIGNED; }
+        | <K_UNSIGNED> { modifier = ColDataType.TypeModifier.UNSIGNED; }
+        | <K_ZEROFILL> { modifier = ColDataType.TypeModifier.ZEROFILL; }
+    )
+    { return modifier; }
 }
 
 Analyze Analyze():
@@ -12064,7 +12295,7 @@ ReferentialAction.Action Action():
  * Parses optional referential actions: [ON DELETE|UPDATE action] [ON DELETE|UPDATE action]
  * Shared between CREATE TABLE FK and ALTER TABLE FK definitions.
  */
-void ReferentialActionsOnIndex(ForeignKeyIndex fkIndex):
+void ReferentialActions(ForeignKeyReference reference):
 {
     Token tk;
     ReferentialAction.Action action = null;
@@ -12073,13 +12304,44 @@ void ReferentialActionsOnIndex(ForeignKeyIndex fkIndex):
     [ LOOKAHEAD(2) (
         <K_ON>
         ( tk=<K_DELETE> | tk=<K_UPDATE> ) action = Action()
-        { fkIndex.setReferentialAction(ReferentialAction.Type.from(tk.image), action); }
+        { reference.setReferentialAction(ReferentialAction.Type.from(tk.image), action); }
     )]
     [ LOOKAHEAD(2) (
         <K_ON>
         ( tk=<K_DELETE> | tk=<K_UPDATE> ) action = Action()
-        { fkIndex.setReferentialAction(ReferentialAction.Type.from(tk.image), action); }
+        { reference.setReferentialAction(ReferentialAction.Type.from(tk.image), action); }
     )]
+}
+
+ForeignKeyReference ForeignKeyReferenceSpec():
+{
+    ForeignKeyReference reference = new ForeignKeyReference();
+    ForeignKeyReference.MatchType matchType;
+    Token matchToken;
+    List<String> refColNames = null;
+    Table fkTable;
+}
+{
+    <K_REFERENCES> fkTable=Table() [ LOOKAHEAD(2) refColNames=ColumnsNamesList() ]
+    {
+        reference.setTable(fkTable);
+        reference.setReferencedColumnNames(refColNames);
+    }
+    [
+        <K_MATCH>
+        (
+            <K_FULL> { matchType = ForeignKeyReference.MatchType.FULL; }
+            | matchToken=<S_IDENTIFIER> {
+                matchType = ForeignKeyReference.MatchType.valueOf(
+                        matchToken.image.toUpperCase(Locale.ROOT));
+            }
+        )
+        { reference.setMatchType(matchType); }
+    ]
+    ReferentialActions(reference)
+    {
+        return reference;
+    }
 }
 
 /**
@@ -12113,9 +12375,8 @@ ForeignKeyIndex ForeignKeySpec(String constraintName):
     String indexName = null;
     Token tk;
     Token tk2;
-    List<String> refColNames = null;
     List<Index.ColumnParams> colNames;
-    Table fkTable;
+    ForeignKeyReference reference;
 }
 {
     tk=<K_FOREIGN> tk2=<K_KEY>
@@ -12125,12 +12386,7 @@ ForeignKeyIndex ForeignKeySpec(String constraintName):
         if (constraintName != null) { fkIndex.setName(constraintName); }
         fkIndex.withType(tk.image + " " + tk2.image).withColumns(colNames);
     }
-    <K_REFERENCES> fkTable=Table() [ LOOKAHEAD(2) refColNames=ColumnsNamesList() ]
-    {
-        fkIndex.setTable(fkTable);
-        fkIndex.setReferencedColumnNames(refColNames);
-    }
-    ReferentialActionsOnIndex(fkIndex)
+    reference=ForeignKeyReferenceSpec() { fkIndex.setReference(reference); }
     {
         return fkIndex;
     }
@@ -12528,16 +12784,25 @@ AlterExpression.ColumnDataType AlterExpressionColumnDataType():
     String columnName = null;
     boolean withType = false;
     ColDataType dataType = null;
-    List<String> columnSpecs = null;
-    List<String> parameter = null;
+    List<String> columnSpecs = new ArrayList<String>();
+    List<ColumnOption> columnOptions = new ArrayList<ColumnOption>();
+    ColumnOption option = null;
+    AlterExpression.ColumnDataType result;
 }
 {
-    columnName = RelObjectName() { columnSpecs = new ArrayList<String>(); }
+    columnName = RelObjectName()
     ( LOOKAHEAD(2) <K_TYPE> { withType = true; } )?
     ( LOOKAHEAD(2) dataType = ColDataType() )?
-    ( LOOKAHEAD(2) parameter = CreateParameter() { columnSpecs.addAll(parameter); } )*
+    ( LOOKAHEAD(2) option = ColumnDefinitionOption() {
+        columnOptions.add(option);
+        columnSpecs.addAll(option.getTokens());
+    } )*
     {
-        return new AlterExpression.ColumnDataType(columnName, withType, dataType, columnSpecs);
+        result = new AlterExpression.ColumnDataType(columnName, withType, dataType, columnSpecs);
+        if (hasStructuredColumnOption(columnOptions)) {
+            result.setColumnOptions(columnOptions);
+        }
+        return result;
     }
 }
 
@@ -13138,21 +13403,8 @@ void AlterExpressionAddConstraint(AlterExpression alterExp):
         |
         sk3=RelObjectName()
         (
-             ( tk=<K_FOREIGN> tk2=<K_KEY>
-                columnNames=ColumnsNamesList()
-                {
-                    fkIndex = new ForeignKeyIndex()
-                        .withName(sk3)
-                        .withType(tk.image + " " + tk2.image)
-                        .withColumnsNames(columnNames);
-                    columnNames = null;
-                }
-                <K_REFERENCES> fkTable=Table() [ LOOKAHEAD(2) columnNames=ColumnsNamesList() ]
-                {
-                    fkIndex.withTable(fkTable).withReferencedColumnNames(columnNames);
-                    alterExp.setIndex(fkIndex);
-                }
-                ReferentialActionsOnIndex(fkIndex)
+             ( fkIndex=ForeignKeySpec(sk3)
+                { alterExp.setIndex(fkIndex); }
                 constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
             )
             |
@@ -13398,65 +13650,38 @@ AlterExpression AlterExpressionAddAlterModify():
     )
 
     (
-        LOOKAHEAD(2) (<K_PRIMARY> <K_KEY> columnNames=ColumnsNamesList() { alterExp.setPkColumns(columnNames); })
-
-        constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
-        [
-            AlterExpressionUsingIndex(alterExp)
-        ]
-        |
-        LOOKAHEAD(2) (
-          (tk=<K_KEY> { alterExp.setUk(true); } | tk=<K_INDEX>)
-          (
-              LOOKAHEAD(3)
-              sk3 = RelObjectName()
-              [ LOOKAHEAD(2) sk4 = UsingIndexType() ]
-              [ LOOKAHEAD(2) indexColumnNames = IndexColumnsWithParamsList() ]
-              |
-              [ LOOKAHEAD(2) sk4 = UsingIndexType() ]
-              [ LOOKAHEAD(2) indexColumnNames = IndexColumnsWithParamsList() ]
-          )
-          IndexOptionList(indexSpec = new ArrayList<String>())
-          {
-            index = new Index()
-                    .withIndexKeyword(tk.image)
-                    .withName(sk3)
-                    .withUsing(sk4)
-                    .withColumns(indexColumnNames)
-                    .withIndexSpec(indexSpec);
-
+        LOOKAHEAD({ alterExp.getOperation() == AlterOperation.ALTER
+                && getToken(1).kind == K_INDEX })
+        tk=<K_INDEX> sk3=RelObjectName() IndexOptionList(indexSpec) {
+            index = new Index().withIndexKeyword(tk.image).withName(sk3)
+                    .withKind(Index.Kind.INDEX).withIndexSpec(indexSpec);
             alterExp.setIndex(index);
-          }
-          constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
-        )
+        }
         |
-        LOOKAHEAD(4)
-        (
-          ( tk=<K_SPATIAL> | tk=<K_FULLTEXT> )
-          [ LOOKAHEAD(2) ( tk2=<K_INDEX> | tk2=<K_KEY> ) ]
-          (
-              sk3 = RelObjectName()
-              columnNames = ColumnsNamesList()
-              |
-              columnNames = ColumnsNamesList()
-          )
-          IndexOptionList(indexSpec = new ArrayList<String>())
-          {
-              String type = tk.image;
-              String keyword = tk2 != null ? tk2.image : null;
-              index = new Index()
-                  .withType(type)
-                  .withIndexKeyword(keyword)
-                  .withColumnsNames(columnNames)
-                  .withIndexSpec(indexSpec);
-
-              if (sk3 != null) {
-                  index.setName(sk3);
-              }
-
-              alterExp.setIndex(index);
-          }
-        )
+        LOOKAHEAD({ isTableIndexAhead() }) index=TableIndexSpec(false) {
+            alterExp.setIndex(index);
+            if (index.getKind() == Index.Kind.PRIMARY_KEY) {
+                alterExp.setPkColumns(index.getColumnsNames());
+            } else if (index.getKind() == Index.Kind.UNIQUE) {
+                alterExp.setUkColumns(index.getColumnsNames());
+                alterExp.setUkName(index instanceof NamedConstraint
+                        ? ((NamedConstraint) index).getIndexName() : index.getName());
+                alterExp.setUk(index.getType().toUpperCase(Locale.ROOT).contains("KEY"));
+                alterExp.setUkTypeSpecified(index.getIndexKeyword() != null);
+                for (String option : new ArrayList<String>(index.getIndexSpec())) {
+                    if (option.toUpperCase(Locale.ROOT).startsWith("USING ")) {
+                        alterExp.addParameters("USING");
+                        alterExp.addParameters(option.substring("USING ".length()));
+                        index.getIndexSpec().remove(option);
+                    } else if (option.toUpperCase(Locale.ROOT).startsWith("COMMENT ")) {
+                        index.setCommentText(option.substring("COMMENT ".length()));
+                        index.getIndexSpec().remove(option);
+                    }
+                }
+            }
+        }
+        constraints=AlterExpressionConstraintState() { alterExp.setConstraints(constraints); }
+        [ AlterExpressionUsingIndex(alterExp) ]
         |
         LOOKAHEAD(2) (
           sk3=RelObjectName() <K_COMMENT> tk=<S_CHAR_LITERAL> { alterExp.withColumnName(sk3).withCommentText(tk.image); }
@@ -13499,37 +13724,6 @@ AlterExpression AlterExpressionAddAlterModify():
         )
         |
         LOOKAHEAD(3) AlterExpressionColumnChanges(alterExp)
-        |
-        (
-            <K_UNIQUE> { index = new Index().withType("UNIQUE"); }
-            (
-                (
-                    tk2=<K_KEY> { alterExp.setUk(true); }
-                    | tk2=<K_INDEX> { alterExp.setUk(false); }
-                )
-                [ (tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER>) {
-                    sk3 = tk.image;
-                    alterExp.setUkName(sk3);
-                } ]
-                |
-                (tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER>) {
-                    sk3 = tk.image;
-                    alterExp.setUkTypeSpecified(false);
-                    alterExp.setUkName(sk3);
-                }
-            )?
-            columnNames=ColumnsNamesList() {
-                alterExp.setUkColumns(columnNames);
-                index.withIndexKeyword(tk2 != null ? tk2.image : null)
-                        .withName(sk3)
-                        .withColumnsNames(columnNames);
-                alterExp.setIndex(index);
-            }
-            [
-                AlterExpressionUsingIndex(alterExp)
-            ]
-            [ LOOKAHEAD(2) index = IndexWithComment(index) { alterExp.setIndex(index); } ]
-        )
         |
         // Standalone FK now uses ForeignKeyIndex, same as CONSTRAINT FK
         (

--- a/src/test/java/net/sf/jsqlparser/statement/create/MySqlTableDefinitionTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/MySqlTableDefinitionTest.java
@@ -133,6 +133,24 @@ public class MySqlTableDefinitionTest {
         assertEquals(TableOption.Kind.CHARACTER_SET, table.getTableOptions().get(1).getKind());
         assertEquals("utf8mb4", table.getTableOptions().get(1).getValue());
         assertReparse(table);
+
+        CreateTable quotedEngine = parseMySql("CREATE TABLE archive_entry (id INT) "
+                + "ENGINE='InnoDB'");
+        assertEquals("'InnoDB'", quotedEngine.getTableOption(TableOption.Kind.ENGINE)
+                .orElseThrow().getValue());
+        assertReparse(quotedEngine);
+
+        CreateTable commonOptions = parseMySql("CREATE TABLE table_options "
+                + "(id BIGINT AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB "
+                + "DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin AUTO_INCREMENT=7 "
+                + "COMMENT='archive'");
+        assertEquals("utf8mb4_bin", commonOptions.getTableOption(TableOption.Kind.COLLATE)
+                .orElseThrow().getValue());
+        assertEquals("7", commonOptions.getTableOption(TableOption.Kind.AUTO_INCREMENT)
+                .orElseThrow().getValue());
+        assertEquals("'archive'", commonOptions.getTableOption(TableOption.Kind.COMMENT)
+                .orElseThrow().getValue());
+        assertReparse(commonOptions);
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/statement/create/MySqlTableDefinitionTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/MySqlTableDefinitionTest.java
@@ -1,0 +1,202 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.AbstractJSqlParser.Dialect;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.alter.Alter;
+import net.sf.jsqlparser.statement.alter.AlterExpression;
+import net.sf.jsqlparser.statement.create.table.ColDataType;
+import net.sf.jsqlparser.statement.create.table.ColumnDefinition;
+import net.sf.jsqlparser.statement.create.table.CreateTable;
+import net.sf.jsqlparser.statement.create.table.ForeignKeyReference;
+import net.sf.jsqlparser.statement.create.table.ForeignKeyIndex;
+import net.sf.jsqlparser.statement.create.table.Index;
+import net.sf.jsqlparser.statement.create.table.NamedConstraint;
+import net.sf.jsqlparser.statement.create.table.TableOption;
+import org.junit.jupiter.api.Test;
+
+/** Regression tests for MySQL table definitions and their structured AST representation. */
+public class MySqlTableDefinitionTest {
+
+    @Test
+    public void testConstraintBeforeColumnDefinition() throws JSQLParserException {
+        CreateTable table =
+                parseMySql("CREATE TABLE inventory (PRIMARY KEY (id), id INT NOT NULL)");
+
+        assertEquals(2, table.getTableElements().size());
+        assertInstanceOf(Index.class, table.getTableElements().get(0));
+        assertInstanceOf(ColumnDefinition.class, table.getTableElements().get(1));
+        assertEquals("PRIMARY KEY", table.getIndexes().get(0).getType());
+        assertReparse(table);
+    }
+
+    @Test
+    public void testNamedPrimaryAndSpecializedIndexes() throws JSQLParserException {
+        CreateTable table = parseMySql("CREATE TABLE documents (id INT, body TEXT, data JSON, "
+                + "PRIMARY KEY pk_documents (id), FULLTEXT INDEX ft_body (body), "
+                + "INDEX ((CAST(data AS CHAR(30)))))");
+
+        NamedConstraint primary = (NamedConstraint) table.getIndexes().get(0);
+        assertEquals("pk_documents", primary.getIndexName());
+        assertEquals(Index.Kind.PRIMARY_KEY, primary.getKind());
+        assertEquals(Index.Kind.FULLTEXT, table.getIndexes().get(1).getKind());
+        assertTrue(table.getIndexes().get(2).getColumns().get(0).isExpression());
+        assertReparse(table);
+    }
+
+    @Test
+    public void testFulltextAndSpatialIndexes() throws JSQLParserException {
+        CreateTable table = parseMySql("CREATE TABLE map_entry (body TEXT, coordinates POINT, "
+                + "FULLTEXT KEY ft_body (body), SPATIAL INDEX sp_coordinates (coordinates))");
+
+        assertEquals(Index.Kind.FULLTEXT, table.getIndexes().get(0).getKind());
+        assertEquals("KEY", table.getIndexes().get(0).getType().split(" ")[1]);
+        assertEquals(Index.Kind.SPATIAL, table.getIndexes().get(1).getKind());
+        assertReparse(table);
+    }
+
+    @Test
+    public void testStructuredColumnOptions() throws JSQLParserException {
+        CreateTable table = parseMySql("CREATE TABLE child_record (id SMALLINT UNSIGNED "
+                + "SERIAL DEFAULT VALUE NOT NULL, parent_id INT REFERENCES parent_record(id) "
+                + "MATCH FULL ON UPDATE CASCADE ON DELETE SET NULL)");
+
+        ColumnDefinition id = table.getColumnDefinitions().get(0);
+        assertTrue(id.isSerialDefaultValue());
+
+        ForeignKeyReference reference = table.getColumnDefinitions().get(1)
+                .getForeignKeyReference();
+        assertNotNull(reference);
+        assertEquals("parent_record", reference.getTable().getName());
+        assertEquals(Arrays.asList("id"), reference.getReferencedColumnNames());
+        assertEquals(ForeignKeyReference.MatchType.FULL, reference.getMatchType());
+        assertNotNull(reference.getReferentialAction(
+                net.sf.jsqlparser.statement.ReferentialAction.Type.UPDATE));
+        assertReparse(table);
+    }
+
+    @Test
+    public void testNationalCharacterTypesAndOrderedModifiers() throws JSQLParserException {
+        CreateTable table = parseMySql("CREATE TABLE type_samples (label NATIONAL CHARACTER "
+                + "VARYING(64), code NATIONAL CHAR(8), flags BIGINT ZEROFILL SIGNED UNSIGNED "
+                + "SIGNED ZEROFILL)");
+
+        assertEquals(ColDataType.NationalCharacterType.VARCHAR,
+                table.getColumnDefinitions().get(0).getColDataType().getNationalCharacterType());
+        assertEquals(ColDataType.NationalCharacterType.CHAR,
+                table.getColumnDefinitions().get(1).getColDataType().getNationalCharacterType());
+        assertEquals(Arrays.asList(ColDataType.TypeModifier.ZEROFILL,
+                ColDataType.TypeModifier.SIGNED, ColDataType.TypeModifier.UNSIGNED,
+                ColDataType.TypeModifier.SIGNED, ColDataType.TypeModifier.ZEROFILL),
+                table.getColumnDefinitions().get(2).getColDataType().getTypeModifiers());
+        assertReparse(table);
+    }
+
+    @Test
+    public void testNationalCharacterAliases() throws JSQLParserException {
+        CreateTable table = parseMySql("CREATE TABLE localized_text (short_name NCHAR(16), "
+                + "long_name NVARCHAR(255), legacy_name NCHAR VARCHAR(64))");
+
+        assertEquals(ColDataType.NationalCharacterType.CHAR,
+                table.getColumnDefinitions().get(0).getColDataType().getNationalCharacterType());
+        assertEquals(ColDataType.NationalCharacterType.VARCHAR,
+                table.getColumnDefinitions().get(1).getColDataType().getNationalCharacterType());
+        assertEquals(ColDataType.NationalCharacterType.VARCHAR,
+                table.getColumnDefinitions().get(2).getColDataType().getNationalCharacterType());
+        assertReparse(table);
+    }
+
+    @Test
+    public void testStructuredMySqlTableOptionsAndKeywordColumn() throws JSQLParserException {
+        CreateTable table =
+                parseMySql("CREATE TABLE log_entry (Position BIGINT, File VARCHAR(255)) "
+                        + "ENGINE=CSV DEFAULT CHAR SET=utf8mb4");
+
+        assertEquals("File", table.getColumnDefinitions().get(1).getColumnName());
+        assertEquals(TableOption.Kind.ENGINE, table.getTableOptions().get(0).getKind());
+        assertEquals("CSV", table.getTableOptions().get(0).getValue());
+        assertEquals(TableOption.Kind.CHARACTER_SET, table.getTableOptions().get(1).getKind());
+        assertEquals("utf8mb4", table.getTableOptions().get(1).getValue());
+        assertReparse(table);
+    }
+
+    @Test
+    public void testEscapedBacktickIdentifier() throws JSQLParserException {
+        CreateTable table = parseMySql("CREATE TABLE `odd``name` (`value``part` INT)");
+
+        assertEquals("`odd``name`", table.getTable().getName());
+        assertEquals("`value``part`", table.getColumnDefinitions().get(0).getColumnName());
+        assertReparse(table);
+    }
+
+    @Test
+    public void testTableForeignKeyUsesStructuredReference() throws JSQLParserException {
+        CreateTable table = parseMySql("CREATE TABLE order_line (customer_id BIGINT, "
+                + "CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customer(id) "
+                + "MATCH FULL ON DELETE CASCADE)");
+
+        ForeignKeyIndex foreignKey = (ForeignKeyIndex) table.getIndexes().get(0);
+        assertEquals(Index.Kind.FOREIGN_KEY, foreignKey.getKind());
+        assertEquals("customer", foreignKey.getReference().getTable().getName());
+        assertEquals(ForeignKeyReference.MatchType.FULL, foreignKey.getMatchType());
+        assertReparse(table);
+    }
+
+    @Test
+    public void testAlterColumnUsesStructuredOptions() throws JSQLParserException {
+        Alter alter = (Alter) CCJSqlParserUtil.parse("ALTER TABLE child_record ADD COLUMN "
+                + "parent_id INT REFERENCES parent_record(id) MATCH FULL ON DELETE CASCADE",
+                parser -> parser.withDialect(Dialect.MYSQL));
+
+        AlterExpression.ColumnDataType column =
+                alter.getAlterExpressions().get(0).getColDataTypeList().get(0);
+        assertEquals("parent_record", column.getForeignKeyReference().getTable().getName());
+        assertEquals(ForeignKeyReference.MatchType.FULL,
+                column.getForeignKeyReference().getMatchType());
+        CCJSqlParserUtil.parse(alter.toString(), parser -> parser.withDialect(Dialect.MYSQL));
+    }
+
+    @Test
+    public void testCreateAndAlterTableIndexParity() throws JSQLParserException {
+        CreateTable create = parseMySql("CREATE TABLE search_item (id INT, body TEXT, "
+                + "PRIMARY KEY pk_search (id), FULLTEXT INDEX ft_body (body))");
+        Alter alter = (Alter) CCJSqlParserUtil.parse(
+                "ALTER TABLE search_item ADD PRIMARY KEY pk_search (id), "
+                        + "ADD FULLTEXT INDEX ft_body (body)",
+                parser -> parser.withDialect(Dialect.MYSQL));
+
+        assertEquals(create.getIndexes().get(0).getClass(),
+                alter.getAlterExpressions().get(0).getIndex().getClass());
+        assertEquals(create.getIndexes().get(0).getKind(),
+                alter.getAlterExpressions().get(0).getIndex().getKind());
+        assertEquals(create.getIndexes().get(0).toString(),
+                alter.getAlterExpressions().get(0).getIndex().toString());
+        assertEquals(create.getIndexes().get(1).toString(),
+                alter.getAlterExpressions().get(1).getIndex().toString());
+        CCJSqlParserUtil.parse(alter.toString(), parser -> parser.withDialect(Dialect.MYSQL));
+    }
+
+    private static CreateTable parseMySql(String sql) throws JSQLParserException {
+        return (CreateTable) CCJSqlParserUtil.parse(sql,
+                parser -> parser.withDialect(Dialect.MYSQL));
+    }
+
+    private static void assertReparse(CreateTable table) throws JSQLParserException {
+        parseMySql(table.toString());
+    }
+}


### PR DESCRIPTION
## Summary

- add ordered, typed AST models for table elements, table options, column options, references, and MySQL type modifiers
- share index, constraint, and reference parsing between `CREATE TABLE` and `ALTER TABLE`
- support the remaining valid MySQL table-definition forms while preserving legacy accessors and deparsing compatibility
- add minimized MySQL regression tests with AST usability and round-trip assertions

## Validation

- `./gradlew test spotlessCheck checkstyleMain checkstyleTest`
- 5,141 tests passed (25 skipped)
- MySQL 8.4.11 execution corpus: all 36 targeted `CREATE TABLE` failures now parse into typed `CreateTable` ASTs
- 516/516 typed statements deparse and reparse successfully
