### PR TITLE
Model MySQL CREATE SCHEMA options

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/create/database/CreateDatabase.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/database/CreateDatabase.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
@@ -27,6 +28,7 @@ public class CreateDatabase implements Statement {
     private String databaseName;
     private boolean hasIfNotExists = false;
     private List<String> databaseOptions = null;
+    private List<DatabaseOption> options;
 
     @Override
     public <T, S> T accept(StatementVisitor<T> statementVisitor, S context) {
@@ -67,7 +69,25 @@ public class CreateDatabase implements Statement {
 
     public CreateDatabase setDatabaseOptions(List<String> databaseOptions) {
         this.databaseOptions = databaseOptions;
+        this.options = null;
         return this;
+    }
+
+    public List<DatabaseOption> getOptions() {
+        return options;
+    }
+
+    public CreateDatabase setOptions(List<DatabaseOption> options) {
+        this.options = options;
+        this.databaseOptions = options == null ? null
+                : options.stream().flatMap(option -> option.getTokens().stream())
+                        .collect(Collectors.toList());
+        return this;
+    }
+
+    public Optional<DatabaseOption> getOption(DatabaseOption.Kind kind) {
+        return Optional.ofNullable(options).orElseGet(Collections::emptyList).stream()
+                .filter(option -> option.getKind() == kind).findFirst();
     }
 
     public CreateDatabase withDatabaseName(String databaseName) {
@@ -80,6 +100,17 @@ public class CreateDatabase implements Statement {
 
     public CreateDatabase withDatabaseOptions(List<String> databaseOptions) {
         return this.setDatabaseOptions(databaseOptions);
+    }
+
+    public CreateDatabase withOptions(List<DatabaseOption> options) {
+        return setOptions(options);
+    }
+
+    public CreateDatabase addOptions(DatabaseOption... options) {
+        List<DatabaseOption> collection =
+                Optional.ofNullable(getOptions()).orElseGet(ArrayList::new);
+        Collections.addAll(collection, options);
+        return withOptions(collection);
     }
 
     public CreateDatabase addDatabaseOptions(String... databaseOptions) {
@@ -105,7 +136,9 @@ public class CreateDatabase implements Statement {
         if (databaseName != null) {
             sql += " " + databaseName;
         }
-        if (databaseOptions != null && !databaseOptions.isEmpty()) {
+        if (options != null && !options.isEmpty()) {
+            sql += " " + options.stream().map(Object::toString).collect(Collectors.joining(" "));
+        } else if (databaseOptions != null && !databaseOptions.isEmpty()) {
             sql += " " + String.join(" ", databaseOptions);
         }
         return sql;

--- a/src/main/java/net/sf/jsqlparser/statement/create/database/DatabaseOption.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/database/DatabaseOption.java
@@ -1,0 +1,142 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.database;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** A structured option shared by MySQL {@code CREATE DATABASE} and {@code CREATE SCHEMA}. */
+public class DatabaseOption implements Serializable {
+
+    public enum Kind {
+        CHARACTER_SET, COLLATE, ENCRYPTION, OTHER
+    }
+
+    private Kind kind = Kind.OTHER;
+    private String name;
+    private String value;
+    private boolean useDefault;
+    private boolean useEquals;
+    private List<String> rawTokens;
+
+    public DatabaseOption() {}
+
+    public DatabaseOption(Kind kind, String name, String value, boolean useDefault,
+            boolean useEquals) {
+        this.kind = kind;
+        this.name = name;
+        this.value = value;
+        this.useDefault = useDefault;
+        this.useEquals = useEquals;
+    }
+
+    public static DatabaseOption raw(List<String> tokens) {
+        DatabaseOption option = new DatabaseOption();
+        option.setRawTokens(tokens);
+        return option;
+    }
+
+    public Kind getKind() {
+        return kind;
+    }
+
+    public void setKind(Kind kind) {
+        this.kind = kind;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public boolean isUseDefault() {
+        return useDefault;
+    }
+
+    public void setUseDefault(boolean useDefault) {
+        this.useDefault = useDefault;
+    }
+
+    public boolean isUseEquals() {
+        return useEquals;
+    }
+
+    public void setUseEquals(boolean useEquals) {
+        this.useEquals = useEquals;
+    }
+
+    public List<String> getRawTokens() {
+        return rawTokens;
+    }
+
+    public void setRawTokens(List<String> rawTokens) {
+        this.rawTokens = rawTokens;
+    }
+
+    /** Returns this option in the legacy flat-token representation. */
+    public List<String> getTokens() {
+        if (rawTokens != null) {
+            return Collections.unmodifiableList(rawTokens);
+        }
+        List<String> tokens = new ArrayList<>();
+        if (useDefault) {
+            tokens.add("DEFAULT");
+        }
+        Collections.addAll(tokens, name.split(" "));
+        if (useEquals) {
+            tokens.add("=");
+        }
+        tokens.add(value);
+        return tokens;
+    }
+
+    @Override
+    public String toString() {
+        return String.join(" ", getTokens());
+    }
+
+    public DatabaseOption withKind(Kind kind) {
+        setKind(kind);
+        return this;
+    }
+
+    public DatabaseOption withName(String name) {
+        setName(name);
+        return this;
+    }
+
+    public DatabaseOption withValue(String value) {
+        setValue(value);
+        return this;
+    }
+
+    public DatabaseOption withUseDefault(boolean useDefault) {
+        setUseDefault(useDefault);
+        return this;
+    }
+
+    public DatabaseOption withUseEquals(boolean useEquals) {
+        setUseEquals(useEquals);
+        return this;
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/schema/CreateSchema.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/schema/CreateSchema.java
@@ -14,9 +14,11 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
+import net.sf.jsqlparser.statement.create.database.DatabaseOption;
 
 public class CreateSchema implements Statement {
 
@@ -25,6 +27,7 @@ public class CreateSchema implements Statement {
     private String schemaName;
     private List<String> schemaPath;
     private List<Statement> statements = new ArrayList<>();
+    private List<DatabaseOption> databaseOptions;
     private boolean hasIfNotExists = false;
 
     @Override
@@ -114,6 +117,19 @@ public class CreateSchema implements Statement {
         return statements;
     }
 
+    public List<DatabaseOption> getDatabaseOptions() {
+        return databaseOptions;
+    }
+
+    public void setDatabaseOptions(List<DatabaseOption> databaseOptions) {
+        this.databaseOptions = databaseOptions;
+    }
+
+    public Optional<DatabaseOption> getDatabaseOption(DatabaseOption.Kind kind) {
+        return Optional.ofNullable(databaseOptions).orElseGet(Collections::emptyList).stream()
+                .filter(option -> option.getKind() == kind).findFirst();
+    }
+
     public boolean hasIfNotExists() {
         return hasIfNotExists;
     }
@@ -131,10 +147,14 @@ public class CreateSchema implements Statement {
         if (schemaName != null) {
             sql += " ";
 
-            if (catalogName!=null) {
+            if (catalogName != null) {
                 sql += catalogName + ".";
             }
             sql += schemaName;
+        }
+        if (databaseOptions != null && !databaseOptions.isEmpty()) {
+            sql += " " + databaseOptions.stream().map(Object::toString)
+                    .collect(Collectors.joining(" "));
         }
         if (authorization != null) {
             sql += " AUTHORIZATION " + authorization;
@@ -155,6 +175,18 @@ public class CreateSchema implements Statement {
     public CreateSchema withSchemaPath(List<String> schemaPath) {
         this.setSchemaPath(schemaPath);
         return this;
+    }
+
+    public CreateSchema withDatabaseOptions(List<DatabaseOption> databaseOptions) {
+        setDatabaseOptions(databaseOptions);
+        return this;
+    }
+
+    public CreateSchema addDatabaseOptions(DatabaseOption... databaseOptions) {
+        List<DatabaseOption> collection =
+                Optional.ofNullable(getDatabaseOptions()).orElseGet(ArrayList::new);
+        Collections.addAll(collection, databaseOptions);
+        return withDatabaseOptions(collection);
     }
 
     public CreateSchema addSchemaPath(String... schemaPath) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -126,6 +126,12 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
         return jjtree.rootNode();
     }
 
+    private boolean isMySqlDatabaseOptionAhead() {
+        int offset = getToken(1).kind == K_DEFAULT ? 2 : 1;
+        int kind = getToken(offset).kind;
+        return kind == K_CHARACTER || kind == K_COLLATE || kind == K_ENCRYPTION;
+    }
+
     private static class ObjectNames {
 
         private final List<String> names;
@@ -11448,6 +11454,7 @@ CreateSchema CreateSchema():
     CreateSchema schema = new CreateSchema();
     List<String> schemaPath = null;
     List<Statement> statements = new ArrayList<Statement>();
+    DatabaseOption databaseOption = null;
 }
 {
     <K_SCHEMA>
@@ -11460,6 +11467,11 @@ CreateSchema CreateSchema():
             ( tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER>) { schema.setSchemaName(tk.image); }
         )?
     ]
+
+    (
+        LOOKAHEAD({ isMySqlDatabaseOptionAhead() })
+        databaseOption=MySqlDatabaseOption() { schema.addDatabaseOptions(databaseOption); }
+    )*
 
     [ <K_AUTHORIZATION>
         (tk=<S_IDENTIFIER> | tk=<S_QUOTED_IDENTIFIER>) { schema.setAuthorization(tk.image); }
@@ -11489,6 +11501,38 @@ CreateSchema CreateSchema():
     }
 }
 
+DatabaseOption MySqlDatabaseOption():
+{
+    boolean useDefault = false;
+    boolean useEquals = false;
+    DatabaseOption.Kind kind = DatabaseOption.Kind.OTHER;
+    String name = null;
+    String value = null;
+    Token valueToken = null;
+}
+{
+    [ <K_DEFAULT> { useDefault = true; } ]
+    (
+        <K_CHARACTER> <K_SET> {
+            kind = DatabaseOption.Kind.CHARACTER_SET;
+            name = "CHARACTER SET";
+        }
+        |
+        <K_COLLATE> {
+            kind = DatabaseOption.Kind.COLLATE;
+            name = "COLLATE";
+        }
+        |
+        <K_ENCRYPTION> {
+            kind = DatabaseOption.Kind.ENCRYPTION;
+            name = "ENCRYPTION";
+        }
+    )
+    [ "=" { useEquals = true; } ]
+    ( value=RelObjectName() | valueToken=<S_CHAR_LITERAL> { value = valueToken.image; } )
+    { return new DatabaseOption(kind, name, value, useDefault, useEquals); }
+}
+
 List<String> PathSpecification():
 {
     Token tk;
@@ -11507,12 +11551,19 @@ CreateDatabase CreateDatabase():
     CreateDatabase createDatabase = new CreateDatabase();
     String databaseName = null;
     List<String> databaseOptions = null;
+    DatabaseOption databaseOption = null;
 }
 {
     <K_DATABASE>
     [ LOOKAHEAD(2) <K_IF> <K_NOT> <K_EXISTS> { createDatabase.setIfNotExists(true); } ]
     databaseName = RelObjectName() { createDatabase.setDatabaseName(databaseName); }
-    [ databaseOptions = captureRest() { createDatabase.setDatabaseOptions(databaseOptions); } ]
+    (
+        LOOKAHEAD({ isMySqlDatabaseOptionAhead() })
+        databaseOption=MySqlDatabaseOption() { createDatabase.addOptions(databaseOption); }
+    )*
+    [ databaseOptions = captureRest() {
+        createDatabase.addOptions(DatabaseOption.raw(databaseOptions));
+    } ]
     {
         return createDatabase;
     }

--- a/src/test/java/net/sf/jsqlparser/statement/create/database/CreateDatabaseTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/database/CreateDatabaseTest.java
@@ -59,6 +59,12 @@ public class CreateDatabaseTest {
                 Arrays.asList("DEFAULT", "CHARACTER", "SET", "utf8mb4", "COLLATE",
                         "utf8mb4_unicode_ci"),
                 createDatabase.getDatabaseOptions());
+        DatabaseOption characterSet =
+                createDatabase.getOption(DatabaseOption.Kind.CHARACTER_SET).orElseThrow();
+        assertEquals("utf8mb4", characterSet.getValue());
+        assertTrue(characterSet.isUseDefault());
+        assertEquals("utf8mb4_unicode_ci",
+                createDatabase.getOption(DatabaseOption.Kind.COLLATE).orElseThrow().getValue());
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/statement/create/schema/CreateSchemaTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/schema/CreateSchemaTest.java
@@ -9,9 +9,14 @@
  */
 package net.sf.jsqlparser.statement.create.schema;
 
-import net.sf.jsqlparser.JSQLParserException;
 import static net.sf.jsqlparser.test.TestUtils.assertDeparse;
 import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.create.database.DatabaseOption;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -48,5 +53,28 @@ public class CreateSchemaTest {
     void testIfNotExistsIssue2061() throws JSQLParserException {
         String sqlStr = "CREATE SCHEMA IF NOT EXISTS sales_kpi";
         assertSqlCanBeParsedAndDeparsed(sqlStr);
+    }
+
+    @Test
+    void testMySqlCreateSchemaOptions() throws JSQLParserException {
+        String sql = "CREATE SCHEMA IF NOT EXISTS schema_4 DEFAULT CHARACTER SET = utf8 "
+                + "COLLATE = utf8_general_ci DEFAULT ENCRYPTION = 'N'";
+        CreateSchema schema = (CreateSchema) assertSqlCanBeParsedAndDeparsed(sql);
+
+        DatabaseOption characterSet = schema
+                .getDatabaseOption(DatabaseOption.Kind.CHARACTER_SET).orElseThrow();
+        assertEquals("utf8", characterSet.getValue());
+        assertTrue(characterSet.isUseDefault());
+        assertTrue(characterSet.isUseEquals());
+
+        DatabaseOption collate =
+                schema.getDatabaseOption(DatabaseOption.Kind.COLLATE).orElseThrow();
+        assertEquals("utf8_general_ci", collate.getValue());
+
+        DatabaseOption encryption =
+                schema.getDatabaseOption(DatabaseOption.Kind.ENCRYPTION).orElseThrow();
+        assertEquals("'N'", encryption.getValue());
+
+        assertEquals(sql, CCJSqlParserUtil.parse(sql).toString());
     }
 }


### PR DESCRIPTION
## Summary

- parse MySQL `CREATE SCHEMA` character-set, collation, and encryption options
- introduce a shared typed `DatabaseOption` model for both `CREATE SCHEMA` and `CREATE DATABASE`
- expose option kind, value, `DEFAULT`, and equals-sign usage without requiring token reparsing
- retain the existing flat `CreateDatabase#getDatabaseOptions()` representation for compatibility

## Validation

- `./gradlew test spotlessCheck checkstyleMain checkstyleTest`
- parser generation remains at the baseline 11 warnings
- combined `CHARACTER SET`, `COLLATE`, and `ENCRYPTION` schema options were executed successfully against MySQL 8.4

## PR checklist

- [x] One independently reviewable feature
- [x] Shared structured AST instead of duplicated raw-token handling
- [x] Existing `CREATE DATABASE` access remains compatible