### PR TITLE
Support MySQL ALTER TABLE rename variants

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -32,10 +32,15 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
 @SuppressWarnings({"PMD.CyclomaticComplexity"})
 public class AlterExpression implements Serializable {
 
+    public enum TableRenameKeyword {
+        NONE, TO, AS
+    }
+
     private final Set<ReferentialAction> referentialActions = new LinkedHashSet<>(2);
     private AlterOperation operation;
     private String optionalSpecifier;
     private String newTableName;
+    private TableRenameKeyword tableRenameKeyword = TableRenameKeyword.TO;
     private String columnName;
     // private ColDataType dataType;
     private String columnOldName;
@@ -447,6 +452,14 @@ public class AlterExpression implements Serializable {
 
     public void setNewTableName(String newTableName) {
         this.newTableName = newTableName;
+    }
+
+    public TableRenameKeyword getTableRenameKeyword() {
+        return tableRenameKeyword;
+    }
+
+    public void setTableRenameKeyword(TableRenameKeyword tableRenameKeyword) {
+        this.tableRenameKeyword = tableRenameKeyword;
     }
 
     public String getColumnName() {
@@ -1214,6 +1227,16 @@ public class AlterExpression implements Serializable {
 
     public AlterExpression withOptionalSpecifier(String optionalSpecifier) {
         this.setOptionalSpecifier(optionalSpecifier);
+        return this;
+    }
+
+    public AlterExpression withNewTableName(String newTableName) {
+        setNewTableName(newTableName);
+        return this;
+    }
+
+    public AlterExpression withTableRenameKeyword(TableRenameKeyword tableRenameKeyword) {
+        setTableRenameKeyword(tableRenameKeyword);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpressionRename.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpressionRename.java
@@ -26,7 +26,11 @@ public class AlterExpressionRename extends AlterExpression {
                 b.append(getColumnOldName()).append(" TO ").append(getColumnName());
                 break;
             case RENAME_TABLE:
-                b.append("RENAME TO ").append(getNewTableName());
+                b.append("RENAME");
+                if (getTableRenameKeyword() != TableRenameKeyword.NONE) {
+                    b.append(" ").append(getTableRenameKeyword());
+                }
+                b.append(" ").append(getNewTableName());
                 break;
             case RENAME_INDEX:
             case RENAME_KEY:

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -13571,7 +13571,7 @@ AlterExpression AlterExpressionAddAlterModify():
 
 /**
  * Parses all RENAME variants within ALTER TABLE.
- * Handles: RENAME [COLUMN] old TO new, RENAME TO tablename,
+ * Handles: RENAME [COLUMN] old TO new, RENAME [TO|AS] tablename, RENAME tablename,
  * RENAME INDEX/KEY/CONSTRAINT old TO new.
  */
 AlterExpression AlterExpressionRenameOp():
@@ -13602,16 +13602,29 @@ AlterExpression AlterExpressionRenameOp():
         }
         |
         LOOKAHEAD(2) (
-            <K_TO> { alterExp.setOperation(AlterOperation.RENAME_TABLE); }
-            (tk2=<S_IDENTIFIER> | tk2=<S_QUOTED_IDENTIFIER>) { alterExp.setNewTableName(tk2.image); }
+            (tk=<K_TO> | tk=<K_AS>) {
+                alterExp.setOperation(AlterOperation.RENAME_TABLE);
+                alterExp.setTableRenameKeyword(AlterExpression.TableRenameKeyword.valueOf(
+                        tk.image.toUpperCase(Locale.ROOT)));
+            }
+            tk2=KeywordOrIdentifier() { alterExp.setNewTableName(tk2.image); }
         )
         |
+        LOOKAHEAD(3)
         (
             { alterExp.setOperation(AlterOperation.RENAME); }
             [ <K_COLUMN> { alterExp.hasColumn(true); } ]
             (tk=KeywordOrIdentifier()) { alterExp.setColOldName(tk.image); }
             <K_TO>
             (tk2=KeywordOrIdentifier()) { alterExp.setColumnName(tk2.image); }
+        )
+        |
+        (
+            {
+                alterExp.setOperation(AlterOperation.RENAME_TABLE);
+                alterExp.setTableRenameKeyword(AlterExpression.TableRenameKeyword.NONE);
+            }
+            tk2=KeywordOrIdentifier() { alterExp.setNewTableName(tk2.image); }
         )
     )
     { return alterExp; }

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterTest.java
@@ -739,6 +739,24 @@ public class AlterTest {
     }
 
     @Test
+    public void testMySqlAlterTableRenameVariants() throws JSQLParserException {
+        Alter withoutKeyword = (Alter) assertSqlCanBeParsedAndDeparsed(
+                "ALTER TABLE t1 RENAME t2");
+        AlterExpression rename = withoutKeyword.getAlterExpressions().get(0);
+        assertEquals(AlterOperation.RENAME_TABLE, rename.getOperation());
+        assertEquals("t2", rename.getNewTableName());
+        assertEquals(AlterExpression.TableRenameKeyword.NONE, rename.getTableRenameKeyword());
+
+        Alter withAs = (Alter) assertSqlCanBeParsedAndDeparsed("ALTER TABLE t1 RENAME AS t2");
+        assertEquals(AlterExpression.TableRenameKeyword.AS,
+                withAs.getAlterExpressions().get(0).getTableRenameKeyword());
+
+        Alter withTo = (Alter) assertSqlCanBeParsedAndDeparsed("ALTER TABLE t1 RENAME TO t2");
+        assertEquals(AlterExpression.TableRenameKeyword.TO,
+                withTo.getAlterExpressions().get(0).getTableRenameKeyword());
+    }
+
+    @Test
     public void testAlterTableForeignKeyIssue981() throws JSQLParserException {
         assertSqlCanBeParsedAndDeparsed(
                 "ALTER TABLE atconfigpro "


### PR DESCRIPTION
## Summary

- parse `ALTER TABLE old RENAME new` and `RENAME AS new` in addition to `RENAME TO new`
- expose the exact table-rename keyword as `NONE`, `AS`, or `TO`
- preserve `RENAME TO` as the default for programmatically constructed `AlterExpression` instances
- keep column and index rename parsing distinct

## Validation

- `./gradlew test spotlessCheck checkstyleMain checkstyleTest`
- parser generation remains at the baseline 11 warnings
- all three table-rename forms were executed successfully against MySQL 8.4

## PR checklist

- [x] One independently reviewable syntax feature
- [x] Structured AST access; no token reparsing
- [x] Existing rename output remains backward compatible