### PR TITLE
feat(parser): parse navigation chains after array subscripts

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -8535,9 +8535,24 @@ Expression ArrayExpression(Expression obj): {
     { return expr; }
 }
 
+Expression NavigationStep(Expression base):
+{
+    Expression step = null;
+    String nm = null;
+}
+{
+    (
+        "." nm=RelObjectNameExt() { step = new RowGetExpression(base, nm); }
+        |
+        step = ArrayExpression(base)
+    )
+    { return step; }
+}
+
 Expression PrimaryExpression() #PrimaryExpression:
 {
     Expression retval = null;
+    Expression nxt = null;
     Expression expression = null;
     CastExpression castExpr = null;
     TimezoneExpression timezoneExpr = null;
@@ -8712,6 +8727,12 @@ Expression PrimaryExpression() #PrimaryExpression:
     ]
 
     [ LOOKAHEAD(2) retval = ArrayExpression(retval) ]
+
+    // navigation chains, e.g. Redshift SUPER col[0].field[1].sub: field accesses
+    // and subscripts may alternate freely after the primary expression
+    (
+        LOOKAHEAD(2) nxt = NavigationStep(retval) { retval = nxt; }
+    )*
 
     (  LOOKAHEAD(2) "::" type=ColDataType() {
             castExpr = new CastExpression();

--- a/src/test/java/net/sf/jsqlparser/expression/ArrayExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/ArrayExpressionTest.java
@@ -30,4 +30,116 @@ class ArrayExpressionTest {
         assertInstanceOf(ArrayConstructor.class, column.getArrayConstructor());
     }
 
+    @Test
+    void testNavigationAfterSubscript() throws JSQLParserException {
+        // Redshift SUPER navigation: subscript then field access
+        String sqlStr = "SELECT recommendations[0].language_id FROM recs";
+        PlainSelect select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        SelectItem<?> selectItem = select.getSelectItem(0);
+
+        RowGetExpression rowGet = selectItem.getExpression(RowGetExpression.class);
+        assertNotNull(rowGet);
+        assertEquals("language_id", rowGet.getColumnName());
+        Column column = assertInstanceOf(Column.class, rowGet.getExpression());
+        assertEquals("recommendations", column.getColumnName());
+        assertInstanceOf(ArrayConstructor.class, column.getArrayConstructor());
+    }
+
+    @Test
+    void testAlternatingNavigationChain() throws JSQLParserException {
+        // field accesses and subscripts may alternate freely after the primary expression
+        String sqlStr = "SELECT a.b[0].c[1].d FROM t";
+        PlainSelect select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        SelectItem<?> selectItem = select.getSelectItem(0);
+
+        RowGetExpression outer = selectItem.getExpression(RowGetExpression.class);
+        assertNotNull(outer);
+        assertEquals("d", outer.getColumnName());
+        ArrayExpression subscript = assertInstanceOf(ArrayExpression.class, outer.getExpression());
+        assertInstanceOf(LongValue.class, subscript.getIndexExpression());
+        RowGetExpression inner =
+                assertInstanceOf(RowGetExpression.class, subscript.getObjExpression());
+        assertEquals("c", inner.getColumnName());
+        Column column = assertInstanceOf(Column.class, inner.getExpression());
+        assertEquals("a", column.getTable().getName());
+        assertEquals("b", column.getColumnName());
+        assertInstanceOf(ArrayConstructor.class, column.getArrayConstructor());
+    }
+
+    @Test
+    void testNavigationFieldNames() throws JSQLParserException {
+        // dotted continuations accept FROM/SELECT/CURRENT and quoted names,
+        // same as ColumnIdentifier's dotted continuation (RelObjectNameExt)
+        PlainSelect select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT a[0].from FROM t", true);
+        RowGetExpression rowGet = select.getSelectItem(0).getExpression(RowGetExpression.class);
+        assertEquals("from", rowGet.getColumnName());
+
+        select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT a[0].\"quoted field\" FROM t", true);
+        rowGet = select.getSelectItem(0).getExpression(RowGetExpression.class);
+        assertEquals("\"quoted field\"", rowGet.getColumnName());
+    }
+
+    @Test
+    void testNavigationInClauses() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT * FROM t WHERE a[0].b = 1", true);
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT * FROM t ORDER BY a[0].b", true);
+    }
+
+    @Test
+    void testNavigationThenCastAndJson() throws JSQLParserException {
+        PlainSelect select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT a[0].b::text FROM t", true);
+        CastExpression cast = select.getSelectItem(0).getExpression(CastExpression.class);
+        assertInstanceOf(RowGetExpression.class, cast.getLeftExpression());
+
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT a[0].b -> 'x' FROM t", true);
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT a.b[1 : 2].c FROM t", true);
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT a[0].b[1][2].c FROM t", true);
+    }
+
+    @Test
+    void testNavigationDoesNotSwallowQualifiedColumns() throws JSQLParserException {
+        // the navigation loop must not change how plain qualified columns parse
+        PlainSelect select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT a.b FROM t", true);
+        Column column = select.getSelectItem(0).getExpression(Column.class);
+        assertEquals("a", column.getTable().getName());
+        assertEquals("b", column.getColumnName());
+        assertNull(column.getArrayConstructor());
+
+        select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT a.b.c FROM t", true);
+        column = select.getSelectItem(0).getExpression(Column.class);
+        assertEquals("a.b.c", column.toString());
+
+        select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT a.b[0] FROM t", true);
+        column = select.getSelectItem(0).getExpression(Column.class);
+        assertEquals("a", column.getTable().getName());
+        assertEquals("b", column.getColumnName());
+        assertInstanceOf(ArrayConstructor.class, column.getArrayConstructor());
+
+        // a bracket group after a subscript stays on the ArrayExpression slot,
+        // not on the navigation loop
+        select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT a[0]['k'] FROM t", true);
+        ArrayExpression array = select.getSelectItem(0).getExpression(ArrayExpression.class);
+        assertNotNull(array);
+        column = assertInstanceOf(Column.class, array.getObjExpression());
+        assertInstanceOf(ArrayConstructor.class, column.getArrayConstructor());
+    }
+
+    @Test
+    void testMalformedNavigationRejected() {
+        assertThrows(JSQLParserException.class,
+                () -> TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT a[0].* FROM t", true));
+    }
+
 }


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What

Parse navigation chains that alternate field accesses and subscripts after any primary expression: `SELECT recommendations[0].language_id FROM recs` now parses and round-trips. Previously the dot after a subscript was unreachable, because field access was only wired inside the parenthesized branch of PrimaryExpression.

## Why

Redshift SUPER navigation and the same family in Spark/Databricks (`arr[0].field`) failed to parse. Feeding the jsqltranspiler test corpus (900 provided segments) to master `ff2bc8d` shows this as the single remaining parse gap: 899/900, the one failure being `recommendations[0].language_id` (redshift 233/234, all other dialect groups clean).

## How

A postfix navigation loop after the existing ArrayExpression slot in PrimaryExpression, via a helper production that reuses the existing `RowGetExpression` and `ArrayExpression` nodes. No new AST classes, no visitor expansion.

1. field access accepts `RelObjectNameExt()`, matching the acceptance set of ColumnIdentifier's dotted continuation, so `a[0].from` parses like `a.from` already does
2. chains like `a.b[0].c[1].d` work; subscripts after a field go through `ArrayExpression`
3. the parenthesized branch keeps its existing row-get loop on `RelObjectName()` (so `(a).from` still fails, as before); untouched as pre-existing behavior

## Root cause

A subscript consumed by Column's ArrayConstructor left no production able to consume a following dot; navigation was reachable only for parenthesized primaries.

## Testing

Two states and mutants, all executed locally on clean rebuilds:

| state | result |
|---|---|
| master `ff2bc8d` | the 5 new encoder tests fail |
| this branch | 8/8 pass |
| mutant: drop dot arm | the 5 dot-arm tests fail |
| mutant: drop subscript arm | only the 2 chain tests fail |
| mutant: dot arm accepts `*` | only the rejection test fails |

`./gradlew check`: 5271 tests, 0 failures. javacc warnings stay at 11, no new choice conflicts.

Performance (gradle jmh, JSQLParserBenchmark.parseSQLStatements on performance.sql, version=latest, 10 forks x 10 iterations, 100 samples per run, interleaved master->branch->master->branch on a 32-core host):

| build | ms/op |
|---|---|
| master `ff2bc8d` | 3.853 ± 0.034 / 3.842 ± 0.029 |
| this branch | 3.870 ± 0.034 / 3.868 ± 0.040 |

Delta inside the confidence intervals -> no regression. A second interleaved batch against the final commit ran in a polluted window (wider CIs, disclosed for honesty): branch <= master in both windows, same conclusion.

## Verification of the original report

No upstream issue; the gap came from the corpus run above. With this branch the same corpus parses 900/900 (redshift 234/234 included).
