### PR TITLE
fix(parser): parse INSERT ON CONFLICT after a join's trailing ON

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1241,6 +1241,65 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
         }
     }
 
+    /**
+     * True when the pending {@code ON} opens the ON CONFLICT clause of the enclosing
+     * INSERT rather than another trailing join condition: after a join, the trailing
+     * ON expressions of Issue #1302 and the INSERT clause claim the same ON token.
+     * The clause shapes are ON CONFLICT DO, ON CONFLICT ON CONSTRAINT and
+     * ON CONFLICT ( target ) [ WHERE ] DO, so the parenthesized target has to be
+     * separated from an expression by scanning past its balanced brackets.
+     */
+    private boolean isInsertOnConflictAhead() {
+        if (getToken(1).kind != K_ON || getToken(2).kind != K_CONFLICT) {
+            return false;
+        }
+        Token t = getToken(3);
+        if (t.kind == K_DO) {
+            return true;
+        }
+        if (t.kind == K_ON) {
+            return getToken(4).kind == K_CONSTRAINT;
+        }
+        if (!"(".equals(t.image)) {
+            return false;
+        }
+        int depth = 1;
+        int i = 4;
+        while (depth > 0) {
+            t = getToken(i++);
+            if (t == null || t.kind == EOF) {
+                return false;
+            }
+            if ("(".equals(t.image)) {
+                depth++;
+            } else if (")".equals(t.image)) {
+                depth--;
+            }
+        }
+        t = getToken(i);
+        if (t.kind == K_DO) {
+            return true;
+        }
+        if (t.kind != K_WHERE) {
+            return false;
+        }
+        // the index predicate ends where the conflict action's DO begins
+        depth = 0;
+        for (i++; ; i++) {
+            t = getToken(i);
+            if (t == null || t.kind == EOF) {
+                return false;
+            }
+            if ("(".equals(t.image)) {
+                depth++;
+            } else if (")".equals(t.image)) {
+                depth--;
+            } else if (t.kind == K_DO && depth == 0) {
+                return true;
+            }
+        }
+    }
+
     private boolean isMySqlDialect() {
         String dialect = getAsString(Feature.dialect);
         return Dialect.MYSQL.name().equals(dialect) || Dialect.MARIADB.name().equals(dialect);
@@ -6925,7 +6984,7 @@ Join JoinerExpression() #JoinerExpression:
         LOOKAHEAD(2) (
                         [ <K_WITHIN> "(" joinWindow = JoinWindow() ")" {join.setJoinWindow(joinWindow);} ]
                         ( <K_ON> onExpression=Expression()  { join.addOnExpression(onExpression); }
-                          ( LOOKAHEAD(2)  <K_ON> onExpression=Expression()  { join.addOnExpression(onExpression); } )*
+                          ( LOOKAHEAD({ getToken(1).kind == K_ON && !isInsertOnConflictAhead() })  <K_ON> onExpression=Expression()  { join.addOnExpression(onExpression); } )*
                         )
                         |
                         (

--- a/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/insert/InsertTest.java
@@ -678,6 +678,118 @@ public class InsertTest {
     }
 
     @Test
+    public void testInsertOnConflictAfterJoinIssue2358() throws JSQLParserException {
+        String sqlStr = "INSERT INTO conf.supply_info (id, deal_id)\n"
+                + "SELECT uuid_generate_v4(), rep.deal_id\n"
+                + "FROM conf.reports rep\n"
+                + "JOIN conf.orders o ON rep.id = o.report_id\n"
+                + "ON CONFLICT DO NOTHING";
+        Insert insert = (Insert) assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        PlainSelect plainSelect = insert.getSelect().getPlainSelect();
+        assertEquals(1, plainSelect.getJoins().size());
+        assertEquals(1, plainSelect.getJoins().get(0).getOnExpressions().size());
+        assertEquals(ConflictActionType.DO_NOTHING,
+                insert.getConflictAction().getConflictActionType());
+        assertNull(insert.getConflictTarget());
+
+        assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO conf.supply_info (id, deal_id)\n"
+                        + "SELECT uuid_generate_v4(), rep.deal_id\n"
+                        + "FROM conf.reports rep\n"
+                        + "JOIN conf.orders o ON rep.id = o.report_id\n"
+                        + "ON CONFLICT (id) DO NOTHING",
+                true);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO distributors (did, dname)\n"
+                        + "SELECT did, dname FROM staging\n"
+                        + "JOIN suppliers s ON staging.did = s.did\n"
+                        + "ON CONFLICT ON CONSTRAINT distributors_pkey DO NOTHING",
+                true);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO distributors (did, dname)\n"
+                        + "SELECT did, dname FROM staging\n"
+                        + "JOIN suppliers s ON staging.did = s.did\n"
+                        + "ON CONFLICT (did) DO UPDATE SET dname = EXCLUDED.dname",
+                true);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO distributors (did, dname)\n"
+                        + "SELECT did, dname FROM staging\n"
+                        + "JOIN suppliers s ON staging.did = s.did\n"
+                        + "ON CONFLICT (did) WHERE is_active DO NOTHING",
+                true);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO conf.supply_info (id, deal_id)\n"
+                        + "SELECT uuid_generate_v4(), rep.deal_id\n"
+                        + "FROM conf.reports rep\n"
+                        + "JOIN conf.orders o ON rep.id = o.report_id\n"
+                        + "ON CONFLICT DO UPDATE SET deal_id = excluded.deal_id",
+                true);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO conf.supply_info (id, deal_id)\n"
+                        + "SELECT uuid_generate_v4(), rep.deal_id\n"
+                        + "FROM conf.reports rep\n"
+                        + "JOIN conf.orders o ON rep.id = o.report_id\n"
+                        + "ON CONFLICT (id, deal_id) DO NOTHING",
+                true);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO supply_info (id, deal_id)\n"
+                        + "SELECT rep.deal_id, o.total\n"
+                        + "FROM reports rep\n"
+                        + "JOIN orders o ON rep.id = o.report_id\n"
+                        + "JOIN regions r ON o.region = r.id\n"
+                        + "ON CONFLICT DO NOTHING",
+                true);
+
+        assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO conf.supply_info (id, deal_id)\n"
+                        + "SELECT uuid_generate_v4(), rep.deal_id\n"
+                        + "FROM conf.reports rep\n"
+                        + "JOIN conf.orders o ON rep.id = o.report_id\n"
+                        + "ON CONFLICT (id) WHERE (deal_id IN (1, 2)) DO NOTHING",
+                true);
+    }
+
+    @Test
+    public void testInsertSelectWithTrailingOnExpressionsIssue2358() throws JSQLParserException {
+        String sqlStr = "INSERT INTO supply_info (id, deal_id)\n"
+                + "SELECT rep.deal_id, o.total\n"
+                + "FROM reports rep\n"
+                + "JOIN orders o ON rep.id = o.report_id\n"
+                + "ON o.total > 100";
+        Insert insert = (Insert) assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        PlainSelect plainSelect = insert.getSelect().getPlainSelect();
+        assertEquals(1, plainSelect.getJoins().size());
+        assertEquals(2, plainSelect.getJoins().get(0).getOnExpressions().size());
+        assertNull(insert.getConflictAction());
+        assertNull(insert.getConflictTarget());
+
+        insert = (Insert) assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO supply_info (id, deal_id)\n"
+                        + "SELECT rep.deal_id, o.total\n"
+                        + "FROM reports rep\n"
+                        + "JOIN orders o ON rep.id = o.report_id\n"
+                        + "ON conflict",
+                true);
+        assertEquals(2,
+                insert.getSelect().getPlainSelect().getJoins().get(0).getOnExpressions().size());
+
+        insert = (Insert) assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO t (a)\n"
+                        + "SELECT x FROM u\n"
+                        + "JOIN v USING (id)\n"
+                        + "ON CONFLICT DO NOTHING",
+                true);
+        assertEquals(ConflictActionType.DO_NOTHING,
+                insert.getConflictAction().getConflictActionType());
+    }
+
+    @Test
     public void insertOnConflictObjectsTest() throws JSQLParserException {
         String sqlStr = "WITH a ( a, b , c ) \n" + "AS (SELECT  1 , 2 , 3 )\n"
                 + "insert into test\n" + "select * from a";


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What
A join's trailing-ON loop no longer claims `ON CONFLICT`: `INSERT ... SELECT ... JOIN ... ON ... ON CONFLICT ...` now parses.

## Why
The trailing-ON expressions added for #1302 collide with the INSERT clause (confirmed in #2358): after a join, `ON CONFLICT` was consumed as an additional join condition with `conflict` parsed as a column, and the statement died on `DO`.

## How
The loop's `LOOKAHEAD` gains a semantic predicate `isInsertOnConflictAhead()` that recognizes the ON CONFLICT clause shapes (`DO`, `ON CONSTRAINT`, parenthesized target with optional `WHERE`) and leaves the ON token to the INSERT production. Every other sequence behaves exactly as before: the #1302 nested form, a function named `conflict` as a join condition, and MySQL `ON DUPLICATE KEY UPDATE` (different tokens) are untouched.

The loop's entry check widens from a two-token lookahead to the presence of `ON`: for malformed input such as `ON ,` the reported error token moves from the outer level into the loop, still a parse error either way. The first ON of a join stays ungated on purpose, so `JOIN v ON CONFLICT DO NOTHING` without a join condition keeps failing, as PostgreSQL requires one.

## Root cause
`LOOKAHEAD(2)` on the trailing-ON loop matched `ON CONFLICT` because `CONFLICT` can start an expression.

## Testing
- New tests `InsertTest#testInsertOnConflictAfterJoinIssue2358` (nine ON CONFLICT clause shapes after a join, with AST assertions on the join's ON list, the conflict target and the conflict action) and `InsertTest#testInsertSelectWithTrailingOnExpressionsIssue2358` (the trailing-ON feature stays intact inside INSERT, a column named `conflict` still works as a second join condition, and `USING` joins are untouched).
- Two-state evidence: each of the nine shapes fails on master in isolation and passes with this change; the guards fail under a mutant predicate that rejects all trailing ONs, and three per-branch mutants (parenthesized target, WHERE, ON CONSTRAINT) each fail exactly their own shapes.
- Local: `./gradlew check` green (5313 tests).
- Performance: `gradle jmh`, `JSQLParserBenchmark.parseSQLStatements` on performance.sql, version=latest, 5 forks x 10 iterations (50 samples per run), interleaved master -> branch on a 32-core host, two runs per build after the background load settled: master `3.959 ± 0.059` / `3.851 ± 0.038`, this PR `3.849 ± 0.031` / `3.906 ± 0.065`. The same-build spread exceeds the between-build delta -> within noise, no regression.

## Verification of the original issue
On master (54a7499) the issue's exact statement fails with `Encountered: <K_DO> / "do", at line 5, column 13`; with this change it parses and deparses.

Fixes #2358
