### PR TITLE
Model MySQL DROP object lists

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
@@ -239,7 +239,7 @@ public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
     @Override
     public <S> T visit(Drop drop, S context) {
         if (drop.getType().equalsIgnoreCase("table")) {
-            fromItemVisitor.visitFromItem(drop.getName(), context);
+            drop.getNames().forEach(name -> fromItemVisitor.visitFromItem(name, context));
         }
         // @todo: handle schemas
 

--- a/src/main/java/net/sf/jsqlparser/statement/drop/Drop.java
+++ b/src/main/java/net/sf/jsqlparser/statement/drop/Drop.java
@@ -14,8 +14,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
@@ -24,8 +26,13 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
 
 public class Drop implements Statement {
 
+    public enum ObjectType {
+        DATABASE, EVENT, FUNCTION, INDEX, PROCEDURE, SCHEMA, SEQUENCE, SERVER, TABLE, TABLESPACE, TRIGGER, VIEW, OTHER
+    }
+
     private String type;
-    private Table name;
+    private ObjectType objectType = ObjectType.OTHER;
+    private final List<Table> names = new ArrayList<>();
     private List<String> parameters;
     private Map<String, List<String>> typeToParameters = new HashMap<>();
     private boolean ifExists = false;
@@ -46,11 +53,25 @@ public class Drop implements Statement {
     }
 
     public Table getName() {
-        return name;
+        return names.isEmpty() ? null : names.get(0);
     }
 
-    public void setName(Table string) {
-        name = string;
+    public void setName(Table name) {
+        names.clear();
+        if (name != null) {
+            names.add(name);
+        }
+    }
+
+    public List<Table> getNames() {
+        return Collections.unmodifiableList(names);
+    }
+
+    public void setNames(Collection<? extends Table> names) {
+        this.names.clear();
+        if (names != null) {
+            this.names.addAll(names);
+        }
     }
 
     public List<String> getParameters() {
@@ -67,6 +88,22 @@ public class Drop implements Statement {
 
     public void setType(String string) {
         type = string;
+        try {
+            objectType = ObjectType.valueOf(string.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException | NullPointerException ignored) {
+            objectType = ObjectType.OTHER;
+        }
+    }
+
+    public ObjectType getObjectType() {
+        return objectType;
+    }
+
+    public void setObjectType(ObjectType objectType) {
+        this.objectType = objectType == null ? ObjectType.OTHER : objectType;
+        if (this.objectType != ObjectType.OTHER) {
+            this.type = this.objectType.name();
+        }
     }
 
     public boolean isIfExists() {
@@ -112,7 +149,8 @@ public class Drop implements Statement {
                 + (isUsingTemporary ? "TEMPORARY " : "")
                 + (materialized ? "MATERIALIZED " : "")
                 + type + " "
-                + (ifExists ? "IF EXISTS " : "") + name.toString();
+                + (ifExists ? "IF EXISTS " : "") + names.stream().map(Table::toString)
+                        .collect(Collectors.joining(", "));
 
         if (type.equals("FUNCTION")) {
             sql += formatFuncParams(getParamsByType("FUNCTION"));
@@ -146,6 +184,21 @@ public class Drop implements Statement {
 
     public Drop withName(Table name) {
         this.setName(name);
+        return this;
+    }
+
+    public Drop withNames(Collection<? extends Table> names) {
+        setNames(names);
+        return this;
+    }
+
+    public Drop addNames(Table... names) {
+        Collections.addAll(this.names, names);
+        return this;
+    }
+
+    public Drop withObjectType(ObjectType objectType) {
+        setObjectType(objectType);
         return this;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -1502,7 +1502,7 @@ public class TablesNamesFinder<Void>
 
     @Override
     public <S> Void visit(Drop drop, S context) {
-        visit(drop.getName(), context);
+        drop.getNames().forEach(name -> visit(name, context));
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/DropDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/DropDeParser.java
@@ -9,6 +9,7 @@
  */
 package net.sf.jsqlparser.util.deparser;
 
+import java.util.stream.Collectors;
 import net.sf.jsqlparser.statement.drop.Drop;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 
@@ -32,7 +33,8 @@ public class DropDeParser extends AbstractDeParser<Drop> {
             builder.append(" IF EXISTS");
         }
 
-        builder.append(" ").append(drop.getName());
+        builder.append(" ").append(drop.getNames().stream().map(Object::toString)
+                .collect(Collectors.joining(", ")));
 
         if (drop.getType().equals("FUNCTION")) {
             builder.append(Drop.formatFuncParams(drop.getParamsByType("FUNCTION")));

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/DropValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/DropValidator.java
@@ -47,7 +47,7 @@ public class DropValidator extends AbstractValidator<Drop> {
 
         NamedObject named = NamedObject.forName(type);
         if (Arrays.asList(NamedObject.table, NamedObject.view).contains(named)) {
-            validateName(named, drop.getName().getFullyQualifiedName());
+            drop.getNames().forEach(name -> validateName(named, name.getFullyQualifiedName()));
         }
     }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -12400,9 +12400,15 @@ Drop Drop():
         |
         tk=<K_VIEW>
         |
+        tk=<K_DATABASE>
+        |
+        tk=<K_PROCEDURE>
+        |
         tk=<K_SCHEMA>
         |
         tk=<K_SEQUENCE>
+        |
+        tk=<K_TRIGGER>
         |
         tk=<K_FUNCTION>
     )
@@ -12411,6 +12417,7 @@ Drop Drop():
     [ LOOKAHEAD(2) <K_IF> <K_EXISTS> {drop.setIfExists(true);} ]
 
     name = Table() { drop.setName(name); }
+    ( "," name = Table() { drop.addNames(name); } )*
     [ LOOKAHEAD(2)  funcArgs = FuncArgsList() ]
     (
         (

--- a/src/test/java/net/sf/jsqlparser/statement/drop/DropTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/drop/DropTest.java
@@ -11,6 +11,7 @@ package net.sf.jsqlparser.statement.drop;
 
 import java.io.StringReader;
 import java.util.List;
+import java.util.stream.Collectors;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
@@ -193,7 +194,7 @@ public class DropTest {
         Drop drop = (Drop) assertSqlCanBeParsedAndDeparsed(sql);
 
         assertEquals(List.of("table_1", "table_2", "table_3"), drop.getNames().stream()
-                .map(Table::getFullyQualifiedName).toList());
+                .map(Table::getFullyQualifiedName).collect(Collectors.toList()));
         assertEquals("table_1", drop.getName().getFullyQualifiedName());
         assertEquals(List.of("RESTRICT"), drop.getParameters());
 
@@ -210,7 +211,7 @@ public class DropTest {
 
         assertEquals(Drop.ObjectType.VIEW, drop.getObjectType());
         assertEquals(List.of("view_1", "view_2"), drop.getNames().stream()
-                .map(Table::getFullyQualifiedName).toList());
+                .map(Table::getFullyQualifiedName).collect(Collectors.toList()));
         assertEquals(List.of("CASCADE"), drop.getParameters());
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/drop/DropTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/drop/DropTest.java
@@ -10,6 +10,7 @@
 package net.sf.jsqlparser.statement.drop;
 
 import java.io.StringReader;
+import java.util.List;
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.parser.CCJSqlParserManager;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
@@ -168,5 +169,48 @@ public class DropTest {
         Statements statements = CCJSqlParserUtil.parseStatements(
                 "DROP TABLE t1; LOCK TABLE t2 IN SHARE MODE;");
         assertEquals(2, statements.size());
+    }
+
+    @Test
+    public void testMySqlDropObjectTypes() throws JSQLParserException {
+        Drop database = (Drop) assertSqlCanBeParsedAndDeparsed(
+                "DROP DATABASE IF EXISTS database_1");
+        assertEquals(Drop.ObjectType.DATABASE, database.getObjectType());
+
+        Drop procedure = (Drop) assertSqlCanBeParsedAndDeparsed(
+                "DROP PROCEDURE IF EXISTS procedure_1");
+        assertEquals(Drop.ObjectType.PROCEDURE, procedure.getObjectType());
+
+        Drop trigger = (Drop) assertSqlCanBeParsedAndDeparsed(
+                "DROP TRIGGER IF EXISTS schema_1.trigger_1");
+        assertEquals(Drop.ObjectType.TRIGGER, trigger.getObjectType());
+        assertEquals("schema_1.trigger_1", trigger.getName().getFullyQualifiedName());
+    }
+
+    @Test
+    public void testMySqlDropMultipleTables() throws JSQLParserException {
+        String sql = "DROP TABLE IF EXISTS table_1, table_2, table_3 RESTRICT";
+        Drop drop = (Drop) assertSqlCanBeParsedAndDeparsed(sql);
+
+        assertEquals(List.of("table_1", "table_2", "table_3"), drop.getNames().stream()
+                .map(Table::getFullyQualifiedName).toList());
+        assertEquals("table_1", drop.getName().getFullyQualifiedName());
+        assertEquals(List.of("RESTRICT"), drop.getParameters());
+
+        assertDeparse(new Drop().withObjectType(Drop.ObjectType.TABLE).withIfExists(true)
+                .withNames(List.of(new Table("table_1"), new Table("table_2"),
+                        new Table("table_3")))
+                .addParameters("RESTRICT"), sql);
+    }
+
+    @Test
+    public void testMySqlDropMultipleViews() throws JSQLParserException {
+        Drop drop = (Drop) assertSqlCanBeParsedAndDeparsed(
+                "DROP VIEW IF EXISTS view_1, view_2 CASCADE");
+
+        assertEquals(Drop.ObjectType.VIEW, drop.getObjectType());
+        assertEquals(List.of("view_1", "view_2"), drop.getNames().stream()
+                .map(Table::getFullyQualifiedName).toList());
+        assertEquals(List.of("CASCADE"), drop.getParameters());
     }
 }


### PR DESCRIPTION
## Summary

- parse `DROP DATABASE`, `DROP PROCEDURE`, and `DROP TRIGGER` as typed `Drop` statements
- support comma-separated table and view targets
- expose a typed object kind and the complete target list through `getObjectType()` and `getNames()`
- retain `getType()` and `getName()` as compatible accessors for existing callers
- update deparsing, validation, table discovery, and statement visitors to process every target

## Validation

- `./gradlew test spotlessCheck checkstyleMain checkstyleTest`
- parser generation remains at the baseline 11 warnings
- database, procedure, trigger, multi-table, and multi-view forms were created and dropped successfully against MySQL 8.4

## PR checklist

- [x] One cohesive DROP AST change
- [x] Structured object kind and target list; no SQL reparsing
- [x] Existing single-target API remains compatible