### PR TITLE
Model MySQL CREATE EVENT and ALTER EVENT

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -25,6 +25,7 @@ module net.sf.jsqlparser {
     exports net.sf.jsqlparser.statement.alter.sequence;
     exports net.sf.jsqlparser.statement.analyze;
     exports net.sf.jsqlparser.statement.comment;
+    exports net.sf.jsqlparser.statement.create.event;
     exports net.sf.jsqlparser.statement.create.function;
     exports net.sf.jsqlparser.statement.create.index;
     exports net.sf.jsqlparser.statement.create.policy;

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitor.java
@@ -17,6 +17,8 @@ import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.analyze.Analyze;
 import net.sf.jsqlparser.statement.comment.Comment;
 import net.sf.jsqlparser.statement.create.database.CreateDatabase;
+import net.sf.jsqlparser.statement.create.event.AlterEvent;
+import net.sf.jsqlparser.statement.create.event.CreateEvent;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.policy.CreatePolicy;
 import net.sf.jsqlparser.statement.create.schema.CreateSchema;
@@ -132,6 +134,12 @@ public interface StatementVisitor<T> {
         this.visit(createUser, null);
     }
 
+    <S> T visit(CreateEvent createEvent, S context);
+
+    default void visit(CreateEvent createEvent) {
+        this.visit(createEvent, null);
+    }
+
     <S> T visit(CreateTable createTable, S context);
 
     default void visit(CreateTable createTable) {
@@ -160,6 +168,12 @@ public interface StatementVisitor<T> {
 
     default void visit(Alter alter) {
         this.visit(alter, null);
+    }
+
+    <S> T visit(AlterEvent alterEvent, S context);
+
+    default void visit(AlterEvent alterEvent) {
+        this.visit(alterEvent, null);
     }
 
     <S> T visit(Statements statements, S context);

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
@@ -21,6 +21,8 @@ import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.analyze.Analyze;
 import net.sf.jsqlparser.statement.comment.Comment;
 import net.sf.jsqlparser.statement.create.database.CreateDatabase;
+import net.sf.jsqlparser.statement.create.event.AlterEvent;
+import net.sf.jsqlparser.statement.create.event.CreateEvent;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.policy.CreatePolicy;
 import net.sf.jsqlparser.statement.create.schema.CreateSchema;
@@ -274,6 +276,11 @@ public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
     }
 
     @Override
+    public <S> T visit(CreateEvent createEvent, S context) {
+        return null;
+    }
+
+    @Override
     public <S> T visit(CreateTable createTable, S context) {
         return createTable.getTable().accept(fromItemVisitor, context);
     }
@@ -286,6 +293,11 @@ public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
     @Override
     public <S> T visit(Alter alter, S context) {
 
+        return null;
+    }
+
+    @Override
+    public <S> T visit(AlterEvent alterEvent, S context) {
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/create/event/AlterEvent.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/event/AlterEvent.java
@@ -1,0 +1,51 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.event;
+
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.StatementVisitor;
+
+/** MySQL {@code ALTER EVENT} statement. */
+public class AlterEvent extends EventStatement {
+
+    private Table renameTo;
+
+    public Table getRenameTo() {
+        return renameTo;
+    }
+
+    public void setRenameTo(Table renameTo) {
+        this.renameTo = renameTo;
+    }
+
+    @Override
+    public <T, S> T accept(StatementVisitor<T> statementVisitor, S context) {
+        return statementVisitor.visit(this, context);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("ALTER EVENT ").append(getEvent());
+        appendScheduleAndCompletion(builder);
+        if (renameTo != null) {
+            builder.append(" RENAME TO ").append(renameTo);
+        }
+        appendStatusAndComment(builder);
+        if (getBody() != null) {
+            builder.append(" DO ").append(getBody());
+        }
+        return builder.toString();
+    }
+
+    public AlterEvent withRenameTo(Table renameTo) {
+        setRenameTo(renameTo);
+        return this;
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/event/CreateEvent.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/event/CreateEvent.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.event;
+
+import net.sf.jsqlparser.statement.StatementVisitor;
+
+/** MySQL {@code CREATE EVENT} statement. */
+public class CreateEvent extends EventStatement {
+
+    private boolean ifNotExists;
+
+    public boolean isIfNotExists() {
+        return ifNotExists;
+    }
+
+    public void setIfNotExists(boolean ifNotExists) {
+        this.ifNotExists = ifNotExists;
+    }
+
+    @Override
+    public <T, S> T accept(StatementVisitor<T> statementVisitor, S context) {
+        return statementVisitor.visit(this, context);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder("CREATE EVENT ");
+        if (ifNotExists) {
+            builder.append("IF NOT EXISTS ");
+        }
+        builder.append(getEvent());
+        appendScheduleAndCompletion(builder);
+        appendStatusAndComment(builder);
+        builder.append(" DO ").append(getBody());
+        return builder.toString();
+    }
+
+    public CreateEvent withIfNotExists(boolean ifNotExists) {
+        setIfNotExists(ifNotExists);
+        return this;
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/event/EventSchedule.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/event/EventSchedule.java
@@ -1,0 +1,123 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.event;
+
+import java.io.Serializable;
+import net.sf.jsqlparser.expression.Expression;
+
+/** Structured {@code ON SCHEDULE} clause of a MySQL event. */
+public class EventSchedule implements Serializable {
+
+    public enum Type {
+        AT, EVERY
+    }
+
+    private Type type;
+    private Expression executeAt;
+    private Expression interval;
+    private String intervalUnit;
+    private Expression starts;
+    private Expression ends;
+
+    public Type getType() {
+        return type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public Expression getExecuteAt() {
+        return executeAt;
+    }
+
+    public void setExecuteAt(Expression executeAt) {
+        this.executeAt = executeAt;
+    }
+
+    public Expression getInterval() {
+        return interval;
+    }
+
+    public void setInterval(Expression interval) {
+        this.interval = interval;
+    }
+
+    public String getIntervalUnit() {
+        return intervalUnit;
+    }
+
+    public void setIntervalUnit(String intervalUnit) {
+        this.intervalUnit = intervalUnit;
+    }
+
+    public Expression getStarts() {
+        return starts;
+    }
+
+    public void setStarts(Expression starts) {
+        this.starts = starts;
+    }
+
+    public Expression getEnds() {
+        return ends;
+    }
+
+    public void setEnds(Expression ends) {
+        this.ends = ends;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        if (type == Type.AT) {
+            builder.append("AT ").append(executeAt);
+        } else if (type == Type.EVERY) {
+            builder.append("EVERY ").append(interval).append(" ").append(intervalUnit);
+            if (starts != null) {
+                builder.append(" STARTS ").append(starts);
+            }
+            if (ends != null) {
+                builder.append(" ENDS ").append(ends);
+            }
+        }
+        return builder.toString();
+    }
+
+    public EventSchedule withType(Type type) {
+        setType(type);
+        return this;
+    }
+
+    public EventSchedule withExecuteAt(Expression executeAt) {
+        setExecuteAt(executeAt);
+        return this;
+    }
+
+    public EventSchedule withInterval(Expression interval) {
+        setInterval(interval);
+        return this;
+    }
+
+    public EventSchedule withIntervalUnit(String intervalUnit) {
+        setIntervalUnit(intervalUnit);
+        return this;
+    }
+
+    public EventSchedule withStarts(Expression starts) {
+        setStarts(starts);
+        return this;
+    }
+
+    public EventSchedule withEnds(Expression ends) {
+        setEnds(ends);
+        return this;
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/event/EventStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/event/EventStatement.java
@@ -1,0 +1,99 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.event;
+
+import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.Statement;
+
+/** Common structured properties of MySQL {@code CREATE EVENT} and {@code ALTER EVENT}. */
+public abstract class EventStatement implements Statement {
+
+    private Table event;
+    private EventSchedule schedule;
+    private Boolean onCompletionPreserve;
+    private EventStatus status;
+    private StringValue comment;
+    private Statement body;
+
+    public Table getEvent() {
+        return event;
+    }
+
+    public void setEvent(Table event) {
+        this.event = event;
+    }
+
+    public EventSchedule getSchedule() {
+        return schedule;
+    }
+
+    public void setSchedule(EventSchedule schedule) {
+        this.schedule = schedule;
+    }
+
+    /**
+     * Returns {@code true} for {@code ON COMPLETION PRESERVE}, {@code false} for
+     * {@code ON COMPLETION NOT PRESERVE}, or {@code null} when omitted.
+     */
+    public Boolean getOnCompletionPreserve() {
+        return onCompletionPreserve;
+    }
+
+    public void setOnCompletionPreserve(Boolean onCompletionPreserve) {
+        this.onCompletionPreserve = onCompletionPreserve;
+    }
+
+    public EventStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(EventStatus status) {
+        this.status = status;
+    }
+
+    public StringValue getComment() {
+        return comment;
+    }
+
+    public void setComment(StringValue comment) {
+        this.comment = comment;
+    }
+
+    public Statement getBody() {
+        return body;
+    }
+
+    public void setBody(Statement body) {
+        this.body = body;
+    }
+
+    protected void appendScheduleAndCompletion(StringBuilder builder) {
+        if (schedule != null) {
+            builder.append(" ON SCHEDULE ").append(schedule);
+        }
+        if (onCompletionPreserve != null) {
+            builder.append(" ON COMPLETION ");
+            if (!onCompletionPreserve) {
+                builder.append("NOT ");
+            }
+            builder.append("PRESERVE");
+        }
+    }
+
+    protected void appendStatusAndComment(StringBuilder builder) {
+        if (status != null) {
+            builder.append(" ").append(status);
+        }
+        if (comment != null) {
+            builder.append(" COMMENT ").append(comment);
+        }
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/event/EventStatus.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/event/EventStatus.java
@@ -1,0 +1,25 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.event;
+
+public enum EventStatus {
+    ENABLE("ENABLE"), DISABLE("DISABLE"), DISABLE_ON_SLAVE("DISABLE ON SLAVE");
+
+    private final String sql;
+
+    EventStatus(String sql) {
+        this.sql = sql;
+    }
+
+    @Override
+    public String toString() {
+        return sql;
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -98,6 +98,8 @@ import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.analyze.Analyze;
 import net.sf.jsqlparser.statement.comment.Comment;
 import net.sf.jsqlparser.statement.create.database.CreateDatabase;
+import net.sf.jsqlparser.statement.create.event.AlterEvent;
+import net.sf.jsqlparser.statement.create.event.CreateEvent;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.policy.CreatePolicy;
 import net.sf.jsqlparser.statement.create.schema.CreateSchema;
@@ -1567,6 +1569,19 @@ public class TablesNamesFinder<Void>
     }
 
     @Override
+    public <S> Void visit(CreateEvent createEvent, S context) {
+        if (createEvent.getBody() != null) {
+            createEvent.getBody().accept(this, context);
+        }
+        return null;
+    }
+
+    @Override
+    public void visit(CreateEvent createEvent) {
+        StatementVisitor.super.visit(createEvent);
+    }
+
+    @Override
     public <S> Void visit(CreateTable create, S context) {
         visit(create.getTable(), null);
         if (create.getSelect() != null) {
@@ -1602,6 +1617,19 @@ public class TablesNamesFinder<Void>
     @Override
     public void visit(Alter alter) {
         alter.getTable().accept(this, null);
+    }
+
+    @Override
+    public <S> Void visit(AlterEvent alterEvent, S context) {
+        if (alterEvent.getBody() != null) {
+            alterEvent.getBody().accept(this, context);
+        }
+        return null;
+    }
+
+    @Override
+    public void visit(AlterEvent alterEvent) {
+        StatementVisitor.super.visit(alterEvent);
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -42,6 +42,8 @@ import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.analyze.Analyze;
 import net.sf.jsqlparser.statement.comment.Comment;
 import net.sf.jsqlparser.statement.create.database.CreateDatabase;
+import net.sf.jsqlparser.statement.create.event.AlterEvent;
+import net.sf.jsqlparser.statement.create.event.CreateEvent;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.policy.CreatePolicy;
 import net.sf.jsqlparser.statement.create.schema.CreateSchema;
@@ -276,6 +278,12 @@ public class StatementDeParser extends AbstractDeParser<Statement>
     }
 
     @Override
+    public <S> StringBuilder visit(AlterEvent alterEvent, S context) {
+        builder.append(alterEvent);
+        return builder;
+    }
+
+    @Override
     public <S> StringBuilder visit(Statements statements, S context) {
         statements.accept(this, context);
         return builder;
@@ -441,6 +449,12 @@ public class StatementDeParser extends AbstractDeParser<Statement>
     @Override
     public <S> StringBuilder visit(CreateUser createUser, S context) {
         builder.append(createUser);
+        return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(CreateEvent createEvent, S context) {
+        builder.append(createEvent);
         return builder;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/StatementValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/StatementValidator.java
@@ -38,6 +38,8 @@ import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
 import net.sf.jsqlparser.statement.analyze.Analyze;
 import net.sf.jsqlparser.statement.comment.Comment;
 import net.sf.jsqlparser.statement.create.database.CreateDatabase;
+import net.sf.jsqlparser.statement.create.event.AlterEvent;
+import net.sf.jsqlparser.statement.create.event.CreateEvent;
 import net.sf.jsqlparser.statement.create.function.CreateFunction;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.policy.CreatePolicy;
@@ -171,6 +173,14 @@ public class StatementValidator extends AbstractValidator<Statement>
     @Override
     public <S> Void visit(Alter alter, S context) {
         getValidator(AlterValidator.class).validate(alter);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(AlterEvent alterEvent, S context) {
+        if (alterEvent.getBody() != null) {
+            alterEvent.getBody().accept(this, context);
+        }
         return null;
     }
 
@@ -310,6 +320,14 @@ public class StatementValidator extends AbstractValidator<Statement>
 
     @Override
     public <S> Void visit(CreateUser createUser, S context) {
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(CreateEvent createEvent, S context) {
+        if (createEvent.getBody() != null) {
+            createEvent.getBody().accept(this, context);
+        }
         return null;
     }
 
@@ -469,6 +487,10 @@ public class StatementValidator extends AbstractValidator<Statement>
         visit(alter, null);
     }
 
+    public void visit(AlterEvent alterEvent) {
+        visit(alterEvent, null);
+    }
+
     public void visit(Statements statements) {
         visit(statements, null);
     }
@@ -547,6 +569,10 @@ public class StatementValidator extends AbstractValidator<Statement>
 
     public void visit(CreateUser createUser) {
         visit(createUser, null);
+    }
+
+    public void visit(CreateEvent createEvent) {
+        visit(createEvent, null);
     }
 
     public void visit(CreateSequence createSequence) {

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -48,6 +48,7 @@ import net.sf.jsqlparser.statement.alter.*;
 import net.sf.jsqlparser.statement.alter.sequence.*;
 import net.sf.jsqlparser.statement.comment.*;
 import net.sf.jsqlparser.statement.create.database.*;
+import net.sf.jsqlparser.statement.create.event.*;
 import net.sf.jsqlparser.statement.create.function.*;
 import net.sf.jsqlparser.statement.create.index.*;
 import net.sf.jsqlparser.statement.create.policy.*;
@@ -1575,6 +1576,7 @@ String NonReservedWord() :
       | tk=<K_COMMIT:"COMMIT">
       | tk=<K_COMMENT:"COMMENT">
       | tk=<K_COMMENTS:"COMMENTS">
+      | tk=<K_COMPLETION:"COMPLETION">
       | tk=<K_CONFLICT:"CONFLICT">
       | tk=<K_CONSTRAINTS:"CONSTRAINTS">
       | tk=<K_CONVERT:"CONVERT">
@@ -1619,11 +1621,14 @@ String NonReservedWord() :
       | tk=<K_ENCODING: "ENCODING">
       | tk=<K_ENCRYPTION: "ENCRYPTION">
       | tk=<K_END: "END">
+      | tk=<K_ENDS: "ENDS">
       | tk=<K_ESCAPED: "ESCAPED">
       | tk=<K_ENFORCED: "ENFORCED">
       | tk=<K_ENGINE: "ENGINE">
       | tk=<K_ERROR: "ERROR">
       | tk=<K_ESCAPE: "ESCAPE">
+      | tk=<K_EVENT: "EVENT">
+      | tk=<K_EVERY: "EVERY">
       | tk=<K_EXA: "EXA">
       | tk=<K_EXCHANGE: "EXCHANGE">
       | tk=<K_EXCLUDE: "EXCLUDE">
@@ -1812,6 +1817,7 @@ String NonReservedWord() :
       | tk=<K_SAFE_CAST: "SAFE_CAST">
       | tk=<K_SAFE_CONVERT: "SAFE_CONVERT">
       | tk=<K_SAVEPOINT: "SAVEPOINT">
+      | tk=<K_SCHEDULE: "SCHEDULE">
       | tk=<K_SCHEMA: "SCHEMA">
       | tk=<K_SEARCH:"SEARCH">
       | tk=<K_SECURE: "SECURE">
@@ -1828,8 +1834,10 @@ String NonReservedWord() :
       | tk=<K_SIMILAR:"SIMILAR">
       | tk=<K_SIZE:"SIZE">
       | tk=<K_SKIP: "SKIP">
+      | tk=<K_SLAVE: "SLAVE">
       | tk=<K_SPATIAL:"SPATIAL">
       | tk=<K_STALENESS: "STALENESS">
+      | tk=<K_STARTS: "STARTS">
       | tk=<K_STARTING:"STARTING">
       | tk=<K_STEP: "STEP">
       | tk=<K_STORED: "STORED">
@@ -11624,6 +11632,131 @@ CreateUser CreateUser():
     { return createUser; }
 }
 
+EventSchedule MySqlEventSchedule():
+{
+    EventSchedule schedule = new EventSchedule();
+    Expression expression = null;
+    Token unitToken = null;
+    String unit = null;
+}
+{
+    <K_ON> <K_SCHEDULE>
+    (
+        <K_AT> expression=Expression() {
+            schedule.setType(EventSchedule.Type.AT);
+            schedule.setExecuteAt(expression);
+        }
+        |
+        <K_EVERY> expression=MySqlEventIntervalValue() {
+            schedule.setType(EventSchedule.Type.EVERY);
+            schedule.setInterval(expression);
+        }
+        ( LOOKAHEAD({ getToken(1).kind == K_DATE_LITERAL })
+          unitToken=<K_DATE_LITERAL> { schedule.setIntervalUnit(unitToken.image); }
+          | unit=RelObjectName() { schedule.setIntervalUnit(unit); } )
+        [ <K_STARTS> expression=Expression() { schedule.setStarts(expression); } ]
+        [ <K_ENDS> expression=Expression() { schedule.setEnds(expression); } ]
+    )
+    { return schedule; }
+}
+
+Expression MySqlEventIntervalValue():
+{
+    Token value = null;
+    Expression expression = null;
+}
+{
+    (
+        value=<S_LONG> { expression = new LongValue(value.image); }
+        |
+        value=<S_DOUBLE> { expression = new DoubleValue(value.image); }
+        |
+        value=<S_CHAR_LITERAL> { expression = new StringValue(value.image); }
+    )
+    { return expression; }
+}
+
+Boolean MySqlEventCompletion():
+{
+    boolean preserve = true;
+}
+{
+    <K_ON> <K_COMPLETION> [ <K_NOT> { preserve = false; } ]
+    LOOKAHEAD({ "PRESERVE".equalsIgnoreCase(getToken(1).image) })
+    <S_IDENTIFIER>
+    { return preserve; }
+}
+
+EventStatus MySqlEventStatus():
+{
+    EventStatus status = null;
+}
+{
+    (
+        <K_ENABLE> { status = EventStatus.ENABLE; }
+        |
+        <K_DISABLE> { status = EventStatus.DISABLE; }
+        [ LOOKAHEAD(2) <K_ON> <K_SLAVE> { status = EventStatus.DISABLE_ON_SLAVE; } ]
+    )
+    { return status; }
+}
+
+CreateEvent CreateEvent():
+{
+    CreateEvent createEvent = new CreateEvent();
+    Table event = null;
+    EventSchedule schedule = null;
+    Boolean preserve = null;
+    EventStatus status = null;
+    Token comment = null;
+    Statement body = null;
+}
+{
+    <K_EVENT>
+    [ LOOKAHEAD(3) <K_IF> <K_NOT> <K_EXISTS> { createEvent.setIfNotExists(true); } ]
+    event=Table() { createEvent.setEvent(event); }
+    schedule=MySqlEventSchedule() { createEvent.setSchedule(schedule); }
+    [ LOOKAHEAD(2) preserve=MySqlEventCompletion() {
+        createEvent.setOnCompletionPreserve(preserve);
+    } ]
+    [ LOOKAHEAD({ getToken(1).kind == K_ENABLE || getToken(1).kind == K_DISABLE })
+      status=MySqlEventStatus() { createEvent.setStatus(status); } ]
+    [ LOOKAHEAD({ getToken(1).kind == K_COMMENT }) <K_COMMENT> comment=<S_CHAR_LITERAL> {
+        createEvent.setComment(new StringValue(comment.image));
+    } ]
+    <K_DO> body=SingleStatement() { createEvent.setBody(body); }
+    { return createEvent; }
+}
+
+AlterEvent AlterEvent():
+{
+    AlterEvent alterEvent = new AlterEvent();
+    Table event = null;
+    Table renameTo = null;
+    EventSchedule schedule = null;
+    Boolean preserve = null;
+    EventStatus status = null;
+    Token comment = null;
+    Statement body = null;
+}
+{
+    <K_EVENT> event=Table() { alterEvent.setEvent(event); }
+    [ LOOKAHEAD({ getToken(1).kind == K_ON && getToken(2).kind == K_SCHEDULE })
+      schedule=MySqlEventSchedule() { alterEvent.setSchedule(schedule); } ]
+    [ LOOKAHEAD({ getToken(1).kind == K_ON && getToken(2).kind == K_COMPLETION })
+      preserve=MySqlEventCompletion() { alterEvent.setOnCompletionPreserve(preserve); } ]
+    [ LOOKAHEAD({ getToken(1).kind == K_RENAME })
+      <K_RENAME> <K_TO> renameTo=Table() { alterEvent.setRenameTo(renameTo); } ]
+    [ LOOKAHEAD({ getToken(1).kind == K_ENABLE || getToken(1).kind == K_DISABLE })
+      status=MySqlEventStatus() { alterEvent.setStatus(status); } ]
+    [ LOOKAHEAD({ getToken(1).kind == K_COMMENT }) <K_COMMENT> comment=<S_CHAR_LITERAL> {
+        alterEvent.setComment(new StringValue(comment.image));
+    } ]
+    [ LOOKAHEAD({ getToken(1).kind == K_DO })
+      <K_DO> body=SingleStatement() { alterEvent.setBody(body); } ]
+    { return alterEvent; }
+}
+
 CreateSchema CreateSchema():
 {
     Token tk = null;
@@ -14287,6 +14420,8 @@ Statement Alter():
         (
             <K_ALTER>
             (
+                statement = AlterEvent()
+                |
                 statement = AlterTable()
                 |
                 statement = AlterSession()
@@ -14813,6 +14948,8 @@ Statement Create():
     <K_CREATE> [ <K_OR> <K_REPLACE> { isUsingOrReplace = true; } ]
     (
         statement = CreateUser()
+        |
+        statement = CreateEvent()
         |
         statement = CreateFunctionStatement(isUsingOrReplace)
         |

--- a/src/test/java/net/sf/jsqlparser/statement/create/event/EventStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/event/EventStatementTest.java
@@ -1,0 +1,95 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.event;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.LongValue;
+import net.sf.jsqlparser.statement.truncate.Truncate;
+import net.sf.jsqlparser.statement.update.Update;
+import org.junit.jupiter.api.Test;
+
+class EventStatementTest {
+
+    @Test
+    void parsesCreateEventIntoStructuredProperties() throws JSQLParserException {
+        String sql = "CREATE EVENT hourly_rollup ON SCHEDULE EVERY 6 HOUR "
+                + "COMMENT 'Refresh aggregate' DO UPDATE app.metrics SET counter = counter + 1";
+        CreateEvent event =
+                assertInstanceOf(CreateEvent.class, assertSqlCanBeParsedAndDeparsed(sql));
+
+        assertEquals("hourly_rollup", event.getEvent().getFullyQualifiedName());
+        assertEquals(EventSchedule.Type.EVERY, event.getSchedule().getType());
+        assertEquals(6, assertInstanceOf(LongValue.class, event.getSchedule().getInterval())
+                .getValue());
+        assertEquals("HOUR", event.getSchedule().getIntervalUnit());
+        assertEquals("Refresh aggregate", event.getComment().getValue());
+        assertInstanceOf(Update.class, event.getBody());
+    }
+
+    @Test
+    void parsesRecurringScheduleBounds() throws JSQLParserException {
+        String sql = "ALTER EVENT hourly_rollup ON SCHEDULE EVERY 12 HOUR "
+                + "STARTS CURRENT_TIMESTAMP + INTERVAL 4 HOUR "
+                + "ENDS CURRENT_TIMESTAMP + INTERVAL 2 DAY";
+        AlterEvent event =
+                assertInstanceOf(AlterEvent.class, assertSqlCanBeParsedAndDeparsed(sql));
+
+        assertEquals(EventSchedule.Type.EVERY, event.getSchedule().getType());
+        assertEquals("HOUR", event.getSchedule().getIntervalUnit());
+        assertEquals("CURRENT_TIMESTAMP + INTERVAL 4 HOUR",
+                event.getSchedule().getStarts().toString());
+        assertEquals("CURRENT_TIMESTAMP + INTERVAL 2 DAY",
+                event.getSchedule().getEnds().toString());
+    }
+
+    @Test
+    void parsesOneTimeScheduleAndReplacementBody() throws JSQLParserException {
+        String sql = "ALTER EVENT hourly_rollup ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 DAY "
+                + "DO TRUNCATE TABLE app.metrics";
+        AlterEvent event =
+                assertInstanceOf(AlterEvent.class, assertSqlCanBeParsedAndDeparsed(sql));
+
+        assertEquals(EventSchedule.Type.AT, event.getSchedule().getType());
+        assertEquals("CURRENT_TIMESTAMP + INTERVAL 1 DAY",
+                event.getSchedule().getExecuteAt().toString());
+        assertInstanceOf(Truncate.class, event.getBody());
+    }
+
+    @Test
+    void parsesStatusAndRenameOperations() throws JSQLParserException {
+        AlterEvent disabled = assertInstanceOf(AlterEvent.class,
+                assertSqlCanBeParsedAndDeparsed("ALTER EVENT hourly_rollup DISABLE"));
+        assertEquals(EventStatus.DISABLE, disabled.getStatus());
+        assertNull(disabled.getRenameTo());
+
+        AlterEvent renamed = assertInstanceOf(AlterEvent.class,
+                assertSqlCanBeParsedAndDeparsed(
+                        "ALTER EVENT hourly_rollup RENAME TO daily_rollup"));
+        assertEquals("daily_rollup", renamed.getRenameTo().getFullyQualifiedName());
+    }
+
+    @Test
+    void parsesCompletionPolicy() throws JSQLParserException {
+        String sql = "CREATE EVENT IF NOT EXISTS one_time_cleanup "
+                + "ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 DAY "
+                + "ON COMPLETION NOT PRESERVE ENABLE DO TRUNCATE TABLE app.staging";
+        CreateEvent event =
+                assertInstanceOf(CreateEvent.class, assertSqlCanBeParsedAndDeparsed(sql));
+
+        assertFalse(event.getOnCompletionPreserve());
+        assertEquals(EventStatus.ENABLE, event.getStatus());
+    }
+}


### PR DESCRIPTION
## Summary
- parse MySQL `CREATE EVENT` and `ALTER EVENT` as dedicated statements
- expose one-time and recurring schedules, bounds, completion policy, status, comments, rename targets, and bodies as structured AST values
- route event bodies through visitors so contained table references and validation remain usable

## Validation
- `./gradlew spotlessApply test spotlessCheck checkstyleMain checkstyleTest`
- executed create, reschedule, body replacement, disable, and rename flows against MySQL 8.4