### PR TITLE
feat(parser): model PostgreSQL schema DDL clauses

### DIFF
--- a/src/main/java/net/sf/jsqlparser/schema/Sequence.java
+++ b/src/main/java/net/sf/jsqlparser/schema/Sequence.java
@@ -30,6 +30,15 @@ public class Sequence extends ASTNodeAccessImpl implements MultiPartName {
 
     private List<Parameter> parameters;
     private String dataType;
+    private SequenceOwnership ownership;
+
+    public SequenceOwnership getOwnership() {
+        return ownership;
+    }
+
+    public void setOwnership(SequenceOwnership ownership) {
+        this.ownership = ownership;
+    }
 
     public Sequence() {}
 
@@ -151,6 +160,9 @@ public class Sequence extends ASTNodeAccessImpl implements MultiPartName {
                 sql.append(" ").append(parameter.formatParameter());
             }
         }
+        if (ownership != null) {
+            sql.append(' ').append(ownership);
+        }
         return sql.toString();
     }
 
@@ -175,7 +187,7 @@ public class Sequence extends ASTNodeAccessImpl implements MultiPartName {
      * The available parameters to a sequence
      */
     public enum ParameterType {
-        INCREMENT_BY, INCREMENT, START_WITH, START, RESTART_WITH, MAXVALUE, NOMAXVALUE, MINVALUE, NOMINVALUE, CYCLE, NOCYCLE, CACHE, NOCACHE, ORDER, NOORDER, KEEP, NOKEEP, SESSION, GLOBAL;
+        INCREMENT_BY, INCREMENT, START_WITH, START, RESTART_WITH, MAXVALUE, NOMAXVALUE, MINVALUE, NOMINVALUE, CYCLE, NOCYCLE, CACHE, NOCACHE, ORDER, NOORDER, KEEP, NOKEEP, SESSION, GLOBAL, NO_MINVALUE, NO_MAXVALUE, NO_CYCLE;
 
         public static ParameterType from(String type) {
             return Enum.valueOf(ParameterType.class, type.toUpperCase(Locale.ROOT));
@@ -185,7 +197,7 @@ public class Sequence extends ASTNodeAccessImpl implements MultiPartName {
     /**
      * Represents a parameter when declaring a sequence
      */
-    public static class Parameter {
+    public static class Parameter implements java.io.Serializable {
 
         private final ParameterType option;
         private Long value;
@@ -196,6 +208,15 @@ public class Sequence extends ASTNodeAccessImpl implements MultiPartName {
 
         public Long getValue() {
             return value;
+        }
+
+        public ParameterType getOption() {
+            return option;
+        }
+
+        @Override
+        public String toString() {
+            return formatParameter();
         }
 
         public void setValue(Long value) {
@@ -222,6 +243,10 @@ public class Sequence extends ASTNodeAccessImpl implements MultiPartName {
                 case MINVALUE:
                 case CACHE:
                     return prefix(option.name());
+                case NO_MINVALUE:
+                case NO_MAXVALUE:
+                case NO_CYCLE:
+                    return option.name().replace('_', ' ');
                 default:
                     // fallthrough just return option name
                     return option.name();

--- a/src/main/java/net/sf/jsqlparser/schema/SequenceOwnership.java
+++ b/src/main/java/net/sf/jsqlparser/schema/SequenceOwnership.java
@@ -1,0 +1,43 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.schema;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Distinguishes explicit OWNED BY NONE from an owning column and from an omitted clause. */
+public class SequenceOwnership implements Serializable {
+    private final Column column;
+
+    private SequenceOwnership(Column column) {
+        this.column = column;
+    }
+
+    public static SequenceOwnership none() {
+        return new SequenceOwnership(null);
+    }
+
+    public static SequenceOwnership ownedBy(Column column) {
+        return new SequenceOwnership(Objects.requireNonNull(column, "column"));
+    }
+
+    public Column getColumn() {
+        return column;
+    }
+
+    public boolean isNone() {
+        return column == null;
+    }
+
+    @Override
+    public String toString() {
+        return "OWNED BY " + (column == null ? "NONE" : column);
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/LikeClause.java
+++ b/src/main/java/net/sf/jsqlparser/statement/LikeClause.java
@@ -12,26 +12,94 @@ package net.sf.jsqlparser.statement;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.imprt.ImportColumn;
+import net.sf.jsqlparser.statement.create.table.TableElement;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.SelectItem;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Exasol Like Clause
+ * A LIKE clause used in table definitions and Exasol imports.
  *
  * @see <a href="https://docs.exasol.com/db/latest/sql/create_table.htm">Like Clause in CREATE
  *      TABLE</a>
  * @see <a href="https://docs.exasol.com/db/latest/sql/import.htm">Like Clause in IMPORT</a>
  */
-public class LikeClause implements ImportColumn, Serializable {
+public class LikeClause implements ImportColumn, TableElement, Serializable {
     private Table table;
     private List<SelectItem<Column>> columnsList;
 
-    private Boolean includingDefaults;
-    private Boolean includingIdentity;
-    private Boolean includingComments;
+    private List<Option> options = new ArrayList<>();
+
+    public enum OptionKind {
+        ALL, COMMENTS, COMPRESSION, CONSTRAINTS, DEFAULTS, GENERATED, IDENTITY, INDEXES, STATISTICS, STORAGE
+    }
+
+    public static class Option implements Serializable {
+        private final OptionKind kind;
+        private final boolean including;
+
+        public Option(OptionKind kind, boolean including) {
+            this.kind = kind;
+            this.including = including;
+        }
+
+        public OptionKind getKind() {
+            return kind;
+        }
+
+        public boolean isIncluding() {
+            return including;
+        }
+
+        @Override
+        public String toString() {
+            return (including ? "INCLUDING " : "EXCLUDING ") + kind;
+        }
+    }
+
+    /** Options in source order, including repeated options and ALL. */
+    public List<Option> getOptions() {
+        return options;
+    }
+
+    public void setOptions(List<Option> options) {
+        this.options = options == null ? new ArrayList<>() : new ArrayList<>(options);
+    }
+
+    public void addOption(OptionKind kind, boolean including) {
+        options.add(new Option(kind, including));
+    }
+
+    /** Resolves ALL and explicit options in declaration order; omission defaults to exclusion. */
+    public boolean isIncluding(OptionKind kind) {
+        boolean including = false;
+        for (Option option : options) {
+            if (option.getKind() == kind || option.getKind() == OptionKind.ALL) {
+                including = option.isIncluding();
+            }
+        }
+        return including;
+    }
+
+    private Boolean explicitIncluding(OptionKind kind) {
+        Boolean including = null;
+        for (Option option : options) {
+            if (option.getKind() == kind) {
+                including = option.isIncluding();
+            }
+        }
+        return including;
+    }
+
+    private void setIncluding(OptionKind kind, Boolean including) {
+        options.removeIf(option -> option.getKind() == kind);
+        if (including != null) {
+            addOption(kind, including);
+        }
+    }
 
     public Table getTable() {
         return table;
@@ -50,51 +118,51 @@ public class LikeClause implements ImportColumn, Serializable {
     }
 
     public Boolean isIncludingDefaults() {
-        return includingDefaults;
+        return explicitIncluding(OptionKind.DEFAULTS);
     }
 
     public void setIncludingDefaults(Boolean includingDefaults) {
-        this.includingDefaults = includingDefaults;
+        setIncluding(OptionKind.DEFAULTS, includingDefaults);
     }
 
     public Boolean isExcludingDefaults() {
-        return includingDefaults == null ? null : !includingDefaults;
+        return isIncludingDefaults() == null ? null : !isIncludingDefaults();
     }
 
     public void setExcludingDefaults(Boolean excludingDefaults) {
-        this.includingDefaults = !excludingDefaults;
+        setIncludingDefaults(excludingDefaults == null ? null : !excludingDefaults);
     }
 
     public Boolean isIncludingIdentity() {
-        return includingIdentity;
+        return explicitIncluding(OptionKind.IDENTITY);
     }
 
     public void setIncludingIdentity(Boolean includingIdentity) {
-        this.includingIdentity = includingIdentity;
+        setIncluding(OptionKind.IDENTITY, includingIdentity);
     }
 
     public Boolean isExcludingIdentity() {
-        return includingIdentity == null ? null : !includingIdentity;
+        return isIncludingIdentity() == null ? null : !isIncludingIdentity();
     }
 
     public void setExcludingIdentity(Boolean excludingIdentity) {
-        this.includingIdentity = !excludingIdentity;
+        setIncludingIdentity(excludingIdentity == null ? null : !excludingIdentity);
     }
 
     public Boolean isIncludingComments() {
-        return includingComments;
+        return explicitIncluding(OptionKind.COMMENTS);
     }
 
     public void setIncludingComments(Boolean includingComments) {
-        this.includingComments = includingComments;
+        setIncluding(OptionKind.COMMENTS, includingComments);
     }
 
     public Boolean isExcludingComments() {
-        return includingComments == null ? null : !includingComments;
+        return isIncludingComments() == null ? null : !isIncludingComments();
     }
 
     public void setExcludingComments(Boolean excludingComments) {
-        this.includingComments = !excludingComments;
+        setIncludingComments(excludingComments == null ? null : !excludingComments);
     }
 
     public StringBuilder appendTo(StringBuilder builder) {
@@ -105,31 +173,8 @@ public class LikeClause implements ImportColumn, Serializable {
             PlainSelect.appendStringListTo(builder, columnsList, true, true);
         }
 
-        if (includingDefaults != null) {
-            if (includingDefaults) {
-                builder.append(" INCLUDING ");
-            } else {
-                builder.append(" EXCLUDING ");
-            }
-            builder.append(" DEFAULTS ");
-        }
-
-        if (includingIdentity != null) {
-            if (includingIdentity) {
-                builder.append(" INCLUDING ");
-            } else {
-                builder.append(" EXCLUDING ");
-            }
-            builder.append(" IDENTITY ");
-        }
-
-        if (includingComments != null) {
-            if (includingComments) {
-                builder.append(" INCLUDING ");
-            } else {
-                builder.append(" EXCLUDING ");
-            }
-            builder.append(" COMMENTS ");
+        for (Option option : options) {
+            builder.append(' ').append(option);
         }
 
         return builder;
@@ -137,6 +182,6 @@ public class LikeClause implements ImportColumn, Serializable {
 
     @Override
     public String toString() {
-        return appendTo(new StringBuilder()).toString();
+        return appendTo(new StringBuilder()).toString().trim();
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/StatementFeatureVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementFeatureVisitor.java
@@ -431,7 +431,6 @@ public class StatementFeatureVisitor extends StatementVisitorAdapter<Void> {
         if (createTable.getSelect() != null) {
             // CTAS reads; it does not return a result set - the top level is already claimed
             analysis.certain(StmtFeature.READS_DATA);
-            createTable.getSelect().accept(analysis.selects, context);
         }
         return super.visit(createTable, context);
     }
@@ -440,11 +439,17 @@ public class StatementFeatureVisitor extends StatementVisitorAdapter<Void> {
     public <S> Void visit(CreateView createView, S context) {
         analysis.claimTopLevel();
         analysis.certain(StmtFeature.MODIFIES_SCHEMA);
-        analysis.suppressReads(() -> {
+        if (createView.isMaterialized() && !Boolean.FALSE.equals(createView.getWithData())) {
             if (createView.getSelect() != null) {
-                createView.getSelect().accept(analysis.selects, null);
+                createView.getSelect().accept(analysis.selects, context);
             }
-        });
+        } else {
+            analysis.suppressReads(() -> {
+                if (createView.getSelect() != null) {
+                    createView.getSelect().accept(analysis.selects, null);
+                }
+            });
+        }
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
@@ -66,6 +66,7 @@ import net.sf.jsqlparser.statement.update.Update;
 import net.sf.jsqlparser.statement.upsert.Upsert;
 
 import java.util.List;
+import net.sf.jsqlparser.util.TableDefinitionTraversal;
 
 @SuppressWarnings({"PMD.UncommentedEmptyMethodBody"})
 public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
@@ -338,6 +339,12 @@ public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
 
     @Override
     public <S> T visit(CreateTable createTable, S context) {
+        TableDefinitionTraversal.visit(createTable,
+                expression -> expression.accept(expressionVisitor, context),
+                table -> table.accept(fromItemVisitor, context));
+        if (createTable.getSelect() != null) {
+            createTable.getSelect().accept(selectVisitor, context);
+        }
         return createTable.getTable().accept(fromItemVisitor, context);
     }
 
@@ -348,12 +355,29 @@ public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
 
     @Override
     public <S> T visit(CreateView createView, S context) {
+        createView.getView().accept(fromItemVisitor, context);
+        if (createView.getSelect() != null) {
+            createView.getSelect().accept(selectVisitor, context);
+        }
         return null;
     }
 
     @Override
     public <S> T visit(Alter alter, S context) {
-
+        alter.getTable().accept(fromItemVisitor, context);
+        for (net.sf.jsqlparser.statement.alter.AlterExpression action : alter
+                .getAlterExpressions()) {
+            if (action.getColDataTypeList() != null) {
+                action.getColDataTypeList().forEach(column -> TableDefinitionTraversal.visit(column,
+                        expression -> expression.accept(expressionVisitor, context),
+                        table -> table.accept(fromItemVisitor, context)));
+            }
+            if (action.getIndex() != null) {
+                TableDefinitionTraversal.visit(action.getIndex(),
+                        expression -> expression.accept(expressionVisitor, context),
+                        table -> table.accept(fromItemVisitor, context));
+            }
+        }
         return null;
     }
 
@@ -476,11 +500,21 @@ public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
 
     @Override
     public <S> T visit(CreateSequence createSequence, S context) {
+        if (createSequence.getSequence().getOwnership() != null
+                && createSequence.getSequence().getOwnership().getColumn() != null) {
+            createSequence.getSequence().getOwnership().getColumn().accept(expressionVisitor,
+                    context);
+        }
         return null;
     }
 
     @Override
     public <S> T visit(AlterSequence alterSequence, S context) {
+        if (alterSequence.getSequence().getOwnership() != null
+                && alterSequence.getSequence().getOwnership().getColumn() != null) {
+            alterSequence.getSequence().getOwnership().getColumn().accept(expressionVisitor,
+                    context);
+        }
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
@@ -14,6 +14,7 @@ import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Partition;
 import net.sf.jsqlparser.statement.alter.Alter;
+import net.sf.jsqlparser.statement.alter.AlterExpression;
 import net.sf.jsqlparser.statement.alter.AlterSession;
 import net.sf.jsqlparser.statement.alter.AlterSystemStatement;
 import net.sf.jsqlparser.statement.alter.RenameTableStatement;
@@ -365,8 +366,7 @@ public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
     @Override
     public <S> T visit(Alter alter, S context) {
         alter.getTable().accept(fromItemVisitor, context);
-        for (net.sf.jsqlparser.statement.alter.AlterExpression action : alter
-                .getAlterExpressions()) {
+        for (AlterExpression action : alter.getAlterExpressions()) {
             if (action.getColDataTypeList() != null) {
                 action.getColDataTypeList().forEach(column -> TableDefinitionTraversal.visit(column,
                         expression -> expression.accept(expressionVisitor, context),

--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -1436,6 +1436,29 @@ public class AlterExpression implements Serializable {
     public static final class ColumnDataType extends ColumnDefinition {
 
         private final boolean withType;
+        private Expression usingExpression;
+        private List<IdentityAlteration> identityAlterations;
+
+        public boolean isWithType() {
+            return withType;
+        }
+
+        public Expression getUsingExpression() {
+            return usingExpression;
+        }
+
+        public void setUsingExpression(Expression usingExpression) {
+            this.usingExpression = usingExpression;
+        }
+
+        public List<IdentityAlteration> getIdentityAlterations() {
+            return identityAlterations;
+        }
+
+        public void setIdentityAlterations(List<IdentityAlteration> identityAlterations) {
+            this.identityAlterations =
+                    identityAlterations == null ? null : new ArrayList<>(identityAlterations);
+        }
 
         public ColumnDataType(boolean withType) {
             super();
@@ -1451,8 +1474,13 @@ public class AlterExpression implements Serializable {
 
         @Override
         public String toString() {
+            if (identityAlterations != null) {
+                return getColumnName() + " "
+                        + PlainSelect.getStringList(identityAlterations, false, false);
+            }
             return getColumnName() + (withType ? " TYPE " : getColDataType() == null ? "" : " ")
-                    + toStringDataTypeAndSpec();
+                    + toStringDataTypeAndSpec()
+                    + (usingExpression == null ? "" : " USING " + usingExpression);
         }
 
         @Override

--- a/src/main/java/net/sf/jsqlparser/statement/alter/IdentityAlteration.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/IdentityAlteration.java
@@ -1,0 +1,100 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.alter;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import net.sf.jsqlparser.schema.Sequence;
+import net.sf.jsqlparser.statement.create.table.IdentityDefinition;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+
+/** An action on an identity column, as opposed to a change of its SQL data type. */
+public class IdentityAlteration implements Serializable {
+    public enum Kind {
+        ADD, SET_GENERATED, SET_PARAMETER, RESTART, DROP
+    }
+
+    private final Kind kind;
+    private IdentityDefinition identityDefinition;
+    private IdentityDefinition.GenerationMode generationMode;
+    private List<Sequence.Parameter> parameters;
+    private Long restartWith;
+    private boolean ifExists;
+
+    public IdentityAlteration(Kind kind) {
+        this.kind = kind;
+    }
+
+    public Kind getKind() {
+        return kind;
+    }
+
+    public IdentityDefinition getIdentityDefinition() {
+        return identityDefinition;
+    }
+
+    public void setIdentityDefinition(IdentityDefinition identityDefinition) {
+        this.identityDefinition = identityDefinition;
+    }
+
+    public IdentityDefinition.GenerationMode getGenerationMode() {
+        return generationMode;
+    }
+
+    public void setGenerationMode(IdentityDefinition.GenerationMode generationMode) {
+        this.generationMode = generationMode;
+    }
+
+    public List<Sequence.Parameter> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(List<Sequence.Parameter> parameters) {
+        this.parameters = parameters == null ? null : new ArrayList<>(parameters);
+    }
+
+    public Long getRestartWith() {
+        return restartWith;
+    }
+
+    public void setRestartWith(Long restartWith) {
+        this.restartWith = restartWith;
+    }
+
+    public boolean isIfExists() {
+        return ifExists;
+    }
+
+    public void setIfExists(boolean ifExists) {
+        this.ifExists = ifExists;
+    }
+
+    @Override
+    public String toString() {
+        switch (kind) {
+            case ADD:
+                return "ADD " + identityDefinition;
+            case SET_GENERATED:
+                return "SET GENERATED "
+                        + (generationMode == IdentityDefinition.GenerationMode.ALWAYS
+                                ? "ALWAYS"
+                                : "BY DEFAULT");
+            case SET_PARAMETER:
+                return "SET " + PlainSelect.getStringList(parameters, false, false);
+            case RESTART:
+                return "RESTART" + (restartWith == null ? "" : " WITH " + restartWith);
+            case DROP:
+                return "DROP IDENTITY" + (ifExists ? " IF EXISTS" : "");
+            default:
+                throw new IllegalStateException("Unknown identity action: " + kind);
+        }
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/CheckConstraint.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/CheckConstraint.java
@@ -65,6 +65,7 @@ public class CheckConstraint extends NamedConstraint {
         if (enforced != null) {
             b.append(enforced ? " ENFORCED" : " NOT ENFORCED");
         }
+        appendConstraintAttributesTo(b);
         return b.toString();
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/ColumnDefinition.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/ColumnDefinition.java
@@ -28,6 +28,15 @@ public class ColumnDefinition implements ImportColumn, TableElement, Serializabl
     private ColDataType colDataType;
     private List<String> columnSpecs;
     private List<ColumnOption> columnOptions;
+    private boolean withOptions;
+
+    public boolean isWithOptions() {
+        return withOptions;
+    }
+
+    public void setWithOptions(boolean withOptions) {
+        this.withOptions = withOptions;
+    }
 
     public ColumnDefinition() {}
 
@@ -42,6 +51,13 @@ public class ColumnDefinition implements ImportColumn, TableElement, Serializabl
     }
 
     public List<String> getColumnSpecs() {
+        if (columnOptions != null) {
+            List<String> tokens = new ArrayList<>();
+            for (ColumnOption option : columnOptions) {
+                tokens.addAll(option.getTokens());
+            }
+            return tokens;
+        }
         return columnSpecs;
     }
 
@@ -108,11 +124,12 @@ public class ColumnDefinition implements ImportColumn, TableElement, Serializabl
 
     @Override
     public String toString() {
-        return columnName + " " + toStringDataTypeAndSpec();
+        return (columnName + " " + toStringDataTypeAndSpec()).trim();
     }
 
     public String toStringDataTypeAndSpec() {
         return (colDataType == null ? "" : colDataType)
+                + (withOptions ? "WITH OPTIONS" : "")
                 + (columnOptions != null && !columnOptions.isEmpty()
                         ? " " + PlainSelect.getStringList(columnOptions, false, false)
                         : columnSpecs != null && !columnSpecs.isEmpty()

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/ColumnOption.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/ColumnOption.java
@@ -19,12 +19,36 @@ import net.sf.jsqlparser.statement.select.PlainSelect;
 public class ColumnOption implements Serializable {
 
     public enum Kind {
-        SERIAL_DEFAULT_VALUE, REFERENCE, OTHER
+        SERIAL_DEFAULT_VALUE, REFERENCE, IDENTITY, CONSTRAINT, OTHER
     }
 
     private Kind kind = Kind.OTHER;
     private List<String> tokens;
     private ForeignKeyReference foreignKeyReference;
+    private IdentityDefinition identityDefinition;
+    private Index constraint;
+
+    public static ColumnOption identity(IdentityDefinition definition) {
+        ColumnOption option = new ColumnOption();
+        option.kind = Kind.IDENTITY;
+        option.identityDefinition = definition;
+        return option;
+    }
+
+    public static ColumnOption constraint(Index constraint) {
+        ColumnOption option = new ColumnOption();
+        option.kind = Kind.CONSTRAINT;
+        option.constraint = constraint;
+        return option;
+    }
+
+    public IdentityDefinition getIdentityDefinition() {
+        return identityDefinition;
+    }
+
+    public Index getConstraint() {
+        return constraint;
+    }
 
     public static ColumnOption raw(List<String> tokens) {
         ColumnOption option = new ColumnOption();
@@ -54,8 +78,8 @@ public class ColumnOption implements Serializable {
     }
 
     public List<String> getTokens() {
-        return kind == Kind.REFERENCE ? Collections.singletonList(foreignKeyReference.toString())
-                : tokens;
+        return kind == Kind.OTHER || kind == Kind.SERIAL_DEFAULT_VALUE ? tokens
+                : Collections.singletonList(toString());
     }
 
     public ForeignKeyReference getForeignKeyReference() {
@@ -64,7 +88,15 @@ public class ColumnOption implements Serializable {
 
     @Override
     public String toString() {
-        return kind == Kind.REFERENCE ? foreignKeyReference.toString()
-                : PlainSelect.getStringList(tokens, false, false);
+        switch (kind) {
+            case REFERENCE:
+                return foreignKeyReference.toString();
+            case IDENTITY:
+                return identityDefinition.toString();
+            case CONSTRAINT:
+                return constraint.toString();
+            default:
+                return PlainSelect.getStringList(tokens, false, false);
+        }
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/ConstraintAttributes.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/ConstraintAttributes.java
@@ -1,0 +1,66 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.table;
+
+import java.io.Serializable;
+
+/** Shared PostgreSQL constraint attributes; null values preserve omitted clauses. */
+public class ConstraintAttributes implements Serializable {
+    public enum Initially {
+        IMMEDIATE, DEFERRED
+    }
+
+    private Boolean deferrable;
+    private Initially initially;
+    private boolean notValid;
+
+    public Boolean getDeferrable() {
+        return deferrable;
+    }
+
+    public void setDeferrable(Boolean deferrable) {
+        this.deferrable = deferrable;
+    }
+
+    public Initially getInitially() {
+        return initially;
+    }
+
+    public void setInitially(Initially initially) {
+        this.initially = initially;
+    }
+
+    public boolean isNotValid() {
+        return notValid;
+    }
+
+    public void setNotValid(boolean notValid) {
+        this.notValid = notValid;
+    }
+
+    public void appendTo(StringBuilder sql) {
+        if (deferrable != null) {
+            sql.append(deferrable ? " DEFERRABLE" : " NOT DEFERRABLE");
+        }
+        if (initially != null) {
+            sql.append(" INITIALLY ").append(initially);
+        }
+        if (notValid) {
+            sql.append(" NOT VALID");
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sql = new StringBuilder();
+        appendTo(sql);
+        return sql.toString().trim();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/CreateTable.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/CreateTable.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import net.sf.jsqlparser.expression.SpannerInterleaveIn;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.LikeClause;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
@@ -35,6 +36,7 @@ public class CreateTable implements Statement {
     private List<TableElement> tableElements;
     private Select select;
     private Table likeTable;
+    private ColDataType ofType;
     private boolean selectParenthesis;
     private boolean ifNotExists = false;
     private boolean orReplace = false;
@@ -195,10 +197,38 @@ public class CreateTable implements Statement {
     }
 
     public Table getLikeTable() {
+        if (likeTable != null) {
+            return likeTable;
+        }
+        List<LikeClause> clauses = getTableElements(LikeClause.class);
+        return clauses.isEmpty() ? null : clauses.get(0).getTable();
+    }
+
+    /** Returns the legacy trailing LIKE source, excluding LIKE clauses inside the definition. */
+    public Table getTrailingLikeTable() {
         return likeTable;
     }
 
+    public ColDataType getOfType() {
+        return ofType;
+    }
+
+    public void setOfType(ColDataType ofType) {
+        this.ofType = ofType;
+    }
+
     public void setLikeTable(Table likeTable, boolean parenthesis) {
+        List<LikeClause> clauses = getTableElements(LikeClause.class);
+        if (this.likeTable == null && !clauses.isEmpty()) {
+            if (likeTable != null) {
+                clauses.get(0).setTable(likeTable);
+            } else {
+                List<TableElement> elements = new ArrayList<>(tableElements);
+                elements.remove(clauses.get(0));
+                setTableElements(elements);
+            }
+            return;
+        }
         this.likeTable = likeTable;
         this.selectParenthesis = parenthesis;
     }
@@ -291,6 +321,9 @@ public class CreateTable implements Statement {
             b.append("IF NOT EXISTS ");
         }
         b.append(table);
+        if (ofType != null) {
+            b.append(" OF ").append(ofType);
+        }
         if (partitionOf != null) {
             b.append(" PARTITION OF ").append(partitionOf);
         }

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/ExcludeConstraint.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/ExcludeConstraint.java
@@ -13,10 +13,16 @@ import java.util.Collection;
 import java.util.List;
 
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.statement.select.PlainSelect;
 
 public class ExcludeConstraint extends Index {
 
     private Expression expression;
+
+    public ExcludeConstraint() {
+        setKind(Kind.EXCLUDE);
+        setType("EXCLUDE");
+    }
 
     public Expression getExpression() {
         return expression;
@@ -28,10 +34,23 @@ public class ExcludeConstraint extends Index {
 
     @Override
     public String toString() {
-        StringBuilder exclusionStatement = new StringBuilder("EXCLUDE WHERE ");
-        exclusionStatement.append("(");
-        exclusionStatement.append(expression);
-        exclusionStatement.append(")");
+        StringBuilder exclusionStatement = new StringBuilder();
+        if (getName() != null) {
+            exclusionStatement.append("CONSTRAINT ").append(getName()).append(' ');
+        }
+        exclusionStatement.append("EXCLUDE");
+        if (getUsing() != null) {
+            exclusionStatement.append(" USING ").append(getUsing());
+        }
+        if (getColumns() != null) {
+            exclusionStatement.append(' ')
+                    .append(PlainSelect.getStringList(getColumns(), true, true));
+        }
+        appendConstraintOptionsTo(exclusionStatement);
+        if (expression != null) {
+            exclusionStatement.append(" WHERE (").append(expression).append(')');
+        }
+        appendConstraintAttributesTo(exclusionStatement);
         return exclusionStatement.toString();
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/ForeignKeyIndex.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/ForeignKeyIndex.java
@@ -174,6 +174,7 @@ public class ForeignKeyIndex extends NamedConstraint {
                     .append(PlainSelect.getStringList(getReferencedColumnNames(), true, true));
             referentialActions.forEach(b::append);
         }
+        appendConstraintAttributesTo(b);
         return b.toString();
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/IdentityDefinition.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/IdentityDefinition.java
@@ -1,0 +1,59 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.table;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import net.sf.jsqlparser.schema.Sequence;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+
+/** The generation mode and sequence parameters of a GENERATED ... AS IDENTITY clause. */
+public class IdentityDefinition implements Serializable {
+    public enum GenerationMode {
+        ALWAYS, BY_DEFAULT
+    }
+
+    private GenerationMode generationMode;
+    private List<Sequence.Parameter> parameters;
+
+    public IdentityDefinition(GenerationMode generationMode) {
+        this.generationMode = generationMode;
+    }
+
+    public GenerationMode getGenerationMode() {
+        return generationMode;
+    }
+
+    public void setGenerationMode(GenerationMode generationMode) {
+        this.generationMode = generationMode;
+    }
+
+    /** Returns null when no parenthesized sequence options were specified. */
+    public List<Sequence.Parameter> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(List<Sequence.Parameter> parameters) {
+        this.parameters = parameters == null ? null : new ArrayList<>(parameters);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sql = new StringBuilder("GENERATED ");
+        sql.append(generationMode == GenerationMode.ALWAYS ? "ALWAYS" : "BY DEFAULT")
+                .append(" AS IDENTITY");
+        if (parameters != null) {
+            sql.append(" (").append(PlainSelect.getStringList(parameters, false, false))
+                    .append(')');
+        }
+        return sql.toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 
@@ -34,6 +35,75 @@ public class Index implements TableElement, Serializable {
     private String commentText;
     private String indexKeyword;
     private Kind kind = Kind.OTHER;
+    private Boolean nullsDistinct;
+    private List<String> includeColumns;
+    private List<Option> storageParameters;
+    private String tableSpace;
+    private ConstraintAttributes constraintAttributes;
+
+    public Boolean getNullsDistinct() {
+        return nullsDistinct;
+    }
+
+    public void setNullsDistinct(Boolean nullsDistinct) {
+        this.nullsDistinct = nullsDistinct;
+    }
+
+    public List<String> getIncludeColumns() {
+        return includeColumns;
+    }
+
+    public void setIncludeColumns(List<String> includeColumns) {
+        this.includeColumns = includeColumns == null ? null : new ArrayList<>(includeColumns);
+    }
+
+    public List<Option> getStorageParameters() {
+        return storageParameters;
+    }
+
+    public void setStorageParameters(List<Option> storageParameters) {
+        this.storageParameters =
+                storageParameters == null ? null : new ArrayList<>(storageParameters);
+    }
+
+    public String getTableSpace() {
+        return tableSpace;
+    }
+
+    public void setTableSpace(String tableSpace) {
+        this.tableSpace = tableSpace;
+    }
+
+    public ConstraintAttributes getConstraintAttributes() {
+        return constraintAttributes;
+    }
+
+    public void setConstraintAttributes(ConstraintAttributes constraintAttributes) {
+        this.constraintAttributes = constraintAttributes;
+    }
+
+    public String nullsDistinctClause() {
+        return nullsDistinct == null ? ""
+                : nullsDistinct ? " NULLS DISTINCT" : " NULLS NOT DISTINCT";
+    }
+
+    public void appendConstraintOptionsTo(StringBuilder sql) {
+        if (includeColumns != null) {
+            sql.append(" INCLUDE ").append(PlainSelect.getStringList(includeColumns, true, true));
+        }
+        if (storageParameters != null) {
+            sql.append(" WITH ").append(PlainSelect.getStringList(storageParameters, true, true));
+        }
+        if (tableSpace != null) {
+            sql.append(" USING INDEX TABLESPACE ").append(tableSpace);
+        }
+    }
+
+    public void appendConstraintAttributesTo(StringBuilder sql) {
+        if (constraintAttributes != null) {
+            constraintAttributes.appendTo(sql);
+        }
+    }
 
     public List<String> getColumnsNames() {
         return columns.stream()
@@ -205,7 +275,13 @@ public class Index implements TableElement, Serializable {
                 : "")
                 + (!idxSpecText.isEmpty() ? " " + idxSpecText : "");
 
-        return tail.isEmpty() ? head : head + " " + tail;
+        StringBuilder sql = new StringBuilder(head).append(nullsDistinctClause());
+        if (!tail.isEmpty()) {
+            sql.append(' ').append(tail);
+        }
+        appendConstraintOptionsTo(sql);
+        appendConstraintAttributesTo(sql);
+        return sql.toString();
     }
 
     public Index withType(String type) {
@@ -258,6 +334,15 @@ public class Index implements TableElement, Serializable {
         private List<Option> operatorClassParameters;
         private SortOrder sortOrder;
         private NullOrdering nullOrdering;
+        private String exclusionOperator;
+
+        public String getExclusionOperator() {
+            return exclusionOperator;
+        }
+
+        public void setExclusionOperator(String exclusionOperator) {
+            this.exclusionOperator = exclusionOperator;
+        }
 
         public ColumnParams(String columnName) {
             this.columnName = columnName;
@@ -366,14 +451,28 @@ public class Index implements TableElement, Serializable {
 
         @Override
         public String toString() {
-            StringBuilder builder = new StringBuilder(
-                    expression != null ? "(" + expression + ")" : columnName);
+            StringBuilder builder = new StringBuilder();
+            appendTo(builder, value -> builder.append(value));
+            return builder.toString();
+        }
+
+        /** Renders expression keys through the caller's expression printer. */
+        public void appendTo(StringBuilder builder, Consumer<Expression> expressionPrinter) {
+            if (expression != null) {
+                builder.append('(');
+                expressionPrinter.accept(expression);
+                builder.append(')');
+            } else {
+                builder.append(columnName);
+            }
             appendParams(builder);
             appendCollation(builder);
             appendOperatorClass(builder);
             appendSortOrder(builder);
             appendNullOrdering(builder);
-            return builder.toString();
+            if (exclusionOperator != null) {
+                builder.append(" WITH ").append(exclusionOperator);
+            }
         }
 
         private void appendParams(StringBuilder builder) {

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/NamedConstraint.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/NamedConstraint.java
@@ -53,12 +53,20 @@ public class NamedConstraint extends Index {
                                 ? " " + getIndexKeyword()
                                 : "";
         String tail = getType()
+                + nullsDistinctClause()
                 + keyword
                 + (indexName != null ? " " + indexName : "")
                 + (getUsing() != null ? " USING " + getUsing() : "")
-                + " " + PlainSelect.getStringList(getColumnsNames(), true, true) +
+                + (getColumns() == null ? ""
+                        : " " + PlainSelect.getStringList(getColumnsNames(), true, true))
+                +
                 (!"".equals(idxSpecText) ? " " + idxSpecText : "");
-        return head + tail;
+        StringBuilder sql = new StringBuilder(head).append(tail);
+        appendConstraintOptionsTo(sql);
+        if (getKind() != Kind.FOREIGN_KEY) {
+            appendConstraintAttributesTo(sql);
+        }
+        return sql.toString();
     }
 
     public NamedConstraint withIndexName(String indexName) {

--- a/src/main/java/net/sf/jsqlparser/statement/create/view/CreateView.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/view/CreateView.java
@@ -9,6 +9,7 @@
  */
 package net.sf.jsqlparser.statement.create.view;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
@@ -16,6 +17,7 @@ import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
+import net.sf.jsqlparser.statement.create.table.Index;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 
@@ -33,6 +35,110 @@ public class CreateView implements Statement {
     private boolean withReadOnly = false;
     private boolean ifNotExists = false;
     private List<String> viewCommentOptions = null;
+    private boolean recursive;
+    private boolean ifNotExistsAfterViewName;
+    private List<ViewOption> options;
+    private String accessMethod;
+    private List<Index.Option> storageParameters;
+    private String tableSpace;
+    private CheckOption checkOption;
+    private Boolean withData;
+
+    /** DEFAULT preserves a CHECK OPTION clause with no explicit LOCAL or CASCADED keyword. */
+    public enum CheckOption {
+        DEFAULT, LOCAL, CASCADED
+    }
+
+    public boolean isRecursive() {
+        return recursive;
+    }
+
+    public void setRecursive(boolean recursive) {
+        this.recursive = recursive;
+    }
+
+    /** Whether the legacy syntax placed IF NOT EXISTS after the view name. */
+    public boolean isIfNotExistsAfterViewName() {
+        return ifNotExistsAfterViewName;
+    }
+
+    public void setIfNotExistsAfterViewName(boolean afterViewName) {
+        this.ifNotExistsAfterViewName = afterViewName;
+    }
+
+    public List<ViewOption> getOptions() {
+        return options;
+    }
+
+    public void setOptions(List<ViewOption> options) {
+        this.options = options == null ? null : new ArrayList<>(options);
+    }
+
+    public String getAccessMethod() {
+        return accessMethod;
+    }
+
+    public void setAccessMethod(String accessMethod) {
+        this.accessMethod = accessMethod;
+    }
+
+    public List<Index.Option> getStorageParameters() {
+        return storageParameters;
+    }
+
+    public void setStorageParameters(List<Index.Option> storageParameters) {
+        this.storageParameters =
+                storageParameters == null ? null : new ArrayList<>(storageParameters);
+    }
+
+    public String getTableSpace() {
+        return tableSpace;
+    }
+
+    public void setTableSpace(String tableSpace) {
+        this.tableSpace = tableSpace;
+    }
+
+    /** Returns null when the trailing CHECK OPTION clause was omitted. */
+    public CheckOption getCheckOption() {
+        return checkOption;
+    }
+
+    public void setCheckOption(CheckOption checkOption) {
+        this.checkOption = checkOption;
+    }
+
+    /** Resolves a bare WITH CHECK OPTION to CASCADED; null still means no trailing clause. */
+    public CheckOption getEffectiveCheckOption() {
+        return checkOption == CheckOption.DEFAULT ? CheckOption.CASCADED : checkOption;
+    }
+
+    /** Returns null for omission, true for WITH DATA, and false for WITH NO DATA. */
+    public Boolean getWithData() {
+        return withData;
+    }
+
+    public void setWithData(Boolean withData) {
+        this.withData = withData;
+    }
+
+    /** Checks combinations introduced by the PostgreSQL view clauses. */
+    public void validateOptions() {
+        if (recursive && (materialized || columnNames == null || columnNames.isEmpty()
+                || checkOption != null)) {
+            throw new IllegalArgumentException(
+                    "A recursive view requires columns and cannot be materialized or have CHECK OPTION");
+        }
+        if (materialized && (options != null || checkOption != null)) {
+            throw new IllegalArgumentException(
+                    "View parameters and CHECK OPTION require an ordinary view");
+        }
+        if (!materialized && (accessMethod != null || storageParameters != null
+                || tableSpace != null || withData != null)) {
+            throw new IllegalArgumentException(
+                    "Storage parameters and WITH DATA require a materialized view");
+        }
+    }
 
     @Override
     public <T, S> T accept(StatementVisitor<T> statementVisitor, S context) {
@@ -132,6 +238,7 @@ public class CreateView implements Statement {
 
     @Override
     public String toString() {
+        validateOptions();
         StringBuilder sql = new StringBuilder("CREATE ");
         if (isOrReplace()) {
             sql.append("OR REPLACE ");
@@ -145,12 +252,18 @@ public class CreateView implements Statement {
             sql.append(temp.name()).append(" ");
         }
 
+        if (recursive) {
+            sql.append("RECURSIVE ");
+        }
         if (isMaterialized()) {
             sql.append("MATERIALIZED ");
         }
         sql.append("VIEW ");
+        if (ifNotExists && !ifNotExistsAfterViewName) {
+            sql.append("IF NOT EXISTS ");
+        }
         sql.append(view);
-        if (ifNotExists) {
+        if (ifNotExists && ifNotExistsAfterViewName) {
             sql.append(" IF NOT EXISTS");
         }
         if (autoRefresh != AutoRefreshOption.NONE) {
@@ -164,11 +277,42 @@ public class CreateView implements Statement {
         if (viewCommentOptions != null) {
             sql.append(PlainSelect.getStringList(viewCommentOptions, false, false));
         }
+        appendParametersTo(sql);
         sql.append(" AS ").append(select);
         if (isWithReadOnly()) {
             sql.append(" WITH READ ONLY");
         }
+        appendOptionsAfterQueryTo(sql);
         return sql.toString();
+    }
+
+    /** Appends the parameters between the view name/columns and AS. */
+    public void appendParametersTo(StringBuilder sql) {
+        if (accessMethod != null) {
+            sql.append(" USING ").append(accessMethod);
+        }
+        if (options != null) {
+            sql.append(" WITH ").append(PlainSelect.getStringList(options, true, true));
+        }
+        if (storageParameters != null) {
+            sql.append(" WITH ").append(PlainSelect.getStringList(storageParameters, true, true));
+        }
+        if (tableSpace != null) {
+            sql.append(" TABLESPACE ").append(tableSpace);
+        }
+    }
+
+    public void appendOptionsAfterQueryTo(StringBuilder sql) {
+        if (checkOption != null) {
+            sql.append(" WITH ");
+            if (checkOption != CheckOption.DEFAULT) {
+                sql.append(checkOption).append(' ');
+            }
+            sql.append("CHECK OPTION");
+        }
+        if (withData != null) {
+            sql.append(withData ? " WITH DATA" : " WITH NO DATA");
+        }
     }
 
     private void appendForceOptionIfApplicable(StringBuilder sql) {

--- a/src/main/java/net/sf/jsqlparser/statement/create/view/ViewOption.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/view/ViewOption.java
@@ -1,0 +1,105 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.view;
+
+import java.io.Serializable;
+import java.util.Locale;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.schema.MultiPartName;
+
+/** A PostgreSQL view parameter, preserving its spelling, value, and optional equals sign. */
+public class ViewOption implements Serializable {
+    public enum Kind {
+        SECURITY_BARRIER, SECURITY_INVOKER, CHECK_OPTION, OTHER
+    }
+
+    private final String name;
+    private final Expression value;
+    private final boolean useEquals;
+
+    public ViewOption(String name, Expression value, boolean useEquals) {
+        this.name = name;
+        this.value = value;
+        this.useEquals = useEquals;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Kind getKind() {
+        switch (MultiPartName.unquote(name).toLowerCase(Locale.ROOT)) {
+            case "security_barrier":
+                return Kind.SECURITY_BARRIER;
+            case "security_invoker":
+                return Kind.SECURITY_INVOKER;
+            case "check_option":
+                return Kind.CHECK_OPTION;
+            default:
+                return Kind.OTHER;
+        }
+    }
+
+    public Expression getValue() {
+        return value;
+    }
+
+    public boolean isUseEquals() {
+        return useEquals;
+    }
+
+    private String valueText() {
+        return value instanceof StringValue ? ((StringValue) value).getValue()
+                : value == null ? null : value.toString();
+    }
+
+    /** Returns the boolean parameter value, or null for a different kind or an unknown value. */
+    public Boolean getBooleanValue() {
+        if (getKind() != Kind.SECURITY_BARRIER && getKind() != Kind.SECURITY_INVOKER) {
+            return null;
+        }
+        String text = valueText();
+        if (text == null) {
+            return true;
+        }
+        switch (text.toLowerCase(Locale.ROOT)) {
+            case "true":
+            case "on":
+            case "yes":
+            case "1":
+                return true;
+            case "false":
+            case "off":
+            case "no":
+            case "0":
+                return false;
+            default:
+                return null;
+        }
+    }
+
+    public CreateView.CheckOption getCheckOption() {
+        if (getKind() == Kind.CHECK_OPTION) {
+            if ("local".equalsIgnoreCase(valueText())) {
+                return CreateView.CheckOption.LOCAL;
+            }
+            if ("cascaded".equalsIgnoreCase(valueText())) {
+                return CreateView.CheckOption.CASCADED;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return name + (value == null ? "" : (useEquals ? " = " : " ") + value);
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/TableDefinitionTraversal.java
+++ b/src/main/java/net/sf/jsqlparser/util/TableDefinitionTraversal.java
@@ -1,0 +1,98 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.util;
+
+import java.util.List;
+import java.util.function.Consumer;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.LikeClause;
+import net.sf.jsqlparser.statement.alter.AlterExpression;
+import net.sf.jsqlparser.statement.create.table.CheckConstraint;
+import net.sf.jsqlparser.statement.create.table.ColumnDefinition;
+import net.sf.jsqlparser.statement.create.table.ColumnOption;
+import net.sf.jsqlparser.statement.create.table.CreateTable;
+import net.sf.jsqlparser.statement.create.table.ExcludeConstraint;
+import net.sf.jsqlparser.statement.create.table.ForeignKeyIndex;
+import net.sf.jsqlparser.statement.create.table.Index;
+import net.sf.jsqlparser.statement.create.table.TableElement;
+
+/** Traverses structured table definitions without interpreting legacy raw column options. */
+public final class TableDefinitionTraversal {
+    private TableDefinitionTraversal() {}
+
+    public static void visit(CreateTable table, Consumer<Expression> expressions,
+            Consumer<Table> tables) {
+        if (table.getTableElements() != null) {
+            table.getTableElements().forEach(element -> visit(element, expressions, tables));
+        } else {
+            if (table.getColumnDefinitions() != null) {
+                table.getColumnDefinitions().forEach(column -> visit(column, expressions, tables));
+            }
+            if (table.getIndexes() != null) {
+                table.getIndexes().forEach(index -> visit(index, expressions, tables));
+            }
+        }
+        accept(table.getTrailingLikeTable(), tables);
+        accept(table.getPartitionOf(), tables);
+    }
+
+    public static void visit(TableElement element, Consumer<Expression> expressions,
+            Consumer<Table> tables) {
+        if (element instanceof LikeClause) {
+            accept(((LikeClause) element).getTable(), tables);
+        } else if (element instanceof ColumnDefinition) {
+            ColumnDefinition column = (ColumnDefinition) element;
+            if (column.getColumnOptions() != null) {
+                for (ColumnOption option : column.getColumnOptions()) {
+                    if (option.getForeignKeyReference() != null) {
+                        accept(option.getForeignKeyReference().getTable(), tables);
+                    }
+                    if (option.getConstraint() != null) {
+                        visit(option.getConstraint(), expressions, tables);
+                    }
+                }
+            }
+            if (column instanceof AlterExpression.ColumnDataType) {
+                accept(((AlterExpression.ColumnDataType) column).getUsingExpression(), expressions);
+            }
+        } else if (element instanceof Index) {
+            Index index = (Index) element;
+            if (index.getColumns() != null) {
+                for (Index.ColumnParams column : index.getColumns()) {
+                    accept(column.getExpression(), expressions);
+                    visitOptions(column.getOperatorClassParameters(), expressions);
+                }
+            }
+            visitOptions(index.getStorageParameters(), expressions);
+            if (index instanceof CheckConstraint) {
+                accept(((CheckConstraint) index).getExpression(), expressions);
+            }
+            if (index instanceof ExcludeConstraint) {
+                accept(((ExcludeConstraint) index).getExpression(), expressions);
+            }
+            if (index instanceof ForeignKeyIndex) {
+                accept(((ForeignKeyIndex) index).getTable(), tables);
+            }
+        }
+    }
+
+    private static void visitOptions(List<Index.Option> options, Consumer<Expression> expressions) {
+        if (options != null) {
+            options.forEach(option -> accept(option.getValue(), expressions));
+        }
+    }
+
+    private static <T> void accept(T value, Consumer<T> consumer) {
+        if (value != null) {
+            consumer.accept(value);
+        }
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -1585,6 +1585,8 @@ public class TablesNamesFinder<Void>
     @Override
     public <S> Void visit(CreateTable create, S context) {
         visit(create.getTable(), null);
+        TableDefinitionTraversal.visit(create,
+                expression -> expression.accept(this, context), table -> visit(table, context));
         if (create.getSelect() != null) {
             create.getSelect().accept((SelectVisitor<?>) this, context);
         }
@@ -1626,12 +1628,25 @@ public class TablesNamesFinder<Void>
 
     @Override
     public <S> Void visit(Alter alter, S context) {
+        for (net.sf.jsqlparser.statement.alter.AlterExpression action : alter
+                .getAlterExpressions()) {
+            if (action.getColDataTypeList() != null) {
+                action.getColDataTypeList().forEach(column -> TableDefinitionTraversal.visit(column,
+                        expression -> expression.accept(this, context),
+                        table -> visit(table, context)));
+            }
+            if (action.getIndex() != null) {
+                TableDefinitionTraversal.visit(action.getIndex(),
+                        expression -> expression.accept(this, context),
+                        table -> visit(table, context));
+            }
+        }
         return alter.getTable().accept(this, context);
     }
 
     @Override
     public void visit(Alter alter) {
-        alter.getTable().accept(this, null);
+        StatementVisitor.super.visit(alter);
     }
 
     @Override
@@ -2076,7 +2091,10 @@ public class TablesNamesFinder<Void>
 
     @Override
     public <S> Void visit(CreateSequence createSequence, S context) {
-        throwUnsupported(createSequence);
+        if (createSequence.getSequence().getOwnership() != null
+                && !createSequence.getSequence().getOwnership().isNone()) {
+            visit(createSequence.getSequence().getOwnership().getColumn().getTable(), context);
+        }
         return null;
     }
 
@@ -2087,7 +2105,10 @@ public class TablesNamesFinder<Void>
 
     @Override
     public <S> Void visit(AlterSequence alterSequence, S context) {
-        throwUnsupported(alterSequence);
+        if (alterSequence.getSequence().getOwnership() != null
+                && !alterSequence.getSequence().getOwnership().isNone()) {
+            visit(alterSequence.getSequence().getOwnership().getColumn().getTable(), context);
+        }
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/AlterDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/AlterDeParser.java
@@ -10,16 +10,63 @@
 package net.sf.jsqlparser.util.deparser;
 
 import net.sf.jsqlparser.statement.alter.Alter;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.statement.alter.AlterExpression;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import java.util.Iterator;
 
 public class AlterDeParser extends AbstractDeParser<Alter> {
+    private final ExpressionVisitor<StringBuilder> expressionVisitor;
 
     public AlterDeParser(StringBuilder buffer) {
+        this(buffer, new StatementDeParser(buffer).getExpressionDeParser());
+    }
+
+    public AlterDeParser(StringBuilder buffer, ExpressionVisitor<StringBuilder> expressionVisitor) {
         super(buffer);
+        this.expressionVisitor = expressionVisitor;
     }
 
     @Override
     public void deParse(Alter alter) {
-        builder.append(alter.toString());
+        builder.append("ALTER TABLE ");
+        if (alter.isUseOnly()) {
+            builder.append("ONLY ");
+        }
+        if (alter.isUseTableIfExists()) {
+            builder.append("IF EXISTS ");
+        }
+        builder.append(alter.getTable().getFullyQualifiedName()).append(' ');
+        for (Iterator<AlterExpression> iterator = alter.getAlterExpressions().iterator(); iterator
+                .hasNext();) {
+            deParseAction(iterator.next());
+            if (iterator.hasNext()) {
+                builder.append(", ");
+            }
+        }
+    }
+
+    private void deParseAction(AlterExpression action) {
+        if (action.getColDataTypeList() == null || action.getColDataTypeList().size() != 1
+                || action.getColDataTypeList().get(0).getUsingExpression() == null) {
+            builder.append(action);
+            return;
+        }
+        AlterExpression.ColumnDataType column = action.getColDataTypeList().get(0);
+        builder.append(action.getOperation()).append(' ');
+        if (action.hasColumn()) {
+            builder.append("COLUMN ");
+        }
+        if (action.isUsingIfExists()) {
+            builder.append("IF EXISTS ");
+        }
+        builder.append(column.getColumnName()).append(column.isWithType() ? " TYPE " : " ")
+                .append(column.toStringDataTypeAndSpec()).append(" USING ");
+        column.getUsingExpression().accept(expressionVisitor, null);
+        if (action.getParameters() != null && !action.getParameters().isEmpty()) {
+            builder.append(' ')
+                    .append(PlainSelect.getStringList(action.getParameters(), false, false));
+        }
     }
 
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/CreateTableDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/CreateTableDeParser.java
@@ -15,6 +15,7 @@ import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.create.table.ColumnDefinition;
 import net.sf.jsqlparser.statement.create.table.CreateTable;
 import net.sf.jsqlparser.statement.create.table.Index;
+import net.sf.jsqlparser.statement.create.table.TableElement;
 import net.sf.jsqlparser.statement.select.PlainSelect;
 import net.sf.jsqlparser.statement.select.Select;
 
@@ -23,7 +24,7 @@ public class CreateTableDeParser extends AbstractDeParser<CreateTable> {
     private StatementDeParser statementDeParser;
 
     public CreateTableDeParser(StringBuilder buffer) {
-        super(buffer);
+        this(new StatementDeParser(buffer), buffer);
     }
 
     public CreateTableDeParser(StatementDeParser statementDeParser, StringBuilder buffer) {
@@ -34,6 +35,8 @@ public class CreateTableDeParser extends AbstractDeParser<CreateTable> {
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     public void deParse(CreateTable createTable) {
+        TableElementDeParser elements =
+                new TableElementDeParser(builder, statementDeParser.getExpressionDeParser());
         builder.append("CREATE ");
         if (createTable.isOrReplace()) {
             builder.append("OR REPLACE ");
@@ -52,6 +55,9 @@ public class CreateTableDeParser extends AbstractDeParser<CreateTable> {
             builder.append("IF NOT EXISTS ");
         }
         builder.append(createTable.getTable().getFullyQualifiedName());
+        if (createTable.getOfType() != null) {
+            builder.append(" OF ").append(createTable.getOfType());
+        }
         if (createTable.getPartitionOf() != null) {
             builder.append(" PARTITION OF ")
                     .append(createTable.getPartitionOf().getFullyQualifiedName());
@@ -66,20 +72,22 @@ public class CreateTableDeParser extends AbstractDeParser<CreateTable> {
             }
             builder.append(")");
         }
-        if (createTable.getColumnDefinitions() != null) {
+        if (createTable.getTableElements() != null && !createTable.getTableElements().isEmpty()) {
+            builder.append(" (");
+            for (Iterator<TableElement> iter = createTable.getTableElements().iterator(); iter
+                    .hasNext();) {
+                elements.deParse(iter.next());
+                if (iter.hasNext()) {
+                    builder.append(", ");
+                }
+            }
+            builder.append(")");
+        } else if (createTable.getColumnDefinitions() != null) {
             builder.append(" (");
             for (Iterator<ColumnDefinition> iter =
                     createTable.getColumnDefinitions().iterator(); iter.hasNext();) {
                 ColumnDefinition columnDefinition = iter.next();
-                builder.append(columnDefinition.getColumnName());
-                builder.append(" ");
-                builder.append(columnDefinition.getColDataType().toString());
-                if (columnDefinition.getColumnSpecs() != null) {
-                    for (String s : columnDefinition.getColumnSpecs()) {
-                        builder.append(" ");
-                        builder.append(s);
-                    }
-                }
+                elements.deParse(columnDefinition);
 
                 if (iter.hasNext()) {
                     builder.append(", ");
@@ -89,7 +97,7 @@ public class CreateTableDeParser extends AbstractDeParser<CreateTable> {
             if (createTable.getIndexes() != null) {
                 for (Index index : createTable.getIndexes()) {
                     builder.append(", ");
-                    builder.append(index.toString());
+                    elements.deParse(index);
                 }
             }
 
@@ -123,12 +131,12 @@ public class CreateTableDeParser extends AbstractDeParser<CreateTable> {
                 builder.append(")");
             }
         }
-        if (createTable.getLikeTable() != null) {
+        if (createTable.getTrailingLikeTable() != null) {
             builder.append(" LIKE ");
             if (createTable.isSelectParenthesis()) {
                 builder.append("(");
             }
-            Table table = createTable.getLikeTable();
+            Table table = createTable.getTrailingLikeTable();
             builder.append(table.getFullyQualifiedName());
             if (createTable.isSelectParenthesis()) {
                 builder.append(")");

--- a/src/main/java/net/sf/jsqlparser/util/deparser/CreateViewDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/CreateViewDeParser.java
@@ -37,6 +37,7 @@ public class CreateViewDeParser extends AbstractDeParser<CreateView> {
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     public void deParse(CreateView createView) {
+        createView.validateOptions();
         builder.append("CREATE ");
         if (createView.isOrReplace()) {
             builder.append("OR REPLACE ");
@@ -59,11 +60,18 @@ public class CreateViewDeParser extends AbstractDeParser<CreateView> {
         if (createView.getTemporary() != TemporaryOption.NONE) {
             builder.append(createView.getTemporary().name()).append(" ");
         }
+        if (createView.isRecursive()) {
+            builder.append("RECURSIVE ");
+        }
         if (createView.isMaterialized()) {
             builder.append("MATERIALIZED ");
         }
-        builder.append("VIEW ").append(createView.getView().getFullyQualifiedName());
-        if (createView.isIfNotExists()) {
+        builder.append("VIEW ");
+        if (createView.isIfNotExists() && !createView.isIfNotExistsAfterViewName()) {
+            builder.append("IF NOT EXISTS ");
+        }
+        builder.append(createView.getView().getFullyQualifiedName());
+        if (createView.isIfNotExists() && createView.isIfNotExistsAfterViewName()) {
             builder.append(" IF NOT EXISTS");
         }
         if (createView.getAutoRefresh() != AutoRefreshOption.NONE) {
@@ -78,6 +86,7 @@ public class CreateViewDeParser extends AbstractDeParser<CreateView> {
             builder.append(
                     PlainSelect.getStringList(createView.getViewCommentOptions(), false, false));
         }
+        createView.appendParametersTo(builder);
         builder.append(" AS ");
 
         Select select = createView.getSelect();
@@ -85,6 +94,7 @@ public class CreateViewDeParser extends AbstractDeParser<CreateView> {
         if (createView.isWithReadOnly()) {
             builder.append(" WITH READ ONLY");
         }
+        createView.appendOptionsAfterQueryTo(builder);
     }
 
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -146,7 +146,7 @@ public class StatementDeParser extends AbstractDeParser<Statement>
 
     @Override
     public <S> StringBuilder visit(CreateView createView, S context) {
-        CreateViewDeParser createViewDeParser = new CreateViewDeParser(builder);
+        CreateViewDeParser createViewDeParser = new CreateViewDeParser(builder, selectDeParser);
         createViewDeParser.deParse(createView);
         return builder;
     }
@@ -279,7 +279,7 @@ public class StatementDeParser extends AbstractDeParser<Statement>
 
     @Override
     public <S> StringBuilder visit(Alter alter, S context) {
-        AlterDeParser alterDeParser = new AlterDeParser(builder);
+        AlterDeParser alterDeParser = new AlterDeParser(builder, expressionDeParser);
         alterDeParser.deParse(alter);
         return builder;
     }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/TableElementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/TableElementDeParser.java
@@ -1,0 +1,112 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.util.deparser;
+
+import java.util.Iterator;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.statement.create.table.CheckConstraint;
+import net.sf.jsqlparser.statement.create.table.ColumnDefinition;
+import net.sf.jsqlparser.statement.create.table.ColumnOption;
+import net.sf.jsqlparser.statement.create.table.ExcludeConstraint;
+import net.sf.jsqlparser.statement.create.table.Index;
+import net.sf.jsqlparser.statement.create.table.TableElement;
+
+/** Deparses table elements while preserving expression visitor customization. */
+public class TableElementDeParser extends AbstractDeParser<TableElement> {
+    private final ExpressionVisitor<StringBuilder> expressionVisitor;
+
+    public TableElementDeParser(StringBuilder builder,
+            ExpressionVisitor<StringBuilder> expressionVisitor) {
+        super(builder);
+        this.expressionVisitor = expressionVisitor;
+    }
+
+    @Override
+    public void deParse(TableElement element) {
+        if (element instanceof ExcludeConstraint) {
+            deParseExclude((ExcludeConstraint) element);
+        } else if (element instanceof CheckConstraint) {
+            deParseCheck((CheckConstraint) element);
+        } else if (element instanceof ColumnDefinition
+                && ((ColumnDefinition) element).getColumnOptions() != null) {
+            deParseColumn((ColumnDefinition) element);
+        } else {
+            builder.append(element);
+        }
+    }
+
+    private void deParseColumn(ColumnDefinition column) {
+        builder.append(column.getColumnName());
+        if (column.getColDataType() != null) {
+            builder.append(' ').append(column.getColDataType());
+        }
+        if (column.isWithOptions()) {
+            builder.append(" WITH OPTIONS");
+        }
+        for (ColumnOption option : column.getColumnOptions()) {
+            builder.append(' ');
+            if (option.getConstraint() != null) {
+                deParse(option.getConstraint());
+            } else {
+                builder.append(option);
+            }
+        }
+    }
+
+    private void deParseExclude(ExcludeConstraint constraint) {
+        if (constraint.getName() != null) {
+            builder.append("CONSTRAINT ").append(constraint.getName()).append(' ');
+        }
+        builder.append("EXCLUDE");
+        if (constraint.getUsing() != null) {
+            builder.append(" USING ").append(constraint.getUsing());
+        }
+        if (constraint.getColumns() != null) {
+            builder.append(" (");
+            for (Iterator<Index.ColumnParams> iterator =
+                    constraint.getColumns().iterator(); iterator.hasNext();) {
+                iterator.next().appendTo(builder,
+                        expression -> expression.accept(expressionVisitor, null));
+                if (iterator.hasNext()) {
+                    builder.append(", ");
+                }
+            }
+            builder.append(')');
+        }
+        constraint.appendConstraintOptionsTo(builder);
+        if (constraint.getExpression() != null) {
+            builder.append(" WHERE (");
+            constraint.getExpression().accept(expressionVisitor, null);
+            builder.append(')');
+        }
+        constraint.appendConstraintAttributesTo(builder);
+    }
+
+    private void deParseCheck(CheckConstraint constraint) {
+        if (constraint.getName() != null || constraint.isUseConstraintKeyword()) {
+            builder.append("CONSTRAINT");
+            if (constraint.getName() != null) {
+                builder.append(' ').append(constraint.getName());
+            }
+            builder.append(' ');
+        }
+        builder.append("CHECK (");
+        if (constraint.getExpression() != null) {
+            constraint.getExpression().accept(expressionVisitor, null);
+        } else {
+            builder.append("null");
+        }
+        builder.append(')');
+        if (constraint.getEnforced() != null) {
+            builder.append(constraint.getEnforced() ? " ENFORCED" : " NOT ENFORCED");
+        }
+        constraint.appendConstraintAttributesTo(builder);
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/PostgresqlVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/PostgresqlVersion.java
@@ -24,19 +24,15 @@ import net.sf.jsqlparser.parser.feature.Feature;
  */
 public enum PostgresqlVersion implements Version {
     V10("10",
-            EnumSet.of(
-                    // supported if used with jdbc
+            EnumSet.of(// supported if used with jdbc
                     Feature.jdbcParameter,
-                    Feature.jdbcNamedParameter,
-                    // expressions
+                    Feature.jdbcNamedParameter, // expressions
                     Feature.exprLike,
-                    Feature.exprSimilarTo,
-                    // https://www.postgresql.org/docs/current/sql-select.html
+                    Feature.exprSimilarTo, // https://www.postgresql.org/docs/current/sql-select.html
                     Feature.select,
                     Feature.selectGroupBy, Feature.function, Feature.tableFunction,
                     Feature.lateralSubSelect,
-                    Feature.selectHaving,
-                    // https://www.postgresql.org/docs/current/queries-table-expressions.html#QUERIES-GROUPING-SETS
+                    Feature.selectHaving, // https://www.postgresql.org/docs/current/queries-table-expressions.html#QUERIES-GROUPING-SETS
                     Feature.selectGroupByGroupingSets,
 
                     // https://www.postgresql.org/docs/current/sql-select.html#join_type
@@ -95,20 +91,15 @@ public enum PostgresqlVersion implements Version {
                     Feature.commentOnView,
 
                     // https://www.postgresql.org/docs/current/sql-createsequence.html
-                    Feature.createSequence,
-                    // https://www.postgresql.org/docs/current/sql-altersequence.html
-                    Feature.alterSequence,
-                    // https://www.postgresql.org/docs/current/sql-createschema.html
-                    Feature.createSchema,
-                    // https://www.postgresql.org/docs/current/sql-createindex.html
-                    Feature.createIndex,
-                    // https://www.postgresql.org/docs/current/sql-createtable.html
+                    Feature.createSequence, // https://www.postgresql.org/docs/current/sql-altersequence.html
+                    Feature.alterSequence, // https://www.postgresql.org/docs/current/sql-createschema.html
+                    Feature.createSchema, // https://www.postgresql.org/docs/current/sql-createindex.html
+                    Feature.createIndex, // https://www.postgresql.org/docs/current/sql-createtable.html
                     Feature.createTable, Feature.createTableUnlogged,
                     Feature.createTableCreateOptionStrings, Feature.createTableTableOptionStrings,
-                    Feature.createTableFromSelect, Feature.createTableIfNotExists,
-                    // https://www.postgresql.org/docs/current/sql-createview.html
+                    Feature.createTableFromSelect, Feature.createTableIfNotExists, // https://www.postgresql.org/docs/current/sql-createview.html
                     Feature.createView, Feature.createViewTemporary, Feature.createOrReplaceView,
-                    // https://www.postgresql.org/docs/current/sql-alterview.html
+                    Feature.createViewMaterialized, // https://www.postgresql.org/docs/current/sql-alterview.html
                     // Feature.alterView,
 
                     // https://www.postgresql.org/docs/16/sql-refreshmaterializedview.html
@@ -122,44 +113,31 @@ public enum PostgresqlVersion implements Version {
                     Feature.values,
                     Feature.insertFromSelect,
                     Feature.insertReturningAll,
-                    Feature.insertReturningExpressionList,
-                    // https://www.postgresql.org/docs/current/sql-update.html
+                    Feature.insertReturningExpressionList, // https://www.postgresql.org/docs/current/sql-update.html
                     Feature.update,
-                    Feature.updateReturning,
-                    // https://www.postgresql.org/docs/current/sql-delete.html
+                    Feature.updateReturning, // https://www.postgresql.org/docs/current/sql-delete.html
                     Feature.delete,
-                    Feature.deleteReturningExpressionList,
-                    // https://www.postgresql.org/docs/current/sql-truncate.html
+                    Feature.deleteReturningExpressionList, // https://www.postgresql.org/docs/current/sql-truncate.html
                     Feature.truncate,
 
                     // https://www.postgresql.org/docs/current/sql-call.html
                     Feature.execute, Feature.executeCall,
 
-                    Feature.drop,
-                    // https://www.postgresql.org/docs/current/sql-droptable.html
-                    Feature.dropTable,
-                    // https://www.postgresql.org/docs/current/sql-dropindex.html
-                    Feature.dropIndex,
-                    // https://www.postgresql.org/docs/current/sql-dropview.html
-                    Feature.dropView,
-                    // https://www.postgresql.org/docs/current/sql-dropschema.html
-                    Feature.dropSchema,
-                    // https://www.postgresql.org/docs/current/sql-dropsequence.html
+                    Feature.drop, // https://www.postgresql.org/docs/current/sql-droptable.html
+                    Feature.dropTable, // https://www.postgresql.org/docs/current/sql-dropindex.html
+                    Feature.dropIndex, // https://www.postgresql.org/docs/current/sql-dropview.html
+                    Feature.dropView, // https://www.postgresql.org/docs/current/sql-dropschema.html
+                    Feature.dropSchema, // https://www.postgresql.org/docs/current/sql-dropsequence.html
                     Feature.dropSequence,
                     Feature.dropTableIfExists, Feature.dropIndexIfExists, Feature.dropViewIfExists,
                     Feature.dropSchemaIfExists, Feature.dropSequenceIfExists,
 
                     // https://www.postgresql.org/docs/current/sql-altertable.html
-                    Feature.alterTable,
-                    // https://www.postgresql.org/docs/current/using-explain.html
-                    Feature.explain,
-                    // https://www.postgresql.org/docs/current/sql-grant.html
-                    Feature.grant,
-                    // https://www.postgresql.org/docs/current/sql-set.html
-                    Feature.set,
-                    // https://www.postgresql.org/docs/current/sql-reset.html
-                    Feature.reset,
-                    // https://www.postgresql.org/docs/current/sql-commit.html
+                    Feature.alterTable, // https://www.postgresql.org/docs/current/using-explain.html
+                    Feature.explain, // https://www.postgresql.org/docs/current/sql-grant.html
+                    Feature.grant, // https://www.postgresql.org/docs/current/sql-set.html
+                    Feature.set, // https://www.postgresql.org/docs/current/sql-reset.html
+                    Feature.reset, // https://www.postgresql.org/docs/current/sql-commit.html
                     Feature.commit)), V11("11", V10.copy().getFeatures()), V12("12",
                             V11.copy().getFeatures()), V13("13",
                                     V12.copy().getFeatures()), V14("14", V13.copy().getFeatures());

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/AlterSequenceValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/AlterSequenceValidator.java
@@ -21,6 +21,9 @@ public class AlterSequenceValidator extends AbstractValidator<AlterSequence> {
 
     @Override
     public void validate(AlterSequence statement) {
+        if (statement.getSequence().getOwnership() != null) {
+            validateOptionalExpression(statement.getSequence().getOwnership().getColumn());
+        }
         validateFeatureAndName(Feature.alterSequence, NamedObject.sequence,
                 statement.getSequence().getFullyQualifiedName());
     }

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/AlterValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/AlterValidator.java
@@ -19,6 +19,7 @@ import net.sf.jsqlparser.statement.alter.AlterExpression.ColumnDataType;
 import net.sf.jsqlparser.statement.alter.AlterExpression.ColumnDropNotNull;
 import net.sf.jsqlparser.statement.alter.AlterExpression.ColumnSetNotNull;
 import net.sf.jsqlparser.statement.alter.AlterOperation;
+import net.sf.jsqlparser.util.TableDefinitionTraversal;
 import net.sf.jsqlparser.util.validation.ValidationCapability;
 import net.sf.jsqlparser.util.validation.ValidationUtil;
 import net.sf.jsqlparser.util.validation.metadata.NamedObject;
@@ -38,6 +39,14 @@ public class AlterValidator extends AbstractValidator<Alter> {
     }
 
     public void validate(Alter alter, AlterExpression e) {
+        if (e.getColDataTypeList() != null) {
+            e.getColDataTypeList().forEach(column -> TableDefinitionTraversal.visit(column,
+                    this::validateOptionalExpression, this::validateOptionalFromItem));
+        }
+        if (e.getIndex() != null) {
+            TableDefinitionTraversal.visit(e.getIndex(), this::validateOptionalExpression,
+                    this::validateOptionalFromItem);
+        }
         for (ValidationCapability c : getCapabilities()) {
 
             validateOptionalColumnName(c, e.getColumnOldName());

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/CreateSequenceValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/CreateSequenceValidator.java
@@ -22,6 +22,9 @@ public class CreateSequenceValidator extends AbstractValidator<CreateSequence> {
 
     @Override
     public void validate(CreateSequence statement) {
+        if (statement.getSequence().getOwnership() != null) {
+            validateOptionalExpression(statement.getSequence().getOwnership().getColumn());
+        }
         for (ValidationCapability c : getCapabilities()) {
             validateFeature(Feature.createSequence);
             validateName(c, NamedObject.sequence, statement.getSequence().getFullyQualifiedName(),

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/CreateTableValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/CreateTableValidator.java
@@ -12,6 +12,7 @@ package net.sf.jsqlparser.util.validation.validator;
 import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.statement.create.table.CreateTable;
 import net.sf.jsqlparser.statement.create.table.Index;
+import net.sf.jsqlparser.util.TableDefinitionTraversal;
 import net.sf.jsqlparser.util.validation.ValidationCapability;
 import net.sf.jsqlparser.util.validation.metadata.NamedObject;
 
@@ -43,6 +44,8 @@ public class CreateTableValidator extends AbstractValidator<CreateTable> {
                     false);
         }
 
+        TableDefinitionTraversal.visit(createTable, this::validateOptionalExpression,
+                this::validateOptionalFromItem);
         if (createTable.getSelect() != null) {
             getValidator(StatementValidator.class).validate(createTable.getSelect());
         }

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/CreateViewValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/CreateViewValidator.java
@@ -25,6 +25,7 @@ public class CreateViewValidator extends AbstractValidator<CreateView> {
 
     @Override
     public void validate(CreateView createView) {
+        createView.validateOptions();
         for (ValidationCapability c : getCapabilities()) {
             validateFeature(c, Feature.createView);
             validateFeature(c, createView.isOrReplace(), Feature.createOrReplaceView);

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1305,6 +1305,42 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
         return Dialect.MYSQL.name().equals(dialect) || Dialect.MARIADB.name().equals(dialect);
     }
 
+    private void requireDdlSyntax(boolean valid, String message) throws ParseException {
+        if (!valid) {
+            throw new ParseException(message);
+        }
+    }
+
+    private LikeClause.OptionKind likeOptionKind(String name) throws ParseException {
+        try {
+            return LikeClause.OptionKind.valueOf(name.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException ex) {
+            throw new ParseException("Unknown LIKE option: " + name);
+        }
+    }
+
+    private boolean isIdentityAlterationAhead() {
+        int first = getToken(1).kind;
+        int second = getToken(2).kind;
+        if ((first == K_ADD || first == K_SET)
+                && "GENERATED".equalsIgnoreCase(getToken(2).image)) {
+            return true;
+        }
+        if (first == K_RESTART || (first == K_DROP && second == K_IDENTITY)) {
+            return true;
+        }
+        if (first == K_SET) {
+            switch (second) {
+                case K_INCREMENT: case K_START: case K_MINVALUE: case K_MAXVALUE:
+                case K_NO: case K_CACHE: case K_CYCLE:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+        return false;
+    }
+
     private static boolean hasStructuredColumnOption(List<ColumnOption> options) {
         for (ColumnOption option : options) {
             if (option.getKind() != ColumnOption.Kind.OTHER) {
@@ -2736,37 +2772,22 @@ LikeClause LikeClause(): {
     LikeClause likeClause = new LikeClause();
     Table table;
     List<SelectItem<Column>> columnsList;
+    boolean including;
+    String option;
 } {
     <K_LIKE>
     table = Table() { likeClause.setTable(table); }
-    [ "(" columnsList = ColumnSelectItemsList() ")" { likeClause.setColumnsList(columnsList); }]
-
-    [
-        LOOKAHEAD(2)
+    [ LOOKAHEAD(2) "(" columnsList = ColumnSelectItemsList() ")" { likeClause.setColumnsList(columnsList); }]
+    (
         (
-              <K_INCLUDING> { likeClause.setIncludingDefaults(true); }
-            | <K_EXCLUDING> { likeClause.setExcludingDefaults(true); }
+            <K_INCLUDING> { including = true; }
+            | <K_EXCLUDING> { including = false; }
         )
-        <K_DEFAULTS>
-    ]
-
-    [
-        LOOKAHEAD(2)
-        (
-              <K_INCLUDING> { likeClause.setIncludingIdentity(true); }
-            | <K_EXCLUDING> { likeClause.setExcludingIdentity(true); }
-        )
-        <K_IDENTITY>
-    ]
-
-    [
-        LOOKAHEAD(2)
-        (
-              <K_INCLUDING> { likeClause.setIncludingComments(true); }
-            | <K_EXCLUDING> { likeClause.setExcludingComments(true); }
-        )
-        <K_COMMENTS>
-    ]
+        option=RelObjectName()
+        {
+            likeClause.addOption(likeOptionKind(option), including);
+        }
+    )*
 
     {
         return likeClause;
@@ -11407,7 +11428,7 @@ Index.ColumnParams IndexColumnWithParams(): {
         { columnParams.add(sortOrder.image); } ]
     [ LOOKAHEAD(2) <K_NULLS> (nullOrdering=<K_FIRST> | nullOrdering=<K_LAST>)
         { columnParams.add("NULLS"); columnParams.add(nullOrdering.image); } ]
-    ( LOOKAHEAD(2) parameter=CreateParameter() { columnParams.addAll(parameter); } )*
+    ( LOOKAHEAD(2, { getToken(1).kind != K_WITH }) parameter=CreateParameter() { columnParams.addAll(parameter); } )*
     {
         column = expression != null
                 ? new Index.ColumnParams(expression,
@@ -11607,8 +11628,17 @@ ColumnOption ColumnDefinitionOption(): {
     List<String> parameter;
     ForeignKeyReference reference;
     ColumnOption option;
+    IdentityDefinition identity;
+    NamedConstraint constraint;
 } {
     (
+        LOOKAHEAD({ isKeywordAhead("GENERATED")
+                && (getToken(4).kind == K_IDENTITY || getToken(5).kind == K_IDENTITY) })
+        identity=IdentityDefinition() { option = ColumnOption.identity(identity); }
+        |
+        LOOKAHEAD(<K_UNIQUE>) constraint=ColumnUniqueConstraint()
+        { option = ColumnOption.constraint(constraint); }
+        |
         LOOKAHEAD({ isKeywordAhead("SERIAL")
                 && getToken(2).kind == K_DEFAULT && getToken(3).kind == K_VALUE })
         tk=<S_IDENTIFIER> <K_DEFAULT> <K_VALUE>
@@ -11621,6 +11651,40 @@ ColumnOption ColumnDefinitionOption(): {
         { option = ColumnOption.raw(parameter); }
     )
     { return option; }
+}
+
+NamedConstraint ColumnUniqueConstraint():
+{
+    NamedConstraint constraint = new NamedConstraint().withType("UNIQUE");
+    Boolean nullsDistinct = null;
+}
+{
+    <K_UNIQUE>
+    [ <K_NULLS> [ <K_NOT> { nullsDistinct = false; } ] <K_DISTINCT> {
+        constraint.setNullsDistinct(nullsDistinct == null ? true : nullsDistinct);
+    } ]
+    { return constraint; }
+}
+
+IdentityDefinition IdentityDefinition():
+{
+    Token token;
+    IdentityDefinition.GenerationMode mode;
+    IdentityDefinition identity;
+    List<Sequence.Parameter> parameters;
+}
+{
+    token=<S_IDENTIFIER> {
+        requireDdlSyntax("GENERATED".equalsIgnoreCase(token.image), "Expected GENERATED");
+    }
+    ( <K_ALWAYS> { mode = IdentityDefinition.GenerationMode.ALWAYS; }
+        | <K_BY> <K_DEFAULT> { mode = IdentityDefinition.GenerationMode.BY_DEFAULT; } )
+    <K_AS> <K_IDENTITY> { identity = new IdentityDefinition(mode); }
+    [ LOOKAHEAD(2) "(" parameters=SequenceParameters() ")" {
+        requireDdlSyntax(!parameters.isEmpty(), "Expected an identity sequence parameter");
+        identity.setParameters(parameters);
+    } ]
+    { return identity; }
 }
 
 StringValue MySqlAccountNamePart():
@@ -12045,6 +12109,7 @@ Index TableIndexSpec(boolean createContext):
     List<Index.ColumnParams> columns;
     List<String> indexOptions = new ArrayList<String>();
     Index index;
+    Boolean nullsDistinct = null;
 }
 {
     (
@@ -12061,6 +12126,9 @@ Index TableIndexSpec(boolean createContext):
         }
         |
         typeToken=<K_UNIQUE>
+        [ LOOKAHEAD(2) <K_NULLS> [ <K_NOT> { nullsDistinct = false; } ] <K_DISTINCT> {
+            if (nullsDistinct == null) { nullsDistinct = true; }
+        } ]
         [ LOOKAHEAD(2) (keywordToken=<K_KEY> | keywordToken=<K_INDEX>) ]
         [ LOOKAHEAD({ getToken(1).kind != OPENING_BRACKET
                 && getToken(1).kind != K_USING }) indexName=RelObjectName() ]
@@ -12122,6 +12190,8 @@ Index TableIndexSpec(boolean createContext):
                     .withName(indexName).withColumns(columns).withIndexSpec(indexOptions);
         }
     )
+    { index.setNullsDistinct(nullsDistinct); }
+    PostgreSqlConstraintOptions(index)
     { return index; }
 }
 
@@ -12132,10 +12202,51 @@ void TableIndexOptions(boolean createContext, List<String> options):
 {
     (
         LOOKAHEAD({ createContext })
-        ( LOOKAHEAD(2) parameter=CreateParameter() { options.addAll(parameter); } )*
+        ( LOOKAHEAD(2, { !(getToken(1).kind == K_WITH && getToken(2).kind == OPENING_BRACKET)
+                && !(getToken(1).kind == K_USING && getToken(2).kind == K_INDEX)
+                && getToken(1).kind != K_DEFERRABLE && !isKeywordAhead("INITIALLY")
+                && !(getToken(1).kind == K_NOT && (getToken(2).kind == K_DEFERRABLE
+                    || "VALID".equalsIgnoreCase(getToken(2).image))) })
+            parameter=CreateParameter() { options.addAll(parameter); } )*
         |
         LOOKAHEAD({ !createContext }) IndexOptionList(options)
     )
+}
+
+void PostgreSqlConstraintOptions(Index index):
+{
+    List<String> columns;
+    List<Index.Option> parameters;
+    String tableSpace;
+}
+{
+    [ <K_INCLUDE> columns=ColumnsNamesList() { index.setIncludeColumns(columns); } ]
+    [ LOOKAHEAD(2) <K_WITH> parameters=PostgreSqlIndexOptions() { index.setStorageParameters(parameters); } ]
+    [ LOOKAHEAD(3) <K_USING> <K_INDEX> <K_TABLESPACE> tableSpace=RelObjectName() {
+        index.setTableSpace(tableSpace);
+    } ]
+}
+
+void PostgreSqlConstraintAttributes(Index index):
+{
+    ConstraintAttributes attributes = new ConstraintAttributes();
+    boolean present = false;
+    boolean deferrable = true;
+    Token token;
+}
+{
+    [ LOOKAHEAD(2) [ <K_NOT> { deferrable = false; } ] <K_DEFERRABLE> {
+        attributes.setDeferrable(deferrable); present = true;
+    } ]
+    [ LOOKAHEAD({ isKeywordAhead("INITIALLY") }) token=<S_IDENTIFIER> token=<S_IDENTIFIER> {
+        requireDdlSyntax("IMMEDIATE".equalsIgnoreCase(token.image) || "DEFERRED".equalsIgnoreCase(token.image),
+                "Expected IMMEDIATE or DEFERRED");
+        attributes.setInitially(ConstraintAttributes.Initially.valueOf(token.image.toUpperCase(Locale.ROOT)));
+        present = true;
+    } ]
+    [ LOOKAHEAD({ getToken(1).kind == K_NOT && "VALID".equalsIgnoreCase(getToken(2).image) })
+        <K_NOT> token=<S_IDENTIFIER> { attributes.setNotValid(true); present = true; } ]
+    { if (present) { index.setConstraintAttributes(attributes); } }
 }
 
 /**
@@ -12144,14 +12255,10 @@ void TableIndexOptions(boolean createContext, List<String> options):
  */
 Index CreateTableConstraint():
 {
-    Token tk = null;
-    Token tk2 = null;
     String constraintName = null;
     Index index = null;
     ForeignKeyIndex fkIndex = null;
     CheckConstraint checkConstraint = null;
-    ExcludeConstraint excludeConstraint = null;
-    Expression expression = null;
 }
 {
     (
@@ -12159,7 +12266,7 @@ Index CreateTableConstraint():
         |
         <K_CONSTRAINT>
         [ LOOKAHEAD({ !isTableIndexAhead() && getToken(1).kind != K_FOREIGN
-                && getToken(1).kind != K_CHECK }) constraintName=RelObjectName() ]
+                && getToken(1).kind != K_CHECK && getToken(1).kind != K_EXCLUDE }) constraintName=RelObjectName() ]
         (
             LOOKAHEAD({ isTableIndexAhead() }) index=TableIndexSpec(true) {
                 if (index instanceof NamedConstraint) {
@@ -12177,20 +12284,53 @@ Index CreateTableConstraint():
                 checkConstraint.setUseConstraintKeyword(true);
                 index = checkConstraint;
             }
+            |
+            index=PostgreSqlExcludeConstraint() { index.setName(constraintName); }
         )
         |
         fkIndex=ForeignKeySpec(null) { index = fkIndex; }
         |
         checkConstraint=CheckConstraintSpec(null) { index = checkConstraint; }
         |
-        tk=<K_EXCLUDE> { excludeConstraint = new ExcludeConstraint(); }
-        (tk2=<K_WHERE> ("(" expression=Expression() ")")*) {
-            excludeConstraint.setExpression(expression);
-            excludeConstraint.setKind(Index.Kind.EXCLUDE);
-            index = excludeConstraint;
-        }
+        index=PostgreSqlExcludeConstraint()
     )
+    PostgreSqlConstraintAttributes(index)
     { return index; }
+}
+
+ExcludeConstraint PostgreSqlExcludeConstraint():
+{
+    ExcludeConstraint constraint = new ExcludeConstraint();
+    String using;
+    List<Index.ColumnParams> columns = new ArrayList<Index.ColumnParams>();
+    Index.ColumnParams column;
+    Expression predicate;
+}
+{
+    <K_EXCLUDE>
+    [ LOOKAHEAD(2) <K_USING> using=RelObjectName() { constraint.setUsing(using); } ]
+    [ "(" column=PostgreSqlExcludeElement() { columns.add(column); }
+        ( "," column=PostgreSqlExcludeElement() { columns.add(column); } )* ")"
+        { constraint.setColumns(columns); } ]
+    PostgreSqlConstraintOptions(constraint)
+    [ <K_WHERE> "(" predicate=Expression() ")" { constraint.setExpression(predicate); } ]
+    {
+        requireDdlSyntax(constraint.getColumns() != null || constraint.getExpression() != null,
+                "Expected exclusion elements or predicate");
+        return constraint;
+    }
+}
+
+Index.ColumnParams PostgreSqlExcludeElement():
+{
+    Index.ColumnParams column;
+    Token operator;
+}
+{
+    column=IndexColumnWithParams() <K_WITH>
+    ( operator="=" | operator=<OP_NOTEQUALSSTANDARD> | operator=<OP_NOTEQUALSBANG> | operator="<" | operator=">"
+        | operator=<OP_MINORTHANEQUALS> | operator=<OP_GREATERTHANEQUALS> | operator="&&" | operator="@>" | operator="<@" )
+    { column.setExclusionOperator(operator.image); return column; }
 }
 
 
@@ -12218,6 +12358,8 @@ CreateTable CreateTable(boolean isUsingOrReplace):
     TablePartitioning partitioning = null;
     Table partitionOfTable = null;
     PartitionBound partitionBound = null;
+    ColDataType ofType = null;
+    LikeClause likeClause = null;
 }
 {
     { createTable.setOrReplace(isUsingOrReplace);}
@@ -12231,6 +12373,7 @@ CreateTable CreateTable(boolean isUsingOrReplace):
     <K_TABLE>
     [ LOOKAHEAD(2) <K_IF> <K_NOT> <K_EXISTS> { createTable.setIfNotExists(true); }]
     table=Table()
+    [ <K_OF> ofType=ColDataType() { createTable.setOfType(ofType); } ]
     [ LOOKAHEAD(2) <K_PARTITION> <K_OF> partitionOfTable=Table()
         { createTable.setPartitionOf(partitionOfTable); } ]
     [ LOOKAHEAD(2) (
@@ -12241,23 +12384,27 @@ CreateTable CreateTable(boolean isUsingOrReplace):
             (
                 "("
                 (
+                    LOOKAHEAD(<K_LIKE>) likeClause=LikeClause() { tableElements.add(likeClause); }
+                    |
                     LOOKAHEAD(3) index = CreateTableConstraint()
                         { indexes.add(index); tableElements.add(index); }
                     |
-                    coldef = ColumnDefinition()
+                    coldef = CreateTableColumnDefinition(ofType != null)
                         { columnDefinitions.add(coldef); tableElements.add(coldef); }
                 )
 
                 (
                     ","
                     (
+                        LOOKAHEAD(<K_LIKE>) likeClause=LikeClause() { tableElements.add(likeClause); }
+                        |
                         LOOKAHEAD(3) (
                             index = CreateTableConstraint()
                             { indexes.add(index); tableElements.add(index); }
                         )
                         |
                         (
-                            coldef = ColumnDefinition()
+                            coldef = CreateTableColumnDefinition(ofType != null)
                             { columnDefinitions.add(coldef); tableElements.add(coldef); }
                         )
                     )
@@ -12308,6 +12455,29 @@ CreateTable CreateTable(boolean isUsingOrReplace):
             createTable.setColumns(columns);
         return createTable;
     }
+}
+
+ColumnDefinition CreateTableColumnDefinition(boolean typed):
+{
+    ColumnDefinition column = null;
+    String name;
+    List<ColumnOption> options = new ArrayList<ColumnOption>();
+    ColumnOption option;
+    Token token;
+}
+{
+        { if (!typed) { return ColumnDefinition(); } }
+        name=RelObjectName()
+        { column = new ColumnDefinition().withColumnName(name); }
+        [ LOOKAHEAD(2) <K_WITH> token=<S_IDENTIFIER> {
+            if (!"OPTIONS".equalsIgnoreCase(token.image)) {
+                throw new ParseException("Expected OPTIONS after WITH");
+            }
+            column.setWithOptions(true);
+        } ]
+        ( LOOKAHEAD(2) option=ColumnDefinitionOption() { options.add(option); } )*
+        { column.setColumnOptions(options); }
+    { if (true) { return column; } }
 }
 
 TableOption MySqlTableOption(): {
@@ -12708,6 +12878,11 @@ CreateView CreateView(boolean isUsingOrReplace):
     ExpressionList<Column> columnNames = null;
     Token tk = null;
     List<String> commentTokens = null;
+    String name = null;
+    List<Index.Option> storageParameters = null;
+    List<ViewOption> viewOptions = new ArrayList<ViewOption>();
+    ViewOption viewOption = null;
+    boolean withData = true;
 }
 {
     { createView.setOrReplace(isUsingOrReplace);}
@@ -12721,16 +12896,61 @@ CreateView CreateView(boolean isUsingOrReplace):
         | <K_TEMPORARY> { createView.setTemporary(TemporaryOption.TEMPORARY); }
         | <K_VOLATILE> { createView.setTemporary(TemporaryOption.VOLATILE); }
     ]
+    [ <K_RECURSIVE> { createView.setRecursive(true); } ]
     [ <K_MATERIALIZED> { createView.setMaterialized(true);} ]
-    <K_VIEW> view=Table() { createView.setView(view); }
+    <K_VIEW>
+    [ LOOKAHEAD(3) <K_IF> <K_NOT> <K_EXISTS> { createView.setIfNotExists(true); } ]
+    view=Table() { createView.setView(view); }
     [LOOKAHEAD(3) <K_AUTO> <K_REFRESH> (tk=<K_YES> | tk=<K_NO>) { createView.setAutoRefresh(AutoRefreshOption.from(tk.image)); } ]
-    [LOOKAHEAD(3) <K_IF> <K_NOT> <K_EXISTS> {createView.setIfNotExists(true);}]
+    [LOOKAHEAD(3) <K_IF> <K_NOT> <K_EXISTS> {
+        createView.setIfNotExists(true);
+        createView.setIfNotExistsAfterViewName(true);
+    }]
     [ columnNames=ColumnWithCommentList( ) { createView.setColumnNames(columnNames); } ]
     [ commentTokens=CreateViewTailComment( ) { createView.setViewCommentOptions(commentTokens); } ]
+    [ <K_USING> name=RelObjectName() { createView.setAccessMethod(name); } ]
+    [ <K_WITH>
+        (
+            LOOKAHEAD({ createView.isMaterialized() })
+            storageParameters=PostgreSqlIndexOptions() { createView.setStorageParameters(storageParameters); }
+            |
+            "(" viewOption=PostgreSqlViewOption() { viewOptions.add(viewOption); }
+            ( "," viewOption=PostgreSqlViewOption() { viewOptions.add(viewOption); } )* ")"
+            { createView.setOptions(viewOptions); }
+        )
+    ]
+    [ <K_TABLESPACE> name=RelObjectName() { createView.setTableSpace(name); } ]
     <K_AS>
     select=Select( ) { createView.setSelect(select); }
-    [ LOOKAHEAD(2)  <K_WITH> <K_READ> <K_ONLY> { createView.setWithReadOnly(true); } ]
-    { return createView; }
+    [ LOOKAHEAD(2) <K_WITH>
+        (
+            <K_READ> <K_ONLY> { createView.setWithReadOnly(true); }
+            |
+            [ <K_LOCAL> { createView.setCheckOption(CreateView.CheckOption.LOCAL); }
+                | LOOKAHEAD({ isKeywordAhead("CASCADED") }) tk=<S_IDENTIFIER>
+                    { createView.setCheckOption(CreateView.CheckOption.CASCADED); } ]
+            <K_CHECK> <K_OPTION> {
+                if (createView.getCheckOption() == null) {
+                    createView.setCheckOption(CreateView.CheckOption.DEFAULT);
+                }
+            }
+            |
+            [ <K_NO> { withData = false; } ] <K_DATA> { createView.setWithData(withData); }
+        )
+    ]
+    { createView.validateOptions(); return createView; }
+}
+
+ViewOption PostgreSqlViewOption():
+{
+    String name;
+    Expression value = null;
+    boolean useEquals = false;
+}
+{
+    name=RelObjectName()
+    [ "=" { useEquals = true; } value=PrimaryExpression() ]
+    { return new ViewOption(name, value, useEquals); }
 }
 
 List<String> CreateViewTailComment():
@@ -12840,7 +13060,7 @@ CheckConstraint CheckConstraintSpec(String constraintName):
 }
 {
     <K_CHECK> ( LOOKAHEAD(2) "(" exp = Expression() ")" )*
-    [
+    [ LOOKAHEAD(2)
         [ <K_NOT> { enforced = false; } ]
         <K_ENFORCED> { if (enforced == null) { enforced = true; } }
     ]
@@ -13282,22 +13502,79 @@ AlterExpression.ColumnDataType AlterExpressionColumnDataType():
     List<ColumnOption> columnOptions = new ArrayList<ColumnOption>();
     ColumnOption option = null;
     AlterExpression.ColumnDataType result;
+    Expression usingExpression = null;
+    List<IdentityAlteration> identityAlterations = null;
+    IdentityAlteration identityAlteration;
 }
 {
     columnName = RelObjectName()
+    (
+    LOOKAHEAD({ isIdentityAlterationAhead() })
+    { identityAlterations = new ArrayList<IdentityAlteration>(); }
+    identityAlteration=ColumnIdentityAlteration() { identityAlterations.add(identityAlteration); }
+    ( LOOKAHEAD({ isIdentityAlterationAhead() })
+        identityAlteration=ColumnIdentityAlteration() { identityAlterations.add(identityAlteration); } )*
+    |
     ( LOOKAHEAD(2) <K_TYPE> { withType = true; } )?
     ( LOOKAHEAD(2) dataType = ColDataType() )?
-    ( LOOKAHEAD(2) option = ColumnDefinitionOption() {
+    ( LOOKAHEAD(2, { !(withType && getToken(1).kind == K_USING) }) option = ColumnDefinitionOption() {
         columnOptions.add(option);
         columnSpecs.addAll(option.getTokens());
     } )*
+    [ LOOKAHEAD({ withType && getToken(1).kind == K_USING }) <K_USING> usingExpression=Expression() ]
+    )
     {
         result = new AlterExpression.ColumnDataType(columnName, withType, dataType, columnSpecs);
+        result.setUsingExpression(usingExpression);
+        result.setIdentityAlterations(identityAlterations);
         if (hasStructuredColumnOption(columnOptions)) {
             result.setColumnOptions(columnOptions);
         }
         return result;
     }
+}
+
+IdentityAlteration ColumnIdentityAlteration():
+{
+    IdentityAlteration alteration;
+    IdentityDefinition identity;
+    IdentityDefinition.GenerationMode mode;
+    Sequence.Parameter parameter;
+    Long restart = null;
+    Token token;
+}
+{
+    (
+        <K_ADD> identity=IdentityDefinition() {
+            alteration = new IdentityAlteration(IdentityAlteration.Kind.ADD);
+            alteration.setIdentityDefinition(identity);
+        }
+        |
+        <K_SET>
+        (
+            LOOKAHEAD({ isKeywordAhead("GENERATED") }) token=<S_IDENTIFIER>
+            ( <K_ALWAYS> { mode = IdentityDefinition.GenerationMode.ALWAYS; }
+                | <K_BY> <K_DEFAULT> { mode = IdentityDefinition.GenerationMode.BY_DEFAULT; } )
+            {
+                alteration = new IdentityAlteration(IdentityAlteration.Kind.SET_GENERATED);
+                alteration.setGenerationMode(mode);
+            }
+            |
+            parameter=SequenceParameter() {
+                alteration = new IdentityAlteration(IdentityAlteration.Kind.SET_PARAMETER);
+                alteration.setParameters(Collections.singletonList(parameter));
+            }
+        )
+        |
+        <K_RESTART> [ LOOKAHEAD(2) <K_WITH> restart=SequenceParameterValue() ] {
+            alteration = new IdentityAlteration(IdentityAlteration.Kind.RESTART);
+            alteration.setRestartWith(restart);
+        }
+        |
+        <K_DROP> <K_IDENTITY> { alteration = new IdentityAlteration(IdentityAlteration.Kind.DROP); }
+        [ LOOKAHEAD(2) <K_IF> <K_EXISTS> { alteration.setIfExists(true); } ]
+    )
+    { return alteration; }
 }
 
 AlterExpression.ColumnDropNotNull AlterExpressionColumnDropNotNull():
@@ -14953,111 +15230,70 @@ Sequence Sequence() #Sequence :
 
 List<Sequence.Parameter> SequenceParameters():
 {
-  List<Sequence.Parameter> sequenceParameters = new ArrayList<Sequence.Parameter>();
-  Sequence.Parameter parameter = null;
-  Token token = null;
-  Token byToken = null;
-  Token withToken = null;
+    List<Sequence.Parameter> parameters = new ArrayList<Sequence.Parameter>();
+    Sequence.Parameter parameter;
+}
+{
+    ( LOOKAHEAD(2) parameter=SequenceParameter() { parameters.add(parameter); } )*
+    { return parameters; }
+}
+
+Sequence.Parameter SequenceParameter():
+{
+    Sequence.ParameterType type;
+    Long value = null;
+    Token token;
+    boolean withKeyword = false;
 }
 {
     (
-        LOOKAHEAD(2) (
-            (
-                <K_INCREMENT> [ byToken=<K_BY> ] token=<S_LONG>
-                {
-                    if (byToken != null) {
-                      parameter = new Sequence.Parameter(Sequence.ParameterType.INCREMENT_BY);
-                    } else {
-                      parameter = new Sequence.Parameter(Sequence.ParameterType.INCREMENT);
-                    }
-                    parameter.setValue(Long.parseLong(token.image));
-                    sequenceParameters.add(parameter);
-                }
-           )
-           |
-           (
-                <K_START> [ withToken=<K_WITH> ] token=<S_LONG>
-                {
-                    if (withToken != null) {
-                        parameter = new Sequence.Parameter(Sequence.ParameterType.START_WITH);
-                    } else {
-                        parameter = new Sequence.Parameter(Sequence.ParameterType.START);
-                    }
-                    parameter.setValue(Long.parseLong(token.image));
-                    sequenceParameters.add(parameter);
-                }
-            )
-            |
-            (
-                <K_RESTART> [ LOOKAHEAD(2) <K_WITH> token=<S_LONG>]
-                {
-                    parameter = new Sequence.Parameter(Sequence.ParameterType.RESTART_WITH);
-                    if(token != null) {
-                        parameter.setValue(Long.parseLong(token.image));
-                    }
-                    sequenceParameters.add(parameter);
-                }
-            )
-            |
-            <K_NOMAXVALUE>
-            {
-              parameter = new Sequence.Parameter(Sequence.ParameterType.NOMAXVALUE);
-              sequenceParameters.add(parameter);
-            }
-            |
-            <K_MAXVALUE> token=<S_LONG>
-            {
-              parameter = new Sequence.Parameter(Sequence.ParameterType.MAXVALUE);
-              parameter.setValue(Long.parseLong(token.image));
-              sequenceParameters.add(parameter);
-            }
-            |
-            <K_NOMINVALUE>
-            {
-              parameter = new Sequence.Parameter(Sequence.ParameterType.NOMINVALUE);
-              sequenceParameters.add(parameter);
-            }
-            |
-            <K_MINVALUE> token=<S_LONG>
-            {
-              parameter = new Sequence.Parameter(Sequence.ParameterType.MINVALUE);
-              parameter.setValue(Long.parseLong(token.image));
-              sequenceParameters.add(parameter);
-            }
-            |
-            <K_NOCYCLE> { sequenceParameters.add(new Sequence.Parameter(Sequence.ParameterType.NOCYCLE)); }
-            |
-            <K_CYCLE> { sequenceParameters.add(new Sequence.Parameter(Sequence.ParameterType.CYCLE)); }
-            |
-            <K_NOCACHE>
-            {
-              parameter = new Sequence.Parameter(Sequence.ParameterType.NOCACHE);
-              sequenceParameters.add(parameter);
-            }
-            |
-            <K_CACHE> token=<S_LONG>
-            {
-              parameter = new Sequence.Parameter(Sequence.ParameterType.CACHE);
-              parameter.setValue(Long.parseLong(token.image));
-              sequenceParameters.add(parameter);
-            }
-            |
-            <K_ORDER> { sequenceParameters.add(new Sequence.Parameter(Sequence.ParameterType.ORDER)); }
-            |
-            <K_NOORDER> { sequenceParameters.add(new Sequence.Parameter(Sequence.ParameterType.NOORDER)); }
-            |
-            <K_KEEP> { sequenceParameters.add(new Sequence.Parameter(Sequence.ParameterType.KEEP)); }
-            |
-            <K_NOKEEP> { sequenceParameters.add(new Sequence.Parameter(Sequence.ParameterType.NOKEEP)); }
-            |
-            <K_SESSION> { sequenceParameters.add(new Sequence.Parameter(Sequence.ParameterType.SESSION)); }
-            |
-            <K_GLOBAL> { sequenceParameters.add(new Sequence.Parameter(Sequence.ParameterType.GLOBAL)); }
-        )
-    )*
-    {
-        return sequenceParameters;
+        <K_INCREMENT> [ <K_BY> { withKeyword = true; } ] value=SequenceParameterValue()
+        { type = withKeyword ? Sequence.ParameterType.INCREMENT_BY : Sequence.ParameterType.INCREMENT; }
+        |
+        <K_START> [ <K_WITH> { withKeyword = true; } ] value=SequenceParameterValue()
+        { type = withKeyword ? Sequence.ParameterType.START_WITH : Sequence.ParameterType.START; }
+        |
+        <K_RESTART> [ LOOKAHEAD(2) <K_WITH> value=SequenceParameterValue() ]
+        { type = Sequence.ParameterType.RESTART_WITH; }
+        |
+        ( token=<K_MINVALUE> | token=<K_MAXVALUE> | token=<K_CACHE> ) value=SequenceParameterValue()
+        { type = Sequence.ParameterType.valueOf(token.image.toUpperCase(Locale.ROOT)); }
+        |
+        <K_NO> ( token=<K_MINVALUE> | token=<K_MAXVALUE> | token=<K_CYCLE> )
+        { type = Sequence.ParameterType.valueOf("NO_" + token.image.toUpperCase(Locale.ROOT)); }
+        |
+        ( token=<K_NOMINVALUE> | token=<K_NOMAXVALUE> | token=<K_CYCLE> | token=<K_NOCYCLE>
+            | token=<K_NOCACHE> | token=<K_ORDER> | token=<K_NOORDER> | token=<K_KEEP>
+            | token=<K_NOKEEP> | token=<K_SESSION> | token=<K_GLOBAL> )
+        { type = Sequence.ParameterType.valueOf(token.image.toUpperCase(Locale.ROOT)); }
+    )
+    { return new Sequence.Parameter(type).withValue(value); }
+}
+
+Long SequenceParameterValue():
+{
+    Token sign = null;
+    Token value;
+}
+{
+    [ sign="-" | sign="+" ] value=<S_LONG>
+    { return Long.valueOf((sign == null ? "" : sign.image) + value.image); }
+}
+
+SequenceOwnership SequenceOwnership():
+{
+    Token token;
+    Column column;
+    SequenceOwnership ownership;
+}
+{
+    token=<S_IDENTIFIER> {
+        requireDdlSyntax("OWNED".equalsIgnoreCase(token.image), "Expected OWNED");
     }
+    <K_BY>
+    ( LOOKAHEAD(1) <K_NONE> { ownership = SequenceOwnership.none(); }
+        | column=Column() { ownership = SequenceOwnership.ownedBy(column); } )
+    { return ownership; }
 }
 
 CreateSequence CreateSequence():
@@ -15066,11 +15302,13 @@ CreateSequence CreateSequence():
   Sequence sequence;
   List<Sequence.Parameter> sequenceParameters;
   Token dataType = null;
+  SequenceOwnership ownership;
 }
 {
   <K_SEQUENCE> sequence=Sequence() { createSequence.setSequence(sequence); }
   [ <K_AS> ( dataType=<S_IDENTIFIER> | dataType=<DATA_TYPE> ) { sequence.setDataType(dataType.image); } ]
   sequenceParameters = SequenceParameters()
+  [ LOOKAHEAD({ isKeywordAhead("OWNED") }) ownership=SequenceOwnership() { sequence.setOwnership(ownership); } ]
     {
         sequence.setParameters(sequenceParameters);
         return createSequence;
@@ -15082,10 +15320,12 @@ AlterSequence AlterSequence():
   AlterSequence alterSequence = new AlterSequence();
   Sequence sequence;
   List<Sequence.Parameter> sequenceParameters;
+  SequenceOwnership ownership;
 }
 {
     <K_SEQUENCE> sequence=Sequence() { alterSequence.setSequence(sequence); }
     sequenceParameters = SequenceParameters()
+    [ LOOKAHEAD({ isKeywordAhead("OWNED") }) ownership=SequenceOwnership() { sequence.setOwnership(ownership); } ]
     {
         sequence.setParameters(sequenceParameters);
         return alterSequence;

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -231,6 +231,48 @@ The fastest way to learn the object model is to look at it. Paste your SQL into 
 Read that as a map: each line is a getter away. ``select.getSelectItems()``, ``select.getFromItem()``, ``select.getWhere()``. Once the tree gets deeper than a couple of levels, stop casting by hand and use :ref:`Use the Visitor Patterns`.
 
 
+Inspect PostgreSQL schema statements
+------------------------------------
+
+PostgreSQL schema clauses extend the existing ``CreateView``, ``CreateTable``, ``Alter`` and ``Sequence`` models. Use their typed properties to inspect the clauses and preserve distinctions between omitted options and explicit values.
+
+.. code-block:: java
+
+    CreateView view = (CreateView) CCJSqlParserUtil.parse(
+            "CREATE MATERIALIZED VIEW IF NOT EXISTS account_totals "
+            + "AS SELECT id FROM accounts WITH NO DATA");
+    view.isMaterialized();       // true
+    view.isIfNotExists();        // true
+    view.getWithData();          // Boolean.FALSE; null means the clause was omitted
+
+Ordinary views expose ordered ``ViewOption`` values for ``security_barrier``, ``security_invoker`` and ``check_option``. ``getCheckOption()`` describes the trailing ``WITH CHECK OPTION`` clause: ``null`` means absent, ``DEFAULT`` preserves the bare clause, and ``LOCAL`` and ``CASCADED`` preserve explicit keywords. ``getEffectiveCheckOption()`` resolves the bare clause to ``CASCADED``. Materialized views expose their access method, storage parameters and tablespace separately. See the PostgreSQL documentation for `CREATE VIEW <https://www.postgresql.org/docs/18/sql-createview.html>`_ and `CREATE MATERIALIZED VIEW <https://www.postgresql.org/docs/18/sql-creatematerializedview.html>`_.
+
+.. code-block:: java
+
+    CreateTable table = (CreateTable) CCJSqlParserUtil.parse(
+            "CREATE TABLE accounts_copy (LIKE accounts INCLUDING ALL EXCLUDING INDEXES)");
+    LikeClause like = table.getTableElements(LikeClause.class).get(0);
+    like.getOptions();                                  // ordered INCLUDING/EXCLUDING clauses
+    like.isIncluding(LikeClause.OptionKind.DEFAULTS);   // true, inherited from ALL
+    like.isIncluding(LikeClause.OptionKind.INDEXES);    // false, overridden by EXCLUDING
+
+``getTableElements()`` preserves the order of columns, constraints and ``LIKE`` clauses, including multiple source tables. The three legacy nullable ``LikeClause`` getters report explicit options of that kind; ``isIncluding(OptionKind)`` also resolves ``ALL`` in declaration order. A typed table's ``OF`` type is available through ``CreateTable.getOfType()``.
+
+Table constraints expose ``Index.getNullsDistinct()``, ``getIncludeColumns()``, storage parameters and ``ConstraintAttributes``. ``ExcludeConstraint`` reuses ``Index.ColumnParams`` for its keys; each key exposes its expression and exclusion operator. Column identity clauses are represented by ``ColumnOption.Kind.IDENTITY`` and ``IdentityDefinition``, with a generation mode and ordered ``Sequence.Parameter`` values. These APIs cover the schema clauses described in `CREATE TABLE <https://www.postgresql.org/docs/18/sql-createtable.html>`_.
+
+.. code-block:: java
+
+    Alter alter = (Alter) CCJSqlParserUtil.parse(
+            "ALTER TABLE accounts ALTER COLUMN id TYPE bigint USING id + 1");
+    AlterExpression.ColumnDataType column = alter.getAlterExpressions().get(0)
+            .getColDataTypeList().get(0);
+    Expression conversion = column.getUsingExpression();
+    column.setUsingExpression(CCJSqlParserUtil.parseExpression("id * 10"));
+    String updatedSql = alter.toString();
+
+Identity alterations are available as ``ColumnDataType.getIdentityAlterations()``. Sequence ownership is shared by ``CreateSequence`` and ``AlterSequence`` through ``Sequence.getOwnership()``: ``null`` means omitted, ``isNone()`` means explicit ``OWNED BY NONE``, and ``getColumn()`` identifies an owner. ``TablesNamesFinder`` includes ``LIKE`` sources and sequence owners without treating sequence or type names as tables. See `ALTER TABLE <https://www.postgresql.org/docs/18/sql-altertable.html>`_ and `ALTER SEQUENCE <https://www.postgresql.org/docs/18/sql-altersequence.html>`_.
+
+
 Classify a Statement
 ==============================
 

--- a/src/test/java/net/sf/jsqlparser/statement/create/PostgreSqlCreateViewTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/PostgreSqlCreateViewTest.java
@@ -1,0 +1,112 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.BooleanValue;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.create.view.CreateView;
+import net.sf.jsqlparser.statement.create.view.ViewOption;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @see <a href="https://www.postgresql.org/docs/18/sql-createview.html">PostgreSQL CREATE VIEW</a>
+ */
+class PostgreSqlCreateViewTest {
+    @Test
+    void testSecurityOptions() throws JSQLParserException {
+        CreateView view = (CreateView) assertSqlCanBeParsedAndDeparsed(
+                "CREATE VIEW visible_accounts WITH (security_barrier = true, security_invoker = false)"
+                        + " AS SELECT * FROM accounts WHERE enabled WITH LOCAL CHECK OPTION");
+        assertThat(view.getOptions()).hasSize(2);
+        assertThat(view.getOptions().get(0).getKind()).isEqualTo(ViewOption.Kind.SECURITY_BARRIER);
+        assertThat(view.getOptions().get(0).getBooleanValue()).isTrue();
+        assertThat(view.getOptions().get(1).getBooleanValue()).isFalse();
+        assertThat(view.getCheckOption()).isEqualTo(CreateView.CheckOption.LOCAL);
+        assertThat(TablesNamesFinder.findTables(view.toString()))
+                .containsExactlyInAnyOrder("visible_accounts", "accounts");
+    }
+
+    @Test
+    void testImplicitOptionValueAndCheckOptionParameter() throws JSQLParserException {
+        CreateView view = (CreateView) assertSqlCanBeParsedAndDeparsed(
+                "CREATE VIEW visible_accounts WITH (security_barrier, check_option = 'local')"
+                        + " AS SELECT * FROM accounts");
+        assertThat(view.getOptions().get(0).getValue()).isNull();
+        assertThat(view.getOptions().get(0).getBooleanValue()).isTrue();
+        assertThat(view.getOptions().get(1).getCheckOption())
+                .isEqualTo(CreateView.CheckOption.LOCAL);
+        assertThat(view.getCheckOption()).isNull();
+    }
+
+    @Test
+    void testDefaultCheckOption() throws JSQLParserException {
+        CreateView view = (CreateView) assertSqlCanBeParsedAndDeparsed(
+                "CREATE VIEW visible_accounts AS SELECT * FROM accounts WITH CHECK OPTION");
+        assertThat(view.getCheckOption()).isEqualTo(CreateView.CheckOption.DEFAULT);
+        assertThat(view.getEffectiveCheckOption()).isEqualTo(CreateView.CheckOption.CASCADED);
+    }
+
+    @Test
+    void testRecursiveView() throws JSQLParserException {
+        CreateView view = (CreateView) assertSqlCanBeParsedAndDeparsed(
+                "CREATE RECURSIVE VIEW numbers(n) AS VALUES (1)"
+                        + " UNION ALL SELECT n + 1 FROM numbers WHERE n < 5");
+        assertThat(view.isRecursive()).isTrue();
+        assertThat(view.getColumnNames()).hasSize(1);
+    }
+
+    @Test
+    void testMaterializedViewParameters() throws JSQLParserException {
+        CreateView view = (CreateView) assertSqlCanBeParsedAndDeparsed(
+                "CREATE MATERIALIZED VIEW IF NOT EXISTS account_totals(id) USING heap"
+                        + " WITH (fillfactor = 70) TABLESPACE archive"
+                        + " AS SELECT id FROM accounts WITH NO DATA");
+        assertThat(view.isMaterialized()).isTrue();
+        assertThat(view.isIfNotExists()).isTrue();
+        assertThat(view.isIfNotExistsAfterViewName()).isFalse();
+        assertThat(view.getAccessMethod()).isEqualTo("heap");
+        assertThat(view.getStorageParameters().get(0).getName()).isEqualTo("fillfactor");
+        assertThat(view.getTableSpace()).isEqualTo("archive");
+        assertThat(view.getWithData()).isFalse();
+        assertThat(view.getOptions()).isNull();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", " WITH DATA", " WITH NO DATA"})
+    void testMaterializedViewDataMode(String suffix) throws JSQLParserException {
+        CreateView view = (CreateView) assertSqlCanBeParsedAndDeparsed(
+                "CREATE MATERIALIZED VIEW account_totals AS SELECT * FROM accounts" + suffix);
+        assertThat(view.getWithData()).isEqualTo(suffix.isEmpty() ? null : !suffix.contains("NO"));
+        CreateView reparsed = (CreateView) CCJSqlParserUtil.parse(view.toString());
+        assertThat(reparsed.getWithData()).isEqualTo(view.getWithData());
+    }
+
+    @Test
+    void testProgrammaticConstruction() throws JSQLParserException {
+        CreateView view = new CreateView().withView(new Table("visible_accounts"))
+                .withSelect((Select) CCJSqlParserUtil.parse("SELECT * FROM accounts"));
+        view.setOptions(Collections.singletonList(
+                new ViewOption("security_barrier", new BooleanValue(true), true)));
+        view.setCheckOption(CreateView.CheckOption.CASCADED);
+        CreateView parsed = (CreateView) assertSqlCanBeParsedAndDeparsed(view.toString());
+        assertThat(parsed.getOptions().get(0).getBooleanValue()).isTrue();
+        assertThat(parsed.getCheckOption()).isEqualTo(CreateView.CheckOption.CASCADED);
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/statement/create/PostgreSqlSchemaDdlTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/PostgreSqlSchemaDdlTest.java
@@ -1,0 +1,236 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.schema.Sequence;
+import net.sf.jsqlparser.schema.SequenceOwnership;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.LikeClause;
+import net.sf.jsqlparser.statement.alter.Alter;
+import net.sf.jsqlparser.statement.alter.AlterExpression;
+import net.sf.jsqlparser.statement.alter.IdentityAlteration;
+import net.sf.jsqlparser.statement.alter.sequence.AlterSequence;
+import net.sf.jsqlparser.statement.create.sequence.CreateSequence;
+import net.sf.jsqlparser.statement.create.table.ColumnOption;
+import net.sf.jsqlparser.statement.create.table.ConstraintAttributes;
+import net.sf.jsqlparser.statement.create.table.CreateTable;
+import net.sf.jsqlparser.statement.create.table.ExcludeConstraint;
+import net.sf.jsqlparser.statement.create.table.IdentityDefinition;
+import net.sf.jsqlparser.statement.create.table.Index;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @see <a href="https://www.postgresql.org/docs/18/sql-createtable.html">PostgreSQL CREATE
+ *      TABLE</a>
+ */
+class PostgreSqlSchemaDdlTest {
+    @Test
+    void testExclusionConstraint() throws JSQLParserException {
+        CreateTable table = (CreateTable) assertSqlCanBeParsedAndDeparsed(
+                "CREATE TABLE reservations (room integer, during tsrange,"
+                        + " CONSTRAINT no_overlap EXCLUDE USING gist (room WITH =, during WITH &&)"
+                        + " WHERE (room > 0) DEFERRABLE INITIALLY DEFERRED)");
+        ExcludeConstraint constraint = (ExcludeConstraint) table.getIndexes().get(0);
+        assertThat(constraint.getName()).isEqualTo("no_overlap");
+        assertThat(constraint.getUsing()).isEqualTo("gist");
+        assertThat(constraint.getColumns().get(0).getExclusionOperator()).isEqualTo("=");
+        assertThat(constraint.getColumns().get(1).getExclusionOperator()).isEqualTo("&&");
+        assertThat(constraint.getExpression()).isNotNull();
+        assertThat(constraint.getConstraintAttributes().getDeferrable()).isTrue();
+        assertThat(constraint.getConstraintAttributes().getInitially())
+                .isEqualTo(ConstraintAttributes.Initially.DEFERRED);
+    }
+
+    @Test
+    void testExclusionExpressionAndStorage() throws JSQLParserException {
+        CreateTable table = (CreateTable) assertSqlCanBeParsedAndDeparsed(
+                "CREATE TABLE reservations (room text, EXCLUDE USING gist ((lower(room)) WITH =)"
+                        + " INCLUDE (room) WITH (fillfactor = 70) USING INDEX TABLESPACE archive)");
+        Index constraint = table.getIndexes().get(0);
+        assertThat(constraint.getColumns().get(0).isExpression()).isTrue();
+        assertThat(constraint.getIncludeColumns()).containsExactly("room");
+        assertThat(constraint.getStorageParameters()).hasSize(1);
+        assertThat(constraint.getTableSpace()).isEqualTo("archive");
+    }
+
+    @Test
+    void testUniqueNullTreatment() throws JSQLParserException {
+        CreateTable table = (CreateTable) assertSqlCanBeParsedAndDeparsed(
+                "CREATE TABLE contacts (email text UNIQUE NULLS NOT DISTINCT,"
+                        + " CONSTRAINT contact_email UNIQUE NULLS DISTINCT (email))");
+        ColumnOption option = table.getColumnDefinitions().get(0).getColumnOptions().get(0);
+        assertThat(option.getKind()).isEqualTo(ColumnOption.Kind.CONSTRAINT);
+        assertThat(option.getConstraint().getNullsDistinct()).isFalse();
+        assertThat(table.getIndexes().get(0).getNullsDistinct()).isTrue();
+    }
+
+    @Test
+    void testPrimaryKeyInclude() throws JSQLParserException {
+        CreateTable table = (CreateTable) assertSqlCanBeParsedAndDeparsed(
+                "CREATE TABLE contacts (id integer, email text, PRIMARY KEY (id) INCLUDE (email))");
+        assertThat(table.getIndexes().get(0).getIncludeColumns()).containsExactly("email");
+        Alter alter = (Alter) assertSqlCanBeParsedAndDeparsed(
+                "ALTER TABLE contacts ADD PRIMARY KEY (id) INCLUDE (email)");
+        assertThat(alter.getAlterExpressions().get(0).getIndex().getIncludeColumns())
+                .containsExactly("email");
+    }
+
+    @Test
+    void testLikeOptionsInOrder() throws JSQLParserException {
+        CreateTable table = (CreateTable) assertSqlCanBeParsedAndDeparsed(
+                "CREATE TABLE contact_copy (LIKE contacts INCLUDING ALL EXCLUDING INDEXES,"
+                        + " extra integer, LIKE history EXCLUDING ALL INCLUDING DEFAULTS INCLUDING COMPRESSION)");
+        assertThat(table.getTableElements()).hasSize(3);
+        LikeClause clause = table.getTableElements(LikeClause.class).get(0);
+        assertThat(table.getLikeTable().getName()).isEqualTo("contacts");
+        assertThat(clause.getOptions()).hasSize(2);
+        assertThat(clause.isIncluding(LikeClause.OptionKind.DEFAULTS)).isTrue();
+        assertThat(clause.isIncluding(LikeClause.OptionKind.INDEXES)).isFalse();
+        assertThat(clause.isIncludingDefaults()).isNull();
+        clause.addOption(LikeClause.OptionKind.INDEXES, true);
+        assertThat(clause.isIncluding(LikeClause.OptionKind.INDEXES)).isTrue();
+        assertSqlCanBeParsedAndDeparsed(table.toString());
+    }
+
+    @Test
+    void testLegacyLikeSetters() {
+        LikeClause clause = new LikeClause();
+        clause.setIncludingDefaults(true);
+        clause.setExcludingIdentity(true);
+        assertThat(clause.isIncludingDefaults()).isTrue();
+        assertThat(clause.isIncludingIdentity()).isFalse();
+        clause.setExcludingDefaults(null);
+        assertThat(clause.isIncludingDefaults()).isNull();
+    }
+
+    @Test
+    void testLegacyLikeTableSetterUpdatesFirstSource() throws JSQLParserException {
+        CreateTable table = (CreateTable) CCJSqlParserUtil
+                .parse("CREATE TABLE copy (LIKE source INCLUDING ALL, id integer)");
+        table.setLikeTable(new Table("replacement"), false);
+        assertThat(table.getTableElements(LikeClause.class).get(0).getTable().getName())
+                .isEqualTo("replacement");
+        assertThat(table.getTrailingLikeTable()).isNull();
+        assertSqlCanBeParsedAndDeparsed(table.toString());
+        table.setLikeTable(null, false);
+        assertThat(table.getLikeTable()).isNull();
+        assertSqlCanBeParsedAndDeparsed(table.toString());
+    }
+
+    @Test
+    void testTypedTable() throws JSQLParserException {
+        CreateTable table = (CreateTable) assertSqlCanBeParsedAndDeparsed(
+                "CREATE TABLE employees OF employee_type (PRIMARY KEY (name), salary WITH OPTIONS DEFAULT 1000)");
+        assertThat(table.getOfType().getDataType()).isEqualTo("employee_type");
+        assertThat(table.getColumnDefinitions().get(0).isWithOptions()).isTrue();
+        assertThat(table.getColumnDefinitions().get(0).getColDataType()).isNull();
+        assertThat(table.getTableElements().get(0)).isInstanceOf(Index.class);
+    }
+
+    @Test
+    void testIdentityOptions() throws JSQLParserException {
+        CreateTable table = (CreateTable) assertSqlCanBeParsedAndDeparsed(
+                "CREATE TABLE counters (id bigint GENERATED BY DEFAULT AS IDENTITY"
+                        + " (START WITH 100 INCREMENT BY -2 NO MINVALUE NO MAXVALUE NO CYCLE CACHE 5), value integer)");
+        IdentityDefinition identity = table.getColumnDefinitions().get(0)
+                .getColumnOptions().get(0).getIdentityDefinition();
+        assertThat(identity.getGenerationMode())
+                .isEqualTo(IdentityDefinition.GenerationMode.BY_DEFAULT);
+        assertThat(identity.getParameters()).hasSize(6);
+        assertThat(identity.getParameters().get(1).getOption())
+                .isEqualTo(Sequence.ParameterType.INCREMENT_BY);
+        assertThat(identity.getParameters().get(1).getValue()).isEqualTo(-2L);
+    }
+
+    @Test
+    void testAlterColumnTypeUsing() throws JSQLParserException {
+        Alter alter = (Alter) assertSqlCanBeParsedAndDeparsed(
+                "ALTER TABLE contacts ALTER COLUMN id TYPE bigint USING (id::bigint)");
+        AlterExpression.ColumnDataType column =
+                alter.getAlterExpressions().get(0).getColDataTypeList().get(0);
+        assertThat(column.isWithType()).isTrue();
+        assertThat(column.getUsingExpression()).isNotNull();
+        column.setUsingExpression(CCJSqlParserUtil.parseExpression("id + 1"));
+        assertSqlCanBeParsedAndDeparsed(alter.toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ADD GENERATED ALWAYS AS IDENTITY",
+            "ADD GENERATED BY DEFAULT AS IDENTITY (START WITH 50)",
+            "SET GENERATED ALWAYS", "SET GENERATED BY DEFAULT", "SET INCREMENT BY -1",
+            "SET NO CYCLE", "RESTART", "RESTART WITH 200", "DROP IDENTITY IF EXISTS",
+            "SET GENERATED ALWAYS SET CACHE 10", "SET CACHE 10 RESTART WITH 50",
+            "SET NO CYCLE RESTART"})
+    void testIdentityAlterations(String action) throws JSQLParserException {
+        Alter alter = (Alter) assertSqlCanBeParsedAndDeparsed(
+                "ALTER TABLE counters ALTER COLUMN id " + action);
+        assertThat(alter.getAlterExpressions().get(0).getColDataTypeList().get(0)
+                .getIdentityAlterations())
+                .isNotEmpty();
+    }
+
+    @Test
+    void testIdentityAlterationKind() throws JSQLParserException {
+        Alter alter = (Alter) CCJSqlParserUtil.parse(
+                "ALTER TABLE counters ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY");
+        IdentityAlteration action = alter.getAlterExpressions().get(0).getColDataTypeList().get(0)
+                .getIdentityAlterations().get(0);
+        assertThat(action.getKind()).isEqualTo(IdentityAlteration.Kind.ADD);
+        assertThat(action.getIdentityDefinition().getGenerationMode())
+                .isEqualTo(IdentityDefinition.GenerationMode.ALWAYS);
+    }
+
+    @Test
+    void testSequenceOwnership() throws JSQLParserException {
+        CreateSequence create = (CreateSequence) assertSqlCanBeParsedAndDeparsed(
+                "CREATE SEQUENCE counter_seq AS bigint INCREMENT BY -1 NO MINVALUE NO MAXVALUE NO CYCLE OWNED BY counters.id");
+        assertThat(create.getSequence().getOwnership().getColumn().getColumnName()).isEqualTo("id");
+        AlterSequence alter = (AlterSequence) assertSqlCanBeParsedAndDeparsed(
+                "ALTER SEQUENCE counter_seq OWNED BY NONE");
+        assertThat(alter.getSequence().getOwnership().isNone()).isTrue();
+        alter.getSequence().setOwnership(SequenceOwnership.ownedBy(new Column("app.counters.id")));
+        assertSqlCanBeParsedAndDeparsed(alter.toString());
+    }
+
+    @Test
+    void testSequenceParametersDoNotReusePreviousValues() throws JSQLParserException {
+        AlterSequence alter = (AlterSequence) assertSqlCanBeParsedAndDeparsed(
+                "ALTER SEQUENCE counter_seq INCREMENT BY 2 INCREMENT 3 START WITH 7 START 8 RESTART");
+        assertThat(alter.getSequence().getParameters().get(1).getOption())
+                .isEqualTo(Sequence.ParameterType.INCREMENT);
+        assertThat(alter.getSequence().getParameters().get(3).getOption())
+                .isEqualTo(Sequence.ParameterType.START);
+        assertThat(alter.getSequence().getParameters().get(4).getValue()).isNull();
+    }
+
+    @Test
+    void testProgrammaticIdentity() throws JSQLParserException {
+        CreateTable table =
+                (CreateTable) CCJSqlParserUtil.parse("CREATE TABLE counters (id bigint)");
+        IdentityDefinition identity =
+                new IdentityDefinition(IdentityDefinition.GenerationMode.ALWAYS);
+        identity.setParameters(Arrays.asList(
+                new Sequence.Parameter(Sequence.ParameterType.START_WITH).withValue(50L),
+                new Sequence.Parameter(Sequence.ParameterType.NO_CYCLE)));
+        table.getColumnDefinitions().get(0)
+                .setColumnOptions(Collections.singletonList(ColumnOption.identity(identity)));
+        assertSqlCanBeParsedAndDeparsed(table.toString());
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/statement/create/PostgreSqlSchemaTraversalTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/PostgreSqlSchemaTraversalTest.java
@@ -1,0 +1,133 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static net.sf.jsqlparser.util.validation.ValidationTestAsserts.validateNoErrors;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.StatementVisitorAdapter;
+import net.sf.jsqlparser.statement.StmtFeature;
+import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
+import net.sf.jsqlparser.util.validation.feature.DatabaseType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PostgreSqlSchemaTraversalTest {
+    @Test
+    void testTableFinderIncludesLikeAndReferenceSources() throws JSQLParserException {
+        assertThat(TablesNamesFinder.findTables(
+                "CREATE TABLE copy (LIKE source INCLUDING ALL, parent_id integer REFERENCES parent (id))"))
+                .containsExactlyInAnyOrder("copy", "source", "parent");
+        assertThat(TablesNamesFinder.findTables("CREATE TABLE employees OF employee_type"))
+                .containsExactly("employees");
+        assertThat(TablesNamesFinder.findTables("ALTER SEQUENCE seq OWNED BY app.counters.id"))
+                .containsExactly("app.counters");
+        assertThat(TablesNamesFinder.findTables("CREATE SEQUENCE seq OWNED BY NONE")).isEmpty();
+    }
+
+    @Test
+    void testExpressionVisitorReceivesContext() throws JSQLParserException {
+        List<String> columns = new ArrayList<>();
+        ExpressionVisitorAdapter<Void> expressions = new ExpressionVisitorAdapter<Void>() {
+            @Override
+            public <S> Void visit(Column column, S context) {
+                assertThat(context).isEqualTo("context");
+                columns.add(column.getColumnName());
+                return null;
+            }
+        };
+        StatementVisitorAdapter<Void> visitor =
+                new StatementVisitorAdapter<>(new SelectVisitorAdapter<>(expressions));
+        CCJSqlParserUtil.parse(
+                "CREATE TABLE bookings (room text, EXCLUDE USING gist ((lower(room)) WITH =) WHERE (room <> ''))")
+                .accept(visitor, "context");
+        CCJSqlParserUtil.parse("ALTER TABLE bookings ALTER COLUMN id TYPE bigint USING id + 1")
+                .accept(visitor, "context");
+        CCJSqlParserUtil.parse("CREATE VIEW v AS SELECT email FROM contacts")
+                .accept(visitor, "context");
+        CCJSqlParserUtil.parse("ALTER SEQUENCE seq OWNED BY bookings.id").accept(visitor,
+                "context");
+        assertThat(columns).containsExactly("room", "room", "id", "email", "id");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "CREATE TABLE bookings (room text, EXCLUDE USING gist ((lower(room)) WITH =) WHERE (room <> ''))",
+            "ALTER TABLE bookings ALTER COLUMN room TYPE text USING lower(room)",
+            "CREATE VIEW v AS SELECT room FROM bookings",
+            "CREATE TABLE bookings (room text, CHECK (room <> ''))"})
+    void testCustomExpressionDeparser(String sql) throws JSQLParserException {
+        StringBuilder output = new StringBuilder();
+        ExpressionDeParser expressions = new ExpressionDeParser() {
+            @Override
+            public <S> StringBuilder visit(Column column, S context) {
+                return getBuilder().append("new_").append(column.getColumnName());
+            }
+        };
+        Statement statement = CCJSqlParserUtil.parse(sql);
+        statement.accept(new StatementDeParser(expressions, new SelectDeParser(), output));
+        assertThat(output.toString()).contains("new_room");
+        assertThat(statement.toString()).doesNotContain("new_room");
+        assertThat(CCJSqlParserUtil.parse(output.toString()).getClass())
+                .isEqualTo(statement.getClass());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"CREATE VIEW v AS SELECT * FROM source WITH NO DATA",
+            "CREATE MATERIALIZED VIEW v AS SELECT * FROM source WITH CHECK OPTION",
+            "CREATE RECURSIVE VIEW v AS SELECT 1",
+            "CREATE RECURSIVE VIEW v(n) AS SELECT 1 WITH CHECK OPTION",
+            "CREATE TABLE copy (LIKE source INCLUDING UNKNOWN)",
+            "CREATE TABLE t (id integer, UNIQUE (id) INITIALLY UNKNOWN)"})
+    void testInvalidClauseCombinations(String sql) {
+        assertThatThrownBy(() -> CCJSqlParserUtil.parse(sql))
+                .isInstanceOf(JSQLParserException.class);
+    }
+
+    @Test
+    void testMaterializedViewReadEffects() throws JSQLParserException {
+        Statement populated =
+                CCJSqlParserUtil.parse("CREATE MATERIALIZED VIEW v AS SELECT * FROM source");
+        assertThat(populated.getFeatures().getCertain())
+                .contains(StmtFeature.MODIFIES_SCHEMA, StmtFeature.READS_DATA)
+                .doesNotContain(StmtFeature.RETURNS_RESULT_SET);
+        Statement empty = CCJSqlParserUtil
+                .parse("CREATE MATERIALIZED VIEW v AS SELECT * FROM source WITH NO DATA");
+        assertThat(empty.getFeatures().getCertain()).contains(StmtFeature.MODIFIES_SCHEMA)
+                .doesNotContain(StmtFeature.READS_DATA);
+        Statement view = CCJSqlParserUtil.parse("CREATE VIEW v AS SELECT * FROM source");
+        assertThat(view.getFeatures().getCertain()).doesNotContain(StmtFeature.READS_DATA);
+    }
+
+    @Test
+    void testPostgreSqlValidation() throws JSQLParserException {
+        validateNoErrors("CREATE MATERIALIZED VIEW v AS SELECT * FROM source WITH NO DATA", 1,
+                DatabaseType.POSTGRESQL);
+        validateNoErrors(
+                "CREATE TABLE bookings (room integer, EXCLUDE USING gist ((room + 1) WITH =) WHERE (room > 0))",
+                1, DatabaseType.POSTGRESQL);
+        validateNoErrors("ALTER TABLE bookings ALTER COLUMN room TYPE bigint USING room + 1", 1,
+                DatabaseType.POSTGRESQL);
+        validateNoErrors("CREATE SEQUENCE seq OWNED BY bookings.room", 1, DatabaseType.POSTGRESQL);
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/TablesNamesFinderTest.java
@@ -367,23 +367,19 @@ public class TablesNamesFinderTest {
     }
 
     @Test
-    public void testCreateSequence_throwsException() throws JSQLParserException {
+    public void testCreateSequenceHasNoTableReferences() throws JSQLParserException {
         String sql = "CREATE SEQUENCE my_seq";
         Statement stmt = CCJSqlParserUtil.parse(sql);
         TablesNamesFinder tablesNamesFinder = new TablesNamesFinder();
-        assertThatThrownBy(() -> tablesNamesFinder.getTables(stmt))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Finding tables from CreateSequence is not supported");
+        assertThat(tablesNamesFinder.getTables(stmt)).isEmpty();
     }
 
     @Test
-    public void testAlterSequence_throwsException() throws JSQLParserException {
+    public void testAlterSequenceHasNoTableReferences() throws JSQLParserException {
         String sql = "ALTER SEQUENCE my_seq";
         Statement stmt = CCJSqlParserUtil.parse(sql);
         TablesNamesFinder tablesNamesFinder = new TablesNamesFinder();
-        assertThatThrownBy(() -> tablesNamesFinder.getTables(stmt))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Finding tables from AlterSequence is not supported");
+        assertThat(tablesNamesFinder.getTables(stmt)).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Extend the existing PostgreSQL schema models with structured clauses:

* View parameters, recursive views, materialized-view storage and WITH DATA options.
* UNIQUE NULLS DISTINCT, exclusion constraints, constraint attributes and index storage options.
* Ordered table LIKE clauses, typed tables, identity definitions and identity alterations.
* ALTER COLUMN TYPE USING expressions and sequence ownership.

Preserve legacy accessors and distinguish omitted clauses from explicit defaults. Wire the new nodes into visitors, table-name discovery, deparsers, validators and statement feature analysis. Include API examples in the usage documentation.

This is the schema DDL portion of the PostgreSQL follow-up work after #2549. Type/domain/extension, logical replication, and role/privilege/trigger changes will be separate PRs.

## Validation

* Full Gradle check, including formatting, static analysis and tests (Spotless ratcheted against upstream/master locally).
* Maven clean verify and Javadoc generation: 5,373 tests, zero failures/errors, 26 skipped.
* 49 new regression cases covering parsing, typed accessors, construction, SQL regeneration and traversal.
* 12 previously unsupported cases from the local PostgreSQL corpus now produce concrete ASTs; no regressions among previously modeled cases.
* Original corpus and regenerated SQL cross-checked with the PostgreSQL 18 grammar through pglast. This is syntax validation, not live database execution.

References: [CREATE TABLE](https://www.postgresql.org/docs/18/sql-createtable.html), [CREATE VIEW](https://www.postgresql.org/docs/18/sql-createview.html), [ALTER TABLE](https://www.postgresql.org/docs/18/sql-altertable.html), [ALTER SEQUENCE](https://www.postgresql.org/docs/18/sql-altersequence.html).
