### PR TITLE
feat(parser): model PostgreSQL type domain and extension DDL

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
+++ b/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
@@ -560,6 +560,10 @@ public enum Feature {
      */
     createSequence,
     /**
+     * Structured type, domain and extension statements.
+     */
+    createType, alterType, createDomain, alterDomain, createExtension, alterExtension,
+    /**
      * SQL "CREATE SYNONYM" statement is allowed
      *
      * @see CreateSynonym

--- a/src/main/java/net/sf/jsqlparser/statement/RoutineReference.java
+++ b/src/main/java/net/sf/jsqlparser/statement/RoutineReference.java
@@ -53,7 +53,7 @@ public class RoutineReference implements Serializable {
     }
 
     /** A signature argument is a data type, not an invocation expression. */
-    public static class Argument implements java.io.Serializable {
+    public static class Argument implements Serializable {
         public enum Mode {
             IN, OUT, INOUT, VARIADIC
         }

--- a/src/main/java/net/sf/jsqlparser/statement/RoutineReference.java
+++ b/src/main/java/net/sf/jsqlparser/statement/RoutineReference.java
@@ -1,0 +1,115 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import net.sf.jsqlparser.statement.create.table.ColDataType;
+import java.io.Serializable;
+
+public class RoutineReference implements Serializable {
+    private String name;
+    private List<Argument> arguments;
+    private boolean allArguments;
+    private List<Argument> orderByArguments;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<Argument> getArguments() {
+        return arguments;
+    }
+
+    public void setArguments(List<Argument> arguments) {
+        this.arguments = arguments;
+    }
+
+    public boolean isAllArguments() {
+        return allArguments;
+    }
+
+    public void setAllArguments(boolean allArguments) {
+        this.allArguments = allArguments;
+    }
+
+    public List<Argument> getOrderByArguments() {
+        return orderByArguments;
+    }
+
+    public void setOrderByArguments(List<Argument> orderByArguments) {
+        this.orderByArguments = orderByArguments;
+    }
+
+    /** A signature argument is a data type, not an invocation expression. */
+    public static class Argument implements java.io.Serializable {
+        public enum Mode {
+            IN, OUT, INOUT, VARIADIC
+        }
+
+        private Mode mode;
+        private String name;
+        private ColDataType dataType;
+
+        public Mode getMode() {
+            return mode;
+        }
+
+        public void setMode(Mode mode) {
+            this.mode = mode;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public ColDataType getDataType() {
+            return dataType;
+        }
+
+        public void setDataType(ColDataType dataType) {
+            this.dataType = dataType;
+        }
+
+        @Override
+        public String toString() {
+            return (mode == null ? "" : mode + " ") + (name == null ? "" : name + " ") + dataType;
+        }
+    }
+
+    @Override
+    public String toString() {
+        if (arguments == null && !allArguments && orderByArguments == null) {
+            return name;
+        }
+        StringBuilder sql = new StringBuilder(name).append('(');
+        if (allArguments) {
+            sql.append('*');
+        } else if (arguments != null) {
+            sql.append(arguments.stream().map(Object::toString).collect(Collectors.joining(", ")));
+        }
+        if (orderByArguments != null) {
+            if (arguments != null && !arguments.isEmpty()) {
+                sql.append(' ');
+            }
+            sql.append("ORDER BY ").append(orderByArguments.stream().map(Object::toString)
+                    .collect(Collectors.joining(", ")));
+        }
+        return sql.append(')').toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/StatementFeatureVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementFeatureVisitor.java
@@ -9,6 +9,13 @@
  */
 package net.sf.jsqlparser.statement;
 
+import net.sf.jsqlparser.statement.create.type.CreateType;
+import net.sf.jsqlparser.statement.alter.AlterType;
+import net.sf.jsqlparser.statement.create.domain.CreateDomain;
+import net.sf.jsqlparser.statement.alter.AlterDomain;
+import net.sf.jsqlparser.statement.create.extension.CreateExtension;
+import net.sf.jsqlparser.statement.alter.AlterExtension;
+
 import net.sf.jsqlparser.JSQLParserException;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
@@ -845,5 +852,47 @@ public class StatementFeatureVisitor extends StatementVisitorAdapter<Void> {
             }
             return super.visit(tableFunction, context);
         }
+    }
+
+    @Override
+    public <S> Void visit(CreateType statement, S context) {
+        analysis.claimTopLevel();
+        analysis.certain(StmtFeature.MODIFIES_SCHEMA);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(AlterType statement, S context) {
+        analysis.claimTopLevel();
+        analysis.certain(StmtFeature.MODIFIES_SCHEMA);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(CreateDomain statement, S context) {
+        analysis.claimTopLevel();
+        analysis.certain(StmtFeature.MODIFIES_SCHEMA);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(AlterDomain statement, S context) {
+        analysis.claimTopLevel();
+        analysis.certain(StmtFeature.MODIFIES_SCHEMA);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(CreateExtension statement, S context) {
+        analysis.claimTopLevel();
+        analysis.certain(StmtFeature.MODIFIES_SCHEMA);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(AlterExtension statement, S context) {
+        analysis.claimTopLevel();
+        analysis.certain(StmtFeature.MODIFIES_SCHEMA);
+        return null;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitor.java
@@ -9,6 +9,13 @@
  */
 package net.sf.jsqlparser.statement;
 
+import net.sf.jsqlparser.statement.create.type.CreateType;
+import net.sf.jsqlparser.statement.alter.AlterType;
+import net.sf.jsqlparser.statement.create.domain.CreateDomain;
+import net.sf.jsqlparser.statement.alter.AlterDomain;
+import net.sf.jsqlparser.statement.create.extension.CreateExtension;
+import net.sf.jsqlparser.statement.alter.AlterExtension;
+
 import net.sf.jsqlparser.statement.alter.Alter;
 import net.sf.jsqlparser.statement.alter.AlterSession;
 import net.sf.jsqlparser.statement.alter.AlterSystemStatement;
@@ -393,4 +400,51 @@ public interface StatementVisitor<T> {
         this.visit(createPolicy, null);
     }
 
+    default <S> T visit(CreateType statement, S context) {
+        return null;
+    }
+
+    default void visit(CreateType statement) {
+        visit(statement, null);
+    }
+
+    default <S> T visit(AlterType statement, S context) {
+        return null;
+    }
+
+    default void visit(AlterType statement) {
+        visit(statement, null);
+    }
+
+    default <S> T visit(CreateDomain statement, S context) {
+        return null;
+    }
+
+    default void visit(CreateDomain statement) {
+        visit(statement, null);
+    }
+
+    default <S> T visit(AlterDomain statement, S context) {
+        return null;
+    }
+
+    default void visit(AlterDomain statement) {
+        visit(statement, null);
+    }
+
+    default <S> T visit(CreateExtension statement, S context) {
+        return null;
+    }
+
+    default void visit(CreateExtension statement) {
+        visit(statement, null);
+    }
+
+    default <S> T visit(AlterExtension statement, S context) {
+        return null;
+    }
+
+    default void visit(AlterExtension statement) {
+        visit(statement, null);
+    }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
@@ -9,9 +9,17 @@
  */
 package net.sf.jsqlparser.statement;
 
+import net.sf.jsqlparser.statement.create.type.CreateType;
+import net.sf.jsqlparser.statement.alter.AlterType;
+import net.sf.jsqlparser.statement.create.domain.CreateDomain;
+import net.sf.jsqlparser.statement.alter.AlterDomain;
+import net.sf.jsqlparser.statement.create.extension.CreateExtension;
+import net.sf.jsqlparser.statement.alter.AlterExtension;
+
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
 import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.schema.Partition;
 import net.sf.jsqlparser.statement.alter.Alter;
 import net.sf.jsqlparser.statement.alter.AlterExpression;
@@ -594,6 +602,58 @@ public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
 
     @Override
     public <S> T visit(Export export, S context) {
+        return null;
+    }
+
+    @Override
+    public <S> T visit(CreateType statement, S context) {
+
+        return null;
+    }
+
+    @Override
+    public <S> T visit(AlterType statement, S context) {
+
+        return null;
+    }
+
+    @Override
+    public <S> T visit(CreateDomain statement, S context) {
+        if (statement.getDefaultExpression() != null) {
+            statement.getDefaultExpression().accept(expressionVisitor, context);
+        }
+        statement.getConstraints().forEach(constraint -> {
+            if (constraint.getExpression() != null) {
+                constraint.getExpression().accept(expressionVisitor, context);
+            }
+        });
+        return null;
+    }
+
+    @Override
+    public <S> T visit(AlterDomain statement, S context) {
+        if (statement.getDefaultExpression() != null) {
+            statement.getDefaultExpression().accept(expressionVisitor, context);
+        }
+        if (statement.getConstraint() != null
+                && statement.getConstraint().getExpression() != null) {
+            statement.getConstraint().getExpression().accept(expressionVisitor, context);
+        }
+        return null;
+    }
+
+    @Override
+    public <S> T visit(CreateExtension statement, S context) {
+
+        return null;
+    }
+
+    @Override
+    public <S> T visit(AlterExtension statement, S context) {
+        if (statement.getMember() != null && statement.getMember().isTable()) {
+            new Table(statement.getMember().getName())
+                    .accept(fromItemVisitor, context);
+        }
         return null;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterDomain.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterDomain.java
@@ -1,0 +1,170 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.alter;
+
+import java.util.function.Consumer;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.statement.create.domain.DomainConstraint;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.StatementVisitor;
+
+public class AlterDomain implements Statement {
+    private String name;
+    private Action action;
+    private Expression defaultExpression;
+    private DomainConstraint constraint;
+    private String constraintName;
+    private String newName;
+    private boolean notValid;
+    private boolean ifExists;
+    private Behavior behavior;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Action getAction() {
+        return action;
+    }
+
+    public void setAction(Action action) {
+        this.action = action;
+    }
+
+    public Expression getDefaultExpression() {
+        return defaultExpression;
+    }
+
+    public void setDefaultExpression(Expression defaultExpression) {
+        this.defaultExpression = defaultExpression;
+    }
+
+    public DomainConstraint getConstraint() {
+        return constraint;
+    }
+
+    public void setConstraint(DomainConstraint constraint) {
+        this.constraint = constraint;
+    }
+
+    public String getConstraintName() {
+        return constraintName;
+    }
+
+    public void setConstraintName(String constraintName) {
+        this.constraintName = constraintName;
+    }
+
+    public String getNewName() {
+        return newName;
+    }
+
+    public void setNewName(String newName) {
+        this.newName = newName;
+    }
+
+    public boolean isNotValid() {
+        return notValid;
+    }
+
+    public void setNotValid(boolean notValid) {
+        this.notValid = notValid;
+    }
+
+    public boolean isIfExists() {
+        return ifExists;
+    }
+
+    public void setIfExists(boolean ifExists) {
+        this.ifExists = ifExists;
+    }
+
+    public Behavior getBehavior() {
+        return behavior;
+    }
+
+    public void setBehavior(Behavior behavior) {
+        this.behavior = behavior;
+    }
+
+    @Override
+    public <T, S> T accept(StatementVisitor<T> visitor, S context) {
+        return visitor.visit(this, context);
+    }
+
+    public enum Action {
+        SET_DEFAULT, DROP_DEFAULT, SET_NOT_NULL, DROP_NOT_NULL, ADD_CONSTRAINT, DROP_CONSTRAINT, RENAME_CONSTRAINT, VALIDATE_CONSTRAINT, OWNER, RENAME, SET_SCHEMA
+    }
+    public enum Behavior {
+        CASCADE, RESTRICT
+    }
+
+    public void appendTo(StringBuilder sql, Consumer<Expression> expressions) {
+        sql.append("ALTER DOMAIN ").append(name).append(' ');
+        switch (action) {
+            case SET_DEFAULT:
+                sql.append("SET DEFAULT ");
+                expressions.accept(defaultExpression);
+                break;
+            case DROP_DEFAULT:
+                sql.append("DROP DEFAULT");
+                break;
+            case SET_NOT_NULL:
+                sql.append("SET NOT NULL");
+                break;
+            case DROP_NOT_NULL:
+                sql.append("DROP NOT NULL");
+                break;
+            case ADD_CONSTRAINT:
+                sql.append("ADD ");
+                constraint.appendTo(sql, expressions);
+                if (notValid) {
+                    sql.append(" NOT VALID");
+                }
+                break;
+            case DROP_CONSTRAINT:
+                sql.append("DROP CONSTRAINT ").append(ifExists ? "IF EXISTS " : "")
+                        .append(constraintName);
+                if (behavior != null) {
+                    sql.append(' ').append(behavior);
+                }
+                break;
+            case RENAME_CONSTRAINT:
+                sql.append("RENAME CONSTRAINT ").append(constraintName).append(" TO ")
+                        .append(newName);
+                break;
+            case VALIDATE_CONSTRAINT:
+                sql.append("VALIDATE CONSTRAINT ").append(constraintName);
+                break;
+            case OWNER:
+                sql.append("OWNER TO ").append(newName);
+                break;
+            case RENAME:
+                sql.append("RENAME TO ").append(newName);
+                break;
+            case SET_SCHEMA:
+                sql.append("SET SCHEMA ").append(newName);
+                break;
+            default:
+                throw new IllegalStateException("Unknown domain alteration: " + action);
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sql = new StringBuilder();
+        appendTo(sql, sql::append);
+        return sql.toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExtension.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExtension.java
@@ -1,0 +1,95 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.alter;
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.statement.create.extension.ExtensionObject;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.StatementVisitor;
+
+public class AlterExtension implements Statement {
+    private String name;
+    private Action action;
+    private Expression version;
+    private String schema;
+    private ExtensionObject member;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Action getAction() {
+        return action;
+    }
+
+    public void setAction(Action action) {
+        this.action = action;
+    }
+
+    public Expression getVersion() {
+        return version;
+    }
+
+    public void setVersion(Expression version) {
+        this.version = version;
+    }
+
+    public String getSchema() {
+        return schema;
+    }
+
+    public void setSchema(String schema) {
+        this.schema = schema;
+    }
+
+    public ExtensionObject getMember() {
+        return member;
+    }
+
+    public void setMember(ExtensionObject member) {
+        this.member = member;
+    }
+
+    @Override
+    public <T, S> T accept(StatementVisitor<T> visitor, S context) {
+        return visitor.visit(this, context);
+    }
+
+    public enum Action {
+        UPDATE, SET_SCHEMA, ADD, DROP
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sql = new StringBuilder("ALTER EXTENSION ").append(name).append(' ');
+        switch (action) {
+            case UPDATE:
+                sql.append("UPDATE");
+                if (version != null) {
+                    sql.append(" TO ").append(version);
+                }
+                break;
+            case SET_SCHEMA:
+                sql.append("SET SCHEMA ").append(schema);
+                break;
+            case ADD:
+            case DROP:
+                sql.append(action).append(' ').append(member);
+                break;
+            default:
+                throw new IllegalStateException("Unknown extension alteration: " + action);
+        }
+        return sql.toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterType.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterType.java
@@ -1,0 +1,247 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.alter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.statement.create.type.TypeAttribute;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.StatementVisitor;
+
+public class AlterType implements Statement {
+    private String name;
+    private Action action;
+    private String newName;
+    private String attributeName;
+    private StringValue value;
+    private StringValue newValue;
+    private StringValue neighborValue;
+    private Position position;
+    private boolean ifNotExists;
+    private Behavior behavior;
+    private List<AttributeChange> attributeChanges = new ArrayList<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Action getAction() {
+        return action;
+    }
+
+    public void setAction(Action action) {
+        this.action = action;
+    }
+
+    public String getNewName() {
+        return newName;
+    }
+
+    public void setNewName(String newName) {
+        this.newName = newName;
+    }
+
+    public String getAttributeName() {
+        return attributeName;
+    }
+
+    public void setAttributeName(String attributeName) {
+        this.attributeName = attributeName;
+    }
+
+    public StringValue getValue() {
+        return value;
+    }
+
+    public void setValue(StringValue value) {
+        this.value = value;
+    }
+
+    public StringValue getNewValue() {
+        return newValue;
+    }
+
+    public void setNewValue(StringValue newValue) {
+        this.newValue = newValue;
+    }
+
+    public StringValue getNeighborValue() {
+        return neighborValue;
+    }
+
+    public void setNeighborValue(StringValue neighborValue) {
+        this.neighborValue = neighborValue;
+    }
+
+    public Position getPosition() {
+        return position;
+    }
+
+    public void setPosition(Position position) {
+        this.position = position;
+    }
+
+    public boolean isIfNotExists() {
+        return ifNotExists;
+    }
+
+    public void setIfNotExists(boolean ifNotExists) {
+        this.ifNotExists = ifNotExists;
+    }
+
+    public Behavior getBehavior() {
+        return behavior;
+    }
+
+    public void setBehavior(Behavior behavior) {
+        this.behavior = behavior;
+    }
+
+    public List<AttributeChange> getAttributeChanges() {
+        return attributeChanges;
+    }
+
+    public void setAttributeChanges(List<AttributeChange> attributeChanges) {
+        this.attributeChanges = attributeChanges;
+    }
+
+    @Override
+    public <T, S> T accept(StatementVisitor<T> visitor, S context) {
+        return visitor.visit(this, context);
+    }
+
+    public enum Action {
+        OWNER, RENAME, SET_SCHEMA, RENAME_ATTRIBUTE, ADD_VALUE, RENAME_VALUE, ATTRIBUTES
+    }
+    public enum Position {
+        BEFORE, AFTER
+    }
+    public enum Behavior {
+        CASCADE, RESTRICT
+    }
+    public static class AttributeChange implements java.io.Serializable {
+        public enum Kind {
+            ADD, DROP, ALTER
+        }
+
+        private Kind kind;
+        private TypeAttribute attribute;
+        private boolean ifExists;
+        private boolean useSetData;
+        private Behavior behavior;
+
+        public Kind getKind() {
+            return kind;
+        }
+
+        public void setKind(Kind kind) {
+            this.kind = kind;
+        }
+
+        public TypeAttribute getAttribute() {
+            return attribute;
+        }
+
+        public void setAttribute(TypeAttribute attribute) {
+            this.attribute = attribute;
+        }
+
+        public boolean isIfExists() {
+            return ifExists;
+        }
+
+        public void setIfExists(boolean ifExists) {
+            this.ifExists = ifExists;
+        }
+
+        public boolean isUseSetData() {
+            return useSetData;
+        }
+
+        public void setUseSetData(boolean useSetData) {
+            this.useSetData = useSetData;
+        }
+
+        public Behavior getBehavior() {
+            return behavior;
+        }
+
+        public void setBehavior(Behavior behavior) {
+            this.behavior = behavior;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sql = new StringBuilder().append(kind).append(" ATTRIBUTE ");
+            if (ifExists) {
+                sql.append("IF EXISTS ");
+            }
+            sql.append(attribute.getName());
+            if (kind == Kind.ALTER) {
+                sql.append(useSetData ? " SET DATA TYPE" : " TYPE");
+            }
+            if (kind != Kind.DROP) {
+                sql.append(' ').append(attribute.getDataType());
+                if (attribute.getCollation() != null) {
+                    sql.append(" COLLATE ").append(attribute.getCollation());
+                }
+            }
+            if (behavior != null) {
+                sql.append(' ').append(behavior);
+            }
+            return sql.toString();
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sql = new StringBuilder("ALTER TYPE ").append(name).append(' ');
+        switch (action) {
+            case OWNER:
+                sql.append("OWNER TO ").append(newName);
+                break;
+            case RENAME:
+                sql.append("RENAME TO ").append(newName);
+                break;
+            case SET_SCHEMA:
+                sql.append("SET SCHEMA ").append(newName);
+                break;
+            case RENAME_ATTRIBUTE:
+                sql.append("RENAME ATTRIBUTE ").append(attributeName).append(" TO ")
+                        .append(newName);
+                if (behavior != null) {
+                    sql.append(' ').append(behavior);
+                }
+                break;
+            case ADD_VALUE:
+                sql.append("ADD VALUE ").append(ifNotExists ? "IF NOT EXISTS " : "").append(value);
+                if (position != null) {
+                    sql.append(' ').append(position).append(' ').append(neighborValue);
+                }
+                break;
+            case RENAME_VALUE:
+                sql.append("RENAME VALUE ").append(value).append(" TO ").append(newValue);
+                break;
+            case ATTRIBUTES:
+                sql.append(attributeChanges.stream().map(Object::toString)
+                        .collect(Collectors.joining(", ")));
+                break;
+            default:
+                throw new IllegalStateException("Unknown type alteration: " + action);
+        }
+        return sql.toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/domain/CreateDomain.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/domain/CreateDomain.java
@@ -1,0 +1,102 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.statement.create.table.ColDataType;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.StatementVisitor;
+
+public class CreateDomain implements Statement {
+    private String name;
+    private boolean useAs;
+    private ColDataType dataType;
+    private String collation;
+    private Expression defaultExpression;
+    private List<DomainConstraint> constraints = new ArrayList<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isUseAs() {
+        return useAs;
+    }
+
+    public void setUseAs(boolean useAs) {
+        this.useAs = useAs;
+    }
+
+    public ColDataType getDataType() {
+        return dataType;
+    }
+
+    public void setDataType(ColDataType dataType) {
+        this.dataType = dataType;
+    }
+
+    public String getCollation() {
+        return collation;
+    }
+
+    public void setCollation(String collation) {
+        this.collation = collation;
+    }
+
+    public Expression getDefaultExpression() {
+        return defaultExpression;
+    }
+
+    public void setDefaultExpression(Expression defaultExpression) {
+        this.defaultExpression = defaultExpression;
+    }
+
+    public List<DomainConstraint> getConstraints() {
+        return constraints;
+    }
+
+    public void setConstraints(List<DomainConstraint> constraints) {
+        this.constraints = constraints;
+    }
+
+    @Override
+    public <T, S> T accept(StatementVisitor<T> visitor, S context) {
+        return visitor.visit(this, context);
+    }
+
+    public void appendTo(StringBuilder sql, Consumer<Expression> expressions) {
+        sql.append("CREATE DOMAIN ").append(name).append(useAs ? " AS " : " ").append(dataType);
+        if (collation != null) {
+            sql.append(" COLLATE ").append(collation);
+        }
+        if (defaultExpression != null) {
+            sql.append(" DEFAULT ");
+            expressions.accept(defaultExpression);
+        }
+        for (DomainConstraint constraint : constraints) {
+            sql.append(' ');
+            constraint.appendTo(sql, expressions);
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sql = new StringBuilder();
+        appendTo(sql, sql::append);
+        return sql.toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/domain/DomainConstraint.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/domain/DomainConstraint.java
@@ -1,0 +1,68 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.domain;
+
+import java.util.function.Consumer;
+import net.sf.jsqlparser.expression.Expression;
+import java.io.Serializable;
+
+public class DomainConstraint implements Serializable {
+    private String name;
+    private Kind kind;
+    private Expression expression;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Kind getKind() {
+        return kind;
+    }
+
+    public void setKind(Kind kind) {
+        this.kind = kind;
+    }
+
+    public Expression getExpression() {
+        return expression;
+    }
+
+    public void setExpression(Expression expression) {
+        this.expression = expression;
+    }
+
+    public enum Kind {
+        NULL, NOT_NULL, CHECK
+    }
+
+    public void appendTo(StringBuilder sql, Consumer<Expression> expressions) {
+        if (name != null) {
+            sql.append("CONSTRAINT ").append(name).append(' ');
+        }
+        if (kind == Kind.CHECK) {
+            sql.append("CHECK (");
+            expressions.accept(expression);
+            sql.append(')');
+        } else {
+            sql.append(kind == Kind.NULL ? "NULL" : "NOT NULL");
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sql = new StringBuilder();
+        appendTo(sql, sql::append);
+        return sql.toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/extension/CreateExtension.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/extension/CreateExtension.java
@@ -1,0 +1,104 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.extension;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.StatementVisitor;
+
+public class CreateExtension implements Statement {
+    private String name;
+    private boolean ifNotExists;
+    private boolean useWith;
+    private List<Option> options = new ArrayList<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isIfNotExists() {
+        return ifNotExists;
+    }
+
+    public void setIfNotExists(boolean ifNotExists) {
+        this.ifNotExists = ifNotExists;
+    }
+
+    public boolean isUseWith() {
+        return useWith;
+    }
+
+    public void setUseWith(boolean useWith) {
+        this.useWith = useWith;
+    }
+
+    public List<Option> getOptions() {
+        return options;
+    }
+
+    public void setOptions(List<Option> options) {
+        this.options = options;
+    }
+
+    @Override
+    public <T, S> T accept(StatementVisitor<T> visitor, S context) {
+        return visitor.visit(this, context);
+    }
+
+    public enum OptionKind {
+        SCHEMA, VERSION, CASCADE
+    }
+    public static class Option implements java.io.Serializable {
+        private final OptionKind kind;
+        private final String schema;
+        private final Expression version;
+
+        public Option(OptionKind kind, String schema, Expression version) {
+            this.kind = kind;
+            this.schema = schema;
+            this.version = version;
+        }
+
+        public OptionKind getKind() {
+            return kind;
+        }
+
+        public String getSchema() {
+            return schema;
+        }
+
+        public Expression getVersion() {
+            return version;
+        }
+
+        @Override
+        public String toString() {
+            return kind + (kind == OptionKind.SCHEMA ? " " + schema
+                    : kind == OptionKind.VERSION ? " " + version : "");
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sql = new StringBuilder("CREATE EXTENSION ")
+                .append(ifNotExists ? "IF NOT EXISTS " : "").append(name);
+        if (useWith) {
+            sql.append(" WITH");
+        }
+        options.forEach(option -> sql.append(' ').append(option));
+        return sql.toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/extension/ExtensionObject.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/extension/ExtensionObject.java
@@ -1,0 +1,115 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.extension;
+
+import net.sf.jsqlparser.statement.RoutineReference;
+import net.sf.jsqlparser.statement.create.table.ColDataType;
+import java.io.Serializable;
+
+public class ExtensionObject implements Serializable {
+    private Kind kind;
+    private String name;
+    private RoutineReference routine;
+    private ColDataType sourceType;
+    private ColDataType targetType;
+    private String accessMethod;
+    private String language;
+    private boolean procedural;
+
+    public Kind getKind() {
+        return kind;
+    }
+
+    public void setKind(Kind kind) {
+        this.kind = kind;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public RoutineReference getRoutine() {
+        return routine;
+    }
+
+    public void setRoutine(RoutineReference routine) {
+        this.routine = routine;
+    }
+
+    public ColDataType getSourceType() {
+        return sourceType;
+    }
+
+    public void setSourceType(ColDataType sourceType) {
+        this.sourceType = sourceType;
+    }
+
+    public ColDataType getTargetType() {
+        return targetType;
+    }
+
+    public void setTargetType(ColDataType targetType) {
+        this.targetType = targetType;
+    }
+
+    public String getAccessMethod() {
+        return accessMethod;
+    }
+
+    public void setAccessMethod(String accessMethod) {
+        this.accessMethod = accessMethod;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public boolean isProcedural() {
+        return procedural;
+    }
+
+    public void setProcedural(boolean procedural) {
+        this.procedural = procedural;
+    }
+
+    public enum Kind {
+        ACCESS_METHOD, AGGREGATE, CAST, COLLATION, CONVERSION, DOMAIN, EVENT_TRIGGER, FOREIGN_DATA_WRAPPER, FOREIGN_TABLE, FUNCTION, MATERIALIZED_VIEW, OPERATOR, OPERATOR_CLASS, OPERATOR_FAMILY, LANGUAGE, PROCEDURE, ROUTINE, SCHEMA, SEQUENCE, SERVER, TABLE, TEXT_SEARCH_CONFIGURATION, TEXT_SEARCH_DICTIONARY, TEXT_SEARCH_PARSER, TEXT_SEARCH_TEMPLATE, TRANSFORM, TYPE, VIEW
+    }
+
+    public boolean isTable() {
+        return kind == Kind.TABLE || kind == Kind.FOREIGN_TABLE || kind == Kind.VIEW
+                || kind == Kind.MATERIALIZED_VIEW;
+    }
+
+    @Override
+    public String toString() {
+        String prefix = (procedural ? "PROCEDURAL " : "") + kind.name().replace('_', ' ') + " ";
+        if (kind == Kind.CAST) {
+            return prefix + "(" + sourceType + " AS " + targetType + ")";
+        }
+        if (kind == Kind.TRANSFORM) {
+            return prefix + "FOR " + sourceType + " LANGUAGE " + language;
+        }
+        if (kind == Kind.OPERATOR) {
+            return prefix + name + " (" + (sourceType == null ? "NONE" : sourceType) + ", "
+                    + (targetType == null ? "NONE" : targetType) + ")";
+        }
+        return prefix + (routine == null ? name : routine)
+                + (accessMethod == null ? "" : " USING " + accessMethod);
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/type/CompositeTypeDefinition.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/type/CompositeTypeDefinition.java
@@ -1,0 +1,32 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.type;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CompositeTypeDefinition implements TypeDefinition {
+    private List<TypeAttribute> attributes = new ArrayList<>();
+
+    public List<TypeAttribute> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(List<TypeAttribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String toString() {
+        return "(" + attributes.stream().map(Object::toString).collect(Collectors.joining(", "))
+                + ")";
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/type/CreateType.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/type/CreateType.java
@@ -1,0 +1,45 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.type;
+
+
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.StatementVisitor;
+
+public class CreateType implements Statement {
+    private String name;
+    private TypeDefinition definition;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public TypeDefinition getDefinition() {
+        return definition;
+    }
+
+    public void setDefinition(TypeDefinition definition) {
+        this.definition = definition;
+    }
+
+    @Override
+    public <T, S> T accept(StatementVisitor<T> visitor, S context) {
+        return visitor.visit(this, context);
+    }
+
+    @Override
+    public String toString() {
+        return "CREATE TYPE " + name + (definition == null ? "" : " AS " + definition);
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/type/EnumTypeDefinition.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/type/EnumTypeDefinition.java
@@ -1,0 +1,33 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.type;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import net.sf.jsqlparser.expression.StringValue;
+
+public class EnumTypeDefinition implements TypeDefinition {
+    private List<StringValue> labels = new ArrayList<>();
+
+    public List<StringValue> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(List<StringValue> labels) {
+        this.labels = labels;
+    }
+
+    @Override
+    public String toString() {
+        return "ENUM (" + labels.stream().map(Object::toString).collect(Collectors.joining(", "))
+                + ")";
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/type/RangeTypeDefinition.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/type/RangeTypeDefinition.java
@@ -1,0 +1,76 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.type;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import net.sf.jsqlparser.statement.create.table.ColDataType;
+
+public class RangeTypeDefinition implements TypeDefinition {
+    private List<Option> options = new ArrayList<>();
+
+    public List<Option> getOptions() {
+        return options;
+    }
+
+    public void setOptions(List<Option> options) {
+        this.options = options;
+    }
+
+    public enum OptionKind {
+        SUBTYPE, SUBTYPE_OPCLASS, COLLATION, CANONICAL, SUBTYPE_DIFF, MULTIRANGE_TYPE_NAME
+    }
+    public static class Option implements java.io.Serializable {
+        private final OptionKind kind;
+        private final ColDataType dataType;
+        private final String name;
+
+        public Option(ColDataType dataType) {
+            this.kind = OptionKind.SUBTYPE;
+            this.dataType = dataType;
+            this.name = null;
+        }
+
+        public Option(OptionKind kind, String name) {
+            this.kind = kind;
+            this.name = name;
+            this.dataType = null;
+        }
+
+        public OptionKind getKind() {
+            return kind;
+        }
+
+        public ColDataType getDataType() {
+            return dataType;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String toString() {
+            return kind + " = " + (dataType == null ? name : dataType);
+        }
+    }
+
+    public ColDataType getSubtype() {
+        return options.stream().filter(option -> option.getKind() == OptionKind.SUBTYPE)
+                .map(Option::getDataType).findFirst().orElse(null);
+    }
+
+    @Override
+    public String toString() {
+        return "RANGE (" + options.stream().map(Object::toString).collect(Collectors.joining(", "))
+                + ")";
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/type/TypeAttribute.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/type/TypeAttribute.java
@@ -1,0 +1,48 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.type;
+
+import net.sf.jsqlparser.statement.create.table.ColDataType;
+import java.io.Serializable;
+
+public class TypeAttribute implements Serializable {
+    private String name;
+    private ColDataType dataType;
+    private String collation;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ColDataType getDataType() {
+        return dataType;
+    }
+
+    public void setDataType(ColDataType dataType) {
+        this.dataType = dataType;
+    }
+
+    public String getCollation() {
+        return collation;
+    }
+
+    public void setCollation(String collation) {
+        this.collation = collation;
+    }
+
+    @Override
+    public String toString() {
+        return name + " " + dataType + (collation == null ? "" : " COLLATE " + collation);
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/create/type/TypeDefinition.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/type/TypeDefinition.java
@@ -1,0 +1,16 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create.type;
+
+import java.io.Serializable;
+
+/** Definition of a composite, enumeration or range type. */
+public interface TypeDefinition extends Serializable {
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -9,6 +9,13 @@
  */
 package net.sf.jsqlparser.util;
 
+import net.sf.jsqlparser.statement.create.type.CreateType;
+import net.sf.jsqlparser.statement.alter.AlterType;
+import net.sf.jsqlparser.statement.create.domain.CreateDomain;
+import net.sf.jsqlparser.statement.alter.AlterDomain;
+import net.sf.jsqlparser.statement.create.extension.CreateExtension;
+import net.sf.jsqlparser.statement.alter.AlterExtension;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -2496,5 +2503,56 @@ public class TablesNamesFinder<Void>
     @Override
     public void visit(CreatePolicy createPolicy) {
         StatementVisitor.super.visit(createPolicy);
+    }
+
+    @Override
+    public <S> Void visit(CreateType statement, S context) {
+
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(AlterType statement, S context) {
+
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(CreateDomain statement, S context) {
+        if (statement.getDefaultExpression() != null) {
+            statement.getDefaultExpression().accept(this, context);
+        }
+        statement.getConstraints().forEach(constraint -> {
+            if (constraint.getExpression() != null) {
+                constraint.getExpression().accept(this, context);
+            }
+        });
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(AlterDomain statement, S context) {
+        if (statement.getDefaultExpression() != null) {
+            statement.getDefaultExpression().accept(this, context);
+        }
+        if (statement.getConstraint() != null
+                && statement.getConstraint().getExpression() != null) {
+            statement.getConstraint().getExpression().accept(this, context);
+        }
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(CreateExtension statement, S context) {
+
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(AlterExtension statement, S context) {
+        if (statement.getMember() != null && statement.getMember().isTable()) {
+            visit(new Table(statement.getMember().getName()), context);
+        }
+        return null;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -9,6 +9,13 @@
  */
 package net.sf.jsqlparser.util.deparser;
 
+import net.sf.jsqlparser.statement.create.type.CreateType;
+import net.sf.jsqlparser.statement.alter.AlterType;
+import net.sf.jsqlparser.statement.create.domain.CreateDomain;
+import net.sf.jsqlparser.statement.alter.AlterDomain;
+import net.sf.jsqlparser.statement.create.extension.CreateExtension;
+import net.sf.jsqlparser.statement.alter.AlterExtension;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -559,6 +566,42 @@ public class StatementDeParser extends AbstractDeParser<Statement>
     @Override
     public <S> StringBuilder visit(CreatePolicy createPolicy, S context) {
         new CreatePolicyDeParser(expressionDeParser, builder).deParse(createPolicy);
+        return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(CreateType statement, S context) {
+        builder.append(statement);
+        return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(AlterType statement, S context) {
+        builder.append(statement);
+        return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(CreateDomain statement, S context) {
+        statement.appendTo(builder, expression -> expression.accept(expressionDeParser, context));
+        return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(AlterDomain statement, S context) {
+        statement.appendTo(builder, expression -> expression.accept(expressionDeParser, context));
+        return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(CreateExtension statement, S context) {
+        builder.append(statement);
+        return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(AlterExtension statement, S context) {
+        builder.append(statement);
         return builder;
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/PostgresqlVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/PostgresqlVersion.java
@@ -91,7 +91,10 @@ public enum PostgresqlVersion implements Version {
                     Feature.commentOnView,
 
                     // https://www.postgresql.org/docs/current/sql-createsequence.html
-                    Feature.createSequence, // https://www.postgresql.org/docs/current/sql-altersequence.html
+                    Feature.createSequence,
+                    Feature.createType, Feature.alterType,
+                    Feature.createDomain, Feature.alterDomain,
+                    Feature.createExtension, Feature.alterExtension, // https://www.postgresql.org/docs/current/sql-altersequence.html
                     Feature.alterSequence, // https://www.postgresql.org/docs/current/sql-createschema.html
                     Feature.createSchema, // https://www.postgresql.org/docs/current/sql-createindex.html
                     Feature.createIndex, // https://www.postgresql.org/docs/current/sql-createtable.html

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/StatementValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/StatementValidator.java
@@ -9,6 +9,15 @@
  */
 package net.sf.jsqlparser.util.validation.validator;
 
+import net.sf.jsqlparser.schema.Table;
+
+import net.sf.jsqlparser.statement.create.type.CreateType;
+import net.sf.jsqlparser.statement.alter.AlterType;
+import net.sf.jsqlparser.statement.create.domain.CreateDomain;
+import net.sf.jsqlparser.statement.alter.AlterDomain;
+import net.sf.jsqlparser.statement.create.extension.CreateExtension;
+import net.sf.jsqlparser.statement.alter.AlterExtension;
+
 import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.statement.Block;
 import net.sf.jsqlparser.statement.Commit;
@@ -658,5 +667,55 @@ public class StatementValidator extends AbstractValidator<Statement>
 
     public void visit(CreatePolicy createPolicy) {
         visit(createPolicy, null);
+    }
+
+    @Override
+    public <S> Void visit(CreateType statement, S context) {
+        validateFeature(Feature.createType);
+
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(AlterType statement, S context) {
+        validateFeature(Feature.alterType);
+
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(CreateDomain statement, S context) {
+        validateFeature(Feature.createDomain);
+        validateOptionalExpression(statement.getDefaultExpression());
+        statement.getConstraints()
+                .forEach(constraint -> validateOptionalExpression(constraint.getExpression()));
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(AlterDomain statement, S context) {
+        validateFeature(Feature.alterDomain);
+        validateOptionalExpression(statement.getDefaultExpression());
+        if (statement.getConstraint() != null) {
+            validateOptionalExpression(statement.getConstraint().getExpression());
+        }
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(CreateExtension statement, S context) {
+        validateFeature(Feature.createExtension);
+
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(AlterExtension statement, S context) {
+        validateFeature(Feature.alterExtension);
+        if (statement.getMember() != null && statement.getMember().isTable()) {
+            validateOptionalFromItem(
+                    new Table(statement.getMember().getName()));
+        }
+        return null;
     }
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -48,6 +48,9 @@ import net.sf.jsqlparser.statement.alter.*;
 import net.sf.jsqlparser.statement.alter.sequence.*;
 import net.sf.jsqlparser.statement.comment.*;
 import net.sf.jsqlparser.statement.create.database.*;
+import net.sf.jsqlparser.statement.create.type.*;
+import net.sf.jsqlparser.statement.create.domain.*;
+import net.sf.jsqlparser.statement.create.extension.*;
 import net.sf.jsqlparser.statement.create.event.*;
 import net.sf.jsqlparser.statement.create.function.*;
 import net.sf.jsqlparser.statement.create.index.*;
@@ -1198,6 +1201,15 @@ public class CCJSqlParser extends AbstractJSqlParser<CCJSqlParser> {
         }
 
         return false;
+    }
+
+    private static void requireTypeDdlSyntax(boolean valid, String message) throws ParseException {
+        if (!valid) { throw new ParseException(message); }
+    }
+
+    private static <E extends Enum<E>> E typeDdlEnum(Class<E> type, String value) throws ParseException {
+        try { return Enum.valueOf(type, value.toUpperCase(Locale.ROOT)); }
+        catch (IllegalArgumentException exception) { throw new ParseException("Unknown " + type.getSimpleName() + ": " + value); }
     }
 
     private boolean isKeywordAhead(String keyword) {
@@ -14858,6 +14870,12 @@ Statement Alter():
         (
             <K_ALTER>
             (
+                LOOKAHEAD(<K_TYPE>) statement = AlterType()
+                |
+                LOOKAHEAD(<K_DOMAIN>) statement = AlterDomain()
+                |
+                LOOKAHEAD({ isKeywordAhead("EXTENSION") }) statement = AlterExtension()
+                |
                 statement = AlterEvent()
                 |
                 statement = AlterTable()
@@ -15348,6 +15366,12 @@ Statement Create():
 {
     <K_CREATE> [ <K_OR> <K_REPLACE> { isUsingOrReplace = true; } ]
     (
+        LOOKAHEAD(<K_TYPE>) { requireTypeDdlSyntax(!isUsingOrReplace, "OR REPLACE is not supported for CREATE TYPE"); } statement = CreateType()
+        |
+        LOOKAHEAD(<K_DOMAIN>) { requireTypeDdlSyntax(!isUsingOrReplace, "OR REPLACE is not supported for CREATE DOMAIN"); } statement = CreateDomain()
+        |
+        LOOKAHEAD({ isKeywordAhead("EXTENSION") }) { requireTypeDdlSyntax(!isUsingOrReplace, "OR REPLACE is not supported for CREATE EXTENSION"); } statement = CreateExtension()
+        |
         statement = CreateUser()
         |
         statement = CreateEvent()
@@ -15371,12 +15395,6 @@ Statement Create():
         LOOKAHEAD(2) statement = CreateView(isUsingOrReplace)
         |
         statement = CreatePolicy()
-        |
-        // @fixme: must appear before INDEX or it will collide with INDEX's CreateParameter() production
-        tk=<K_DOMAIN> captureRest = captureRest()
-        {
-            statement = new UnsupportedStatement("CREATE " + tk.image, captureRest);
-        }
         |
         /* @fixme
          *  Create Index uses CreateParameter() which allows all kind of tokens
@@ -15450,6 +15468,340 @@ Synonym Synonym() #Synonym :
 		linkAST(synonym,jjtThis);
         return synonym;
     }
+}
+
+
+String TypeDdlName():
+{ String name; String part; Token keyword; }
+{
+    ( name=RelObjectName() | keyword=<K_SETTINGS> { name = keyword.image; } )
+    ( LOOKAHEAD(2) "." ( part=RelObjectNameExt() | keyword=<K_SETTINGS> { part = keyword.image; } )
+      { name += "." + part; } )*
+    { return name; }
+}
+
+void TypeDdlKeyword(String expected):
+{ Token keyword; }
+{ ( keyword=<S_IDENTIFIER> | keyword=<DATA_TYPE> ) { requireTypeDdlSyntax(expected.equalsIgnoreCase(keyword.image), "Expected " + expected); } }
+
+Expression ExtensionVersion():
+{ Token token; String name; Expression result; }
+{
+    ( token=<S_CHAR_LITERAL> { result = new StringValue(token.image); }
+      | name=RelObjectName() { result = new Column(name); } )
+    { return result; }
+}
+
+TypeAttribute TypeAttribute():
+{ TypeAttribute attribute = new TypeAttribute(); String name; ColDataType type; }
+{
+    name=RelObjectName() { attribute.setName(name); }
+    type=ColDataType() { attribute.setDataType(type); }
+    [ <K_COLLATE> name=TypeDdlName() { attribute.setCollation(name); } ]
+    { return attribute; }
+}
+
+CreateType CreateType():
+{
+    CreateType result = new CreateType();
+    String name; Token label; TypeAttribute attribute;
+    EnumTypeDefinition enumeration = new EnumTypeDefinition();
+    CompositeTypeDefinition composite = new CompositeTypeDefinition();
+    RangeTypeDefinition range = new RangeTypeDefinition();
+    RangeTypeDefinition.Option option;
+}
+{
+    <K_TYPE> name=TypeDdlName() { result.setName(name); }
+    [
+        <K_AS>
+        (
+            LOOKAHEAD({ isKeywordAhead("ENUM") }) TypeDdlKeyword("ENUM") "("
+            [ label=<S_CHAR_LITERAL> { enumeration.getLabels().add(new StringValue(label.image)); }
+              ( "," label=<S_CHAR_LITERAL> { enumeration.getLabels().add(new StringValue(label.image)); } )* ]
+            ")" { result.setDefinition(enumeration); }
+            | <K_RANGE> "(" option=RangeTypeOption() { range.getOptions().add(option); }
+              ( "," option=RangeTypeOption() { range.getOptions().add(option); } )* ")"
+              {
+                  requireTypeDdlSyntax(range.getSubtype() != null, "A range definition requires SUBTYPE");
+                  result.setDefinition(range);
+              }
+            | "(" [ attribute=TypeAttribute() { composite.getAttributes().add(attribute); }
+                    ( "," attribute=TypeAttribute() { composite.getAttributes().add(attribute); } )* ]
+              ")" { result.setDefinition(composite); }
+        )
+    ]
+    { return result; }
+}
+
+RangeTypeDefinition.Option RangeTypeOption():
+{ String name; RangeTypeDefinition.OptionKind kind; ColDataType type; }
+{
+    name=RelObjectName() "=" { kind = typeDdlEnum(RangeTypeDefinition.OptionKind.class, name); }
+    (
+        LOOKAHEAD({ kind == RangeTypeDefinition.OptionKind.SUBTYPE })
+        type=ColDataType() { return new RangeTypeDefinition.Option(type); }
+        | name=TypeDdlName() { return new RangeTypeDefinition.Option(kind, name); }
+    )
+}
+
+AlterType.Behavior TypeAlterBehavior():
+{ AlterType.Behavior result; }
+{
+    ( <K_CASCADE> { result = AlterType.Behavior.CASCADE; }
+      | <K_RESTRICT> { result = AlterType.Behavior.RESTRICT; } )
+    { return result; }
+}
+
+AlterType.AttributeChange TypeAttributeChange():
+{
+    AlterType.AttributeChange result = new AlterType.AttributeChange();
+    TypeAttribute attribute = new TypeAttribute();
+    String name; ColDataType type; AlterType.Behavior behavior;
+}
+{
+    (
+        <K_ADD> TypeDdlKeyword("ATTRIBUTE") attribute=TypeAttribute()
+        { result.setKind(AlterType.AttributeChange.Kind.ADD); }
+        | <K_DROP> TypeDdlKeyword("ATTRIBUTE") [ LOOKAHEAD(2) <K_IF> <K_EXISTS> { result.setIfExists(true); } ]
+          name=RelObjectName() { attribute.setName(name); result.setKind(AlterType.AttributeChange.Kind.DROP); }
+        | <K_ALTER> TypeDdlKeyword("ATTRIBUTE") name=RelObjectName() { attribute.setName(name); }
+          [ <K_SET> <K_DATA> { result.setUseSetData(true); } ] <K_TYPE>
+          type=ColDataType() { attribute.setDataType(type); result.setKind(AlterType.AttributeChange.Kind.ALTER); }
+          [ <K_COLLATE> name=TypeDdlName() { attribute.setCollation(name); } ]
+    )
+    [ behavior=TypeAlterBehavior() { result.setBehavior(behavior); } ]
+    { result.setAttribute(attribute); return result; }
+}
+
+AlterType AlterType():
+{
+    AlterType result = new AlterType(); String name; Token label;
+    AlterType.AttributeChange change; AlterType.Behavior behavior;
+}
+{
+    <K_TYPE> name=TypeDdlName() { result.setName(name); }
+    (
+        LOOKAHEAD(<K_ADD> <K_VALUE>)
+        <K_ADD> <K_VALUE> { result.setAction(AlterType.Action.ADD_VALUE); }
+        [ <K_IF> <K_NOT> <K_EXISTS> { result.setIfNotExists(true); } ]
+        label=<S_CHAR_LITERAL> { result.setValue(new StringValue(label.image)); }
+        [ ( <K_BEFORE> { result.setPosition(AlterType.Position.BEFORE); }
+            | TypeDdlKeyword("AFTER") { result.setPosition(AlterType.Position.AFTER); } )
+          label=<S_CHAR_LITERAL> { result.setNeighborValue(new StringValue(label.image)); } ]
+        | <K_RENAME>
+          (
+              <K_VALUE> label=<S_CHAR_LITERAL> { result.setValue(new StringValue(label.image)); }
+              <K_TO> label=<S_CHAR_LITERAL> { result.setNewValue(new StringValue(label.image)); result.setAction(AlterType.Action.RENAME_VALUE); }
+              | LOOKAHEAD({ isKeywordAhead("ATTRIBUTE") }) TypeDdlKeyword("ATTRIBUTE")
+                name=RelObjectName() { result.setAttributeName(name); }
+                <K_TO> name=RelObjectName() { result.setNewName(name); result.setAction(AlterType.Action.RENAME_ATTRIBUTE); }
+                [ behavior=TypeAlterBehavior() { result.setBehavior(behavior); } ]
+              | <K_TO> name=RelObjectName() { result.setNewName(name); result.setAction(AlterType.Action.RENAME); }
+          )
+        | <K_SET> <K_SCHEMA> name=RelObjectName() { result.setNewName(name); result.setAction(AlterType.Action.SET_SCHEMA); }
+        | LOOKAHEAD({ isKeywordAhead("OWNER") }) TypeDdlKeyword("OWNER") <K_TO>
+          name=RelObjectName() { result.setNewName(name); result.setAction(AlterType.Action.OWNER); }
+        | change=TypeAttributeChange() { result.setAction(AlterType.Action.ATTRIBUTES); result.getAttributeChanges().add(change); }
+          ( "," change=TypeAttributeChange() { result.getAttributeChanges().add(change); } )*
+    )
+    { return result; }
+}
+
+DomainConstraint DomainConstraint(boolean allowNull):
+{ DomainConstraint result = new DomainConstraint(); String name; Expression expression; }
+{
+    [ <K_CONSTRAINT> name=RelObjectName() { result.setName(name); } ]
+    (
+        <K_NOT> <K_NULL> { result.setKind(DomainConstraint.Kind.NOT_NULL); }
+        | <K_NULL> { requireTypeDdlSyntax(allowNull, "ALTER DOMAIN ADD does not accept NULL"); result.setKind(DomainConstraint.Kind.NULL); }
+        | <K_CHECK> "(" expression=Expression() ")"
+          { result.setKind(DomainConstraint.Kind.CHECK); result.setExpression(expression); }
+    )
+    { return result; }
+}
+
+CreateDomain CreateDomain():
+{ CreateDomain result = new CreateDomain(); String name; ColDataType type; Expression expression; DomainConstraint constraint; }
+{
+    <K_DOMAIN> name=TypeDdlName() { result.setName(name); }
+    [ <K_AS> { result.setUseAs(true); } ] type=ColDataType() { result.setDataType(type); }
+    [ <K_COLLATE> name=TypeDdlName() { result.setCollation(name); } ]
+    [ <K_DEFAULT> expression=Expression() { result.setDefaultExpression(expression); } ]
+    ( constraint=DomainConstraint(true) { result.getConstraints().add(constraint); } )*
+    { return result; }
+}
+
+AlterDomain AlterDomain():
+{ AlterDomain result = new AlterDomain(); String name; Expression expression; DomainConstraint constraint; }
+{
+    <K_DOMAIN> name=TypeDdlName() { result.setName(name); }
+    (
+        <K_SET>
+        (
+            <K_DEFAULT> expression=Expression() { result.setAction(AlterDomain.Action.SET_DEFAULT); result.setDefaultExpression(expression); }
+            | <K_NOT> <K_NULL> { result.setAction(AlterDomain.Action.SET_NOT_NULL); }
+            | <K_SCHEMA> name=RelObjectName() { result.setAction(AlterDomain.Action.SET_SCHEMA); result.setNewName(name); }
+        )
+        | <K_DROP>
+        (
+            <K_DEFAULT> { result.setAction(AlterDomain.Action.DROP_DEFAULT); }
+            | <K_NOT> <K_NULL> { result.setAction(AlterDomain.Action.DROP_NOT_NULL); }
+            | <K_CONSTRAINT> [ LOOKAHEAD(2) <K_IF> <K_EXISTS> { result.setIfExists(true); } ]
+              name=RelObjectName() { result.setAction(AlterDomain.Action.DROP_CONSTRAINT); result.setConstraintName(name); }
+              [ <K_CASCADE> { result.setBehavior(AlterDomain.Behavior.CASCADE); }
+                | <K_RESTRICT> { result.setBehavior(AlterDomain.Behavior.RESTRICT); } ]
+        )
+        | <K_ADD> constraint=DomainConstraint(false) { result.setAction(AlterDomain.Action.ADD_CONSTRAINT); result.setConstraint(constraint); }
+          [ <K_NOT> TypeDdlKeyword("VALID") {
+              requireTypeDdlSyntax(constraint.getKind() == DomainConstraint.Kind.CHECK, "NOT VALID requires a CHECK constraint");
+              result.setNotValid(true);
+          } ]
+        | <K_RENAME>
+          (
+              <K_CONSTRAINT> name=RelObjectName() { result.setConstraintName(name); }
+              <K_TO> name=RelObjectName() { result.setNewName(name); result.setAction(AlterDomain.Action.RENAME_CONSTRAINT); }
+              | <K_TO> name=RelObjectName() { result.setNewName(name); result.setAction(AlterDomain.Action.RENAME); }
+          )
+        | <K_VALIDATE> <K_CONSTRAINT>
+          name=RelObjectName() { result.setConstraintName(name); result.setAction(AlterDomain.Action.VALIDATE_CONSTRAINT); }
+        | LOOKAHEAD({ isKeywordAhead("OWNER") }) TypeDdlKeyword("OWNER") <K_TO>
+          name=RelObjectName() { result.setNewName(name); result.setAction(AlterDomain.Action.OWNER); }
+    )
+    { return result; }
+}
+
+CreateExtension CreateExtension():
+{ CreateExtension result = new CreateExtension(); String name; Expression version; }
+{
+    TypeDdlKeyword("EXTENSION")
+    [ LOOKAHEAD(3) <K_IF> <K_NOT> <K_EXISTS> { result.setIfNotExists(true); } ]
+    name=RelObjectName() { result.setName(name); }
+    [ LOOKAHEAD(1) <K_WITH> { result.setUseWith(true); } ]
+    (
+        <K_SCHEMA> name=RelObjectName() { result.getOptions().add(new CreateExtension.Option(CreateExtension.OptionKind.SCHEMA, name, null)); }
+        | <K_VERSION> version=ExtensionVersion() { result.getOptions().add(new CreateExtension.Option(CreateExtension.OptionKind.VERSION, null, version)); }
+        | <K_CASCADE> { result.getOptions().add(new CreateExtension.Option(CreateExtension.OptionKind.CASCADE, null, null)); }
+    )*
+    { return result; }
+}
+
+RoutineReference.Argument RoutineSignatureArgument():
+{ RoutineReference.Argument result = new RoutineReference.Argument(); String name; Token mode; ColDataType type; }
+{
+    [
+        LOOKAHEAD({ isKeywordAhead("IN") || isKeywordAhead("OUT") || isKeywordAhead("INOUT") || isKeywordAhead("VARIADIC") })
+        ( <K_IN> { result.setMode(RoutineReference.Argument.Mode.IN); }
+          | mode=<S_IDENTIFIER> { result.setMode(typeDdlEnum(RoutineReference.Argument.Mode.class, mode.image)); } )
+    ]
+    (
+        LOOKAHEAD(ColDataType() ("," | ")" | <K_ORDER>)) type=ColDataType()
+        | name=RelObjectName() { result.setName(name); } type=ColDataType()
+    )
+    { result.setDataType(type); return result; }
+}
+
+RoutineReference RoutineReference(boolean aggregate):
+{
+    RoutineReference result = new RoutineReference(); String name; RoutineReference.Argument argument;
+    List<RoutineReference.Argument> arguments; List<RoutineReference.Argument> orderBy;
+}
+{
+    name=TypeDdlName() { result.setName(name); }
+    [
+        LOOKAHEAD(1)
+        "(" { arguments = new ArrayList<RoutineReference.Argument>(); result.setArguments(arguments); }
+        (
+            "*" { requireTypeDdlSyntax(aggregate, "Only aggregate signatures accept *"); result.setAllArguments(true); }
+            |
+            [ argument=RoutineSignatureArgument() { arguments.add(argument); }
+              ( "," argument=RoutineSignatureArgument() { arguments.add(argument); } )* ]
+            [ <K_ORDER> <K_BY> { requireTypeDdlSyntax(aggregate, "ORDER BY requires an aggregate signature"); orderBy = new ArrayList<RoutineReference.Argument>(); }
+              argument=RoutineSignatureArgument() { orderBy.add(argument); }
+              ( "," argument=RoutineSignatureArgument() { orderBy.add(argument); } )*
+              { result.setOrderByArguments(orderBy); } ]
+        )
+        ")"
+    ]
+    { requireTypeDdlSyntax(!aggregate || result.getArguments() != null, "An aggregate signature is required"); return result; }
+}
+
+String ExtensionOperatorName():
+{ String schema = null; String operator = ""; Token token; }
+{
+    [ LOOKAHEAD(RelObjectName() ".") schema=RelObjectName() "." ]
+    ( token="+" | token="-" | token="*" | token="/" | token="%" | token="="
+      | token=<OP_NOTEQUALSSTANDARD> | token=<OP_NOTEQUALSBANG> | token="<" | token=">"
+      | token=<OP_MINORTHANEQUALS> | token=<OP_GREATERTHANEQUALS> | token="&&" | token="@>" | token="<@" | token="~"
+      | token="~*" | token="!~" | token="!~*" | token="?" | token="?|" | token="?&"
+      | token=<OP_CONCAT> )
+    { operator = token.image; return (schema == null ? "" : schema + ".") + operator; }
+}
+
+ColDataType ExtensionOperatorType():
+{ ColDataType type = null; }
+{ ( <K_NONE> | type=ColDataType() ) { return type; } }
+
+ExtensionObject ExtensionObject():
+{
+    ExtensionObject result = new ExtensionObject(); String name; String kind;
+    RoutineReference routine; ColDataType type;
+}
+{
+    (
+        LOOKAHEAD({ isKeywordAhead("FUNCTION") || isKeywordAhead("PROCEDURE") || isKeywordAhead("ROUTINE") || isKeywordAhead("AGGREGATE") })
+        ( LOOKAHEAD(1) <K_PROCEDURE> { kind = "PROCEDURE"; } | kind=RelObjectName() )
+        routine=RoutineReference("AGGREGATE".equalsIgnoreCase(kind))
+        { result.setKind(typeDdlEnum(ExtensionObject.Kind.class, kind)); result.setRoutine(routine); }
+        | LOOKAHEAD({ isKeywordAhead("CAST") }) <K_CAST> "("
+          type=ColDataType() { result.setSourceType(type); } <K_AS>
+          type=ColDataType() { result.setTargetType(type); } ")" { result.setKind(ExtensionObject.Kind.CAST); }
+        | LOOKAHEAD({ isKeywordAhead("OPERATOR") && !"CLASS".equalsIgnoreCase(getToken(2).image) && !"FAMILY".equalsIgnoreCase(getToken(2).image) })
+          TypeDdlKeyword("OPERATOR") name=ExtensionOperatorName() "("
+          type=ExtensionOperatorType() { result.setSourceType(type); } ","
+          type=ExtensionOperatorType() { result.setTargetType(type); } ")"
+          { result.setKind(ExtensionObject.Kind.OPERATOR); result.setName(name); }
+        | LOOKAHEAD({ isKeywordAhead("TRANSFORM") }) TypeDdlKeyword("TRANSFORM") <K_FOR>
+          type=ColDataType() { result.setSourceType(type); } TypeDdlKeyword("LANGUAGE")
+          name=RelObjectName() { result.setLanguage(name); result.setKind(ExtensionObject.Kind.TRANSFORM); }
+        |
+        (
+            <K_FOREIGN>
+            ( <K_TABLE> { kind = "FOREIGN_TABLE"; }
+              | <K_DATA> TypeDdlKeyword("WRAPPER") { kind = "FOREIGN_DATA_WRAPPER"; } )
+            | LOOKAHEAD(2) <K_MATERIALIZED> <K_VIEW> { kind = "MATERIALIZED_VIEW"; }
+            | LOOKAHEAD({ isKeywordAhead("TEXT") }) <K_TEXT_LITERAL> <K_SEARCH>
+              name=RelObjectName() { kind = "TEXT_SEARCH_" + name; }
+            | LOOKAHEAD({ isKeywordAhead("EVENT") }) <K_EVENT> <K_TRIGGER> { kind = "EVENT_TRIGGER"; }
+            | LOOKAHEAD({ isKeywordAhead("ACCESS") }) TypeDdlKeyword("ACCESS") TypeDdlKeyword("METHOD") { kind = "ACCESS_METHOD"; }
+            | LOOKAHEAD({ isKeywordAhead("OPERATOR") }) TypeDdlKeyword("OPERATOR")
+              name=RelObjectName() { kind = "OPERATOR_" + name; }
+            | LOOKAHEAD({ isKeywordAhead("PROCEDURAL") }) TypeDdlKeyword("PROCEDURAL") TypeDdlKeyword("LANGUAGE")
+              { result.setProcedural(true); kind = "LANGUAGE"; }
+            | kind=RelObjectName()
+        )
+        { result.setKind(typeDdlEnum(ExtensionObject.Kind.class, kind)); }
+        name=TypeDdlName() { result.setName(name); }
+        [ <K_USING> name=RelObjectName() { result.setAccessMethod(name); } ]
+    )
+    {
+        requireTypeDdlSyntax((result.getKind() == ExtensionObject.Kind.OPERATOR_CLASS || result.getKind() == ExtensionObject.Kind.OPERATOR_FAMILY)
+                == (result.getAccessMethod() != null), "USING is required only for operator classes and families");
+        return result;
+    }
+}
+
+AlterExtension AlterExtension():
+{ AlterExtension result = new AlterExtension(); String name; Expression version; ExtensionObject member; }
+{
+    TypeDdlKeyword("EXTENSION") name=RelObjectName() { result.setName(name); }
+    (
+        <K_UPDATE> { result.setAction(AlterExtension.Action.UPDATE); }
+        [ <K_TO> version=ExtensionVersion() { result.setVersion(version); } ]
+        | <K_SET> <K_SCHEMA> name=RelObjectName() { result.setAction(AlterExtension.Action.SET_SCHEMA); result.setSchema(name); }
+        | ( <K_ADD> { result.setAction(AlterExtension.Action.ADD); } | <K_DROP> { result.setAction(AlterExtension.Action.DROP); } )
+          member=ExtensionObject() { result.setMember(member); }
+    )
+    { return result; }
 }
 
 CreatePolicy CreatePolicy() #CreatePolicy:

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -273,6 +273,33 @@ Table constraints expose ``Index.getNullsDistinct()``, ``getIncludeColumns()``, 
 Identity alterations are available as ``ColumnDataType.getIdentityAlterations()``. Sequence ownership is shared by ``CreateSequence`` and ``AlterSequence`` through ``Sequence.getOwnership()``: ``null`` means omitted, ``isNone()`` means explicit ``OWNED BY NONE``, and ``getColumn()`` identifies an owner. ``TablesNamesFinder`` includes ``LIKE`` sources and sequence owners without treating sequence or type names as tables. See `ALTER TABLE <https://www.postgresql.org/docs/18/sql-altertable.html>`_ and `ALTER SEQUENCE <https://www.postgresql.org/docs/18/sql-altersequence.html>`_.
 
 
+Inspect type, domain and extension statements
+=============================================
+
+PostgreSQL type DDL uses the existing column data-type model. A ``CreateType`` exposes its qualified name and a ``TypeDefinition``: ``EnumTypeDefinition``, ``CompositeTypeDefinition`` or ``RangeTypeDefinition``. A null definition denotes a shell type. Enum labels are ordered ``StringValue`` nodes, composite attributes carry a name, ``ColDataType`` and optional collation, and range options distinguish the subtype from names of support functions, collations and operator classes.
+
+.. code-block:: java
+
+    CreateType type = (CreateType) CCJSqlParserUtil.parse(
+            "CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')");
+    EnumTypeDefinition definition = (EnumTypeDefinition) type.getDefinition();
+    String firstLabel = definition.getLabels().get(0).getValue();
+
+    AlterType alteration = (AlterType) CCJSqlParserUtil.parse(
+            "ALTER TYPE mood ADD VALUE IF NOT EXISTS 'fine' AFTER 'ok'");
+    alteration.getPosition();       // AlterType.Position.AFTER
+    alteration.getNeighborValue(); // StringValue containing 'ok'
+
+``AlterType`` also models type ownership, renaming, schema moves and ordered composite-attribute changes. Base-type I/O definitions and base-type ``SET (...)`` alterations are not part of this support.
+
+``CreateDomain`` stores a ``ColDataType``, default expression and ordered ``DomainConstraint`` nodes. Each constraint distinguishes nullability from a check expression and preserves its optional name. ``AlterDomain`` models default/nullability changes, constraint actions, ownership, renaming and schema moves. Its ``isNotValid()`` flag describes the newly added check constraint. Domain expressions participate in statement visitors, expression deparsers and validation.
+
+``CreateExtension`` preserves ``IF NOT EXISTS``, the optional ``WITH``, and ordered schema/version/cascade options. Version identifiers and quoted versions are represented as ``Column`` and ``StringValue``, respectively. ``AlterExtension`` distinguishes update, schema change, and member addition/removal. An ``ExtensionObject`` identifies the object kind and target; function/procedure/aggregate members expose a ``RoutineReference`` with typed signature arguments, not call expressions. A null argument list means the signature was omitted, whereas an empty list means explicit ``()``.
+
+Type names, domain names and routine signatures are not reported as tables by ``TablesNamesFinder``; relation members of an extension are included. Extension scripts themselves are not inspected or executed. The obsolete ``CREATE EXTENSION ... FROM`` form is not supported.
+
+See PostgreSQL's documentation for `CREATE TYPE <https://www.postgresql.org/docs/18/sql-createtype.html>`_, `ALTER TYPE <https://www.postgresql.org/docs/18/sql-altertype.html>`_, `CREATE DOMAIN <https://www.postgresql.org/docs/18/sql-createdomain.html>`_ and `ALTER EXTENSION <https://www.postgresql.org/docs/18/sql-alterextension.html>`_.
+
 Classify a Statement
 ==============================
 

--- a/src/test/java/net/sf/jsqlparser/statement/UnsupportedStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/UnsupportedStatementTest.java
@@ -9,6 +9,8 @@
  */
 package net.sf.jsqlparser.statement;
 
+import net.sf.jsqlparser.statement.create.domain.CreateDomain;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -140,7 +142,7 @@ public class UnsupportedStatementTest {
         sqlStr =
                 "create domain TNOTIFICATION_ACTION as ENUM ('ADD', 'CHANGE', 'DEL')";
         statement = TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
-        assertTrue(statement instanceof UnsupportedStatement);
+        assertInstanceOf(CreateDomain.class, statement);
     }
 
     @Test

--- a/src/test/java/net/sf/jsqlparser/statement/create/PostgreSqlTypeDdlTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/PostgreSqlTypeDdlTest.java
@@ -1,0 +1,213 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static net.sf.jsqlparser.util.validation.ValidationTestAsserts.validateNoErrors;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.StatementVisitorAdapter;
+import net.sf.jsqlparser.statement.StmtFeature;
+import net.sf.jsqlparser.statement.alter.AlterDomain;
+import net.sf.jsqlparser.statement.alter.AlterExtension;
+import net.sf.jsqlparser.statement.alter.AlterType;
+import net.sf.jsqlparser.statement.create.domain.CreateDomain;
+import net.sf.jsqlparser.statement.create.domain.DomainConstraint;
+import net.sf.jsqlparser.statement.create.extension.CreateExtension;
+import net.sf.jsqlparser.statement.create.type.CreateType;
+import net.sf.jsqlparser.statement.create.type.TypeAttribute;
+import net.sf.jsqlparser.statement.create.type.EnumTypeDefinition;
+import net.sf.jsqlparser.statement.create.type.CompositeTypeDefinition;
+import net.sf.jsqlparser.statement.create.type.RangeTypeDefinition;
+import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
+import net.sf.jsqlparser.util.validation.feature.DatabaseType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PostgreSqlTypeDdlTest {
+    static Stream<String> statements() throws Exception {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+                PostgreSqlTypeDdlTest.class.getResourceAsStream("/postgresql/type-ddl.sql"),
+                StandardCharsets.UTF_8))) {
+            return reader.lines().filter(line -> !line.isEmpty()).collect(Collectors.toList())
+                    .stream();
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("statements")
+    void testRoundTripAndValidation(String sql) throws Exception {
+        Statement statement = assertSqlCanBeParsedAndDeparsed(sql);
+        assertThat(statement).isInstanceOfAny(CreateType.class, AlterType.class, CreateDomain.class,
+                AlterDomain.class, CreateExtension.class, AlterExtension.class);
+        assertThat(CCJSqlParserUtil.parse(statement.toString()).toString())
+                .isEqualTo(statement.toString());
+        assertThat(statement.getFeatures().getCertain()).contains(StmtFeature.MODIFIES_SCHEMA)
+                .doesNotContain(StmtFeature.READS_DATA, StmtFeature.RETURNS_RESULT_SET);
+        validateNoErrors(sql, 1, DatabaseType.POSTGRESQL);
+    }
+
+    @Test
+    void testTypeDefinitionsAndConstruction() throws Exception {
+        CreateType enumeration =
+                (CreateType) CCJSqlParserUtil.parse("CREATE TYPE mood AS ENUM ('sad', 'ok')");
+        EnumTypeDefinition definition = (EnumTypeDefinition) enumeration.getDefinition();
+        assertThat(definition.getLabels()).extracting(StringValue::getValue).containsExactly("sad",
+                "ok");
+        definition.getLabels().add(new StringValue("happy"));
+        assertThat(enumeration.toString())
+                .isEqualTo("CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')");
+
+        CreateType composite = (CreateType) CCJSqlParserUtil
+                .parse("CREATE TYPE item AS (name text COLLATE \"C\")");
+        TypeAttribute attribute =
+                ((CompositeTypeDefinition) composite.getDefinition()).getAttributes().get(0);
+        assertThat(attribute.getName()).isEqualTo("name");
+        assertThat(attribute.getDataType().getDataType()).isEqualTo("text");
+        assertThat(attribute.getCollation()).isEqualTo("\"C\"");
+
+        CreateType range = (CreateType) CCJSqlParserUtil
+                .parse("CREATE TYPE r AS RANGE (SUBTYPE = numeric, SUBTYPE_DIFF = app.diff)");
+        RangeTypeDefinition rangeDefinition = (RangeTypeDefinition) range.getDefinition();
+        assertThat(rangeDefinition.getSubtype().getDataType()).isEqualTo("numeric");
+        assertThat(rangeDefinition.getOptions().get(1).getKind())
+                .isEqualTo(RangeTypeDefinition.OptionKind.SUBTYPE_DIFF);
+        assertThat(rangeDefinition.getOptions().get(1).getName()).isEqualTo("app.diff");
+
+        CreateType constructed = new CreateType();
+        constructed.setName("new_mood");
+        constructed.setDefinition(definition);
+        assertThat(CCJSqlParserUtil.parse(constructed.toString()).toString())
+                .isEqualTo(constructed.toString());
+    }
+
+    @Test
+    void testTypeAlterations() throws Exception {
+        AlterType alteration = (AlterType) CCJSqlParserUtil
+                .parse("ALTER TYPE mood ADD VALUE IF NOT EXISTS 'fine' AFTER 'ok'");
+        assertThat(alteration.getAction()).isEqualTo(AlterType.Action.ADD_VALUE);
+        assertThat(alteration.isIfNotExists()).isTrue();
+        assertThat(alteration.getPosition()).isEqualTo(AlterType.Position.AFTER);
+        assertThat(alteration.getValue().getValue()).isEqualTo("fine");
+        assertThat(alteration.getNeighborValue().getValue()).isEqualTo("ok");
+        AlterType attributes = (AlterType) CCJSqlParserUtil.parse(
+                "ALTER TYPE item ADD ATTRIBUTE code text, DROP ATTRIBUTE IF EXISTS price CASCADE");
+        assertThat(attributes.getAttributeChanges()).hasSize(2);
+        assertThat(attributes.getAttributeChanges().get(1).isIfExists()).isTrue();
+        assertThat(attributes.getAttributeChanges().get(1).getBehavior())
+                .isEqualTo(AlterType.Behavior.CASCADE);
+    }
+
+    @Test
+    void testDomainConstraintsAndTraversal() throws Exception {
+        CreateDomain domain = (CreateDomain) CCJSqlParserUtil.parse(
+                "CREATE DOMAIN positive AS integer DEFAULT 1 CONSTRAINT required NOT NULL CHECK (VALUE > 0)");
+        assertThat(domain.isUseAs()).isTrue();
+        assertThat(domain.getConstraints()).extracting(DomainConstraint::getKind)
+                .containsExactly(DomainConstraint.Kind.NOT_NULL, DomainConstraint.Kind.CHECK);
+        assertThat(domain.getConstraints().get(0).getName()).isEqualTo("required");
+        AlterDomain altered = (AlterDomain) CCJSqlParserUtil.parse(
+                "ALTER DOMAIN positive ADD CONSTRAINT positive_check CHECK (VALUE > 1) NOT VALID");
+        assertThat(altered.isNotValid()).isTrue();
+        assertThat(altered.getConstraint().getExpression()).isNotNull();
+
+        List<String> names = new ArrayList<>();
+        ExpressionVisitorAdapter<Void> expressions = new ExpressionVisitorAdapter<Void>() {
+            @Override
+            public <S> Void visit(Column column, S context) {
+                assertThat(context).isEqualTo("domain");
+                names.add(column.getColumnName());
+                return null;
+            }
+        };
+        StatementVisitorAdapter<Void> visitor =
+                new StatementVisitorAdapter<>(new SelectVisitorAdapter<>(expressions));
+        domain.accept(visitor, "domain");
+        altered.accept(visitor, "domain");
+        assertThat(names).containsExactly("VALUE", "VALUE");
+        assertThat(TablesNamesFinder.findTables(domain.toString())).isEmpty();
+    }
+
+    @Test
+    void testDomainExpressionDeparser() throws Exception {
+        for (String sql : new String[] {"CREATE DOMAIN positive AS integer CHECK (VALUE > 0)",
+                "ALTER DOMAIN positive ADD CHECK (VALUE > 0) NOT VALID"}) {
+            StringBuilder output = new StringBuilder();
+            ExpressionDeParser expressions = new ExpressionDeParser() {
+                @Override
+                public <S> StringBuilder visit(Column column, S context) {
+                    return getBuilder().append("new_").append(column.getColumnName());
+                }
+            };
+            Statement statement = CCJSqlParserUtil.parse(sql);
+            statement.accept(new StatementDeParser(expressions, new SelectDeParser(), output));
+            assertThat(output.toString()).contains("new_VALUE");
+            assertThat(statement.toString()).doesNotContain("new_VALUE");
+            CCJSqlParserUtil.parse(output.toString());
+        }
+    }
+
+    @Test
+    void testExtensionOptionsAndRoutineSignatures() throws Exception {
+        CreateExtension extension = (CreateExtension) CCJSqlParserUtil.parse(
+                "CREATE EXTENSION IF NOT EXISTS hstore WITH VERSION '1.8' SCHEMA public CASCADE");
+        assertThat(extension.isIfNotExists()).isTrue();
+        assertThat(extension.isUseWith()).isTrue();
+        assertThat(extension.getOptions()).extracting(CreateExtension.Option::getKind)
+                .containsExactly(CreateExtension.OptionKind.VERSION,
+                        CreateExtension.OptionKind.SCHEMA, CreateExtension.OptionKind.CASCADE);
+        assertThat(extension.getOptions().get(0).getVersion()).isInstanceOf(StringValue.class);
+        AlterExtension alteration = (AlterExtension) CCJSqlParserUtil
+                .parse("ALTER EXTENSION hstore ADD FUNCTION app.f(integer, text[])");
+        assertThat(alteration.getMember().getRoutine().getArguments()).hasSize(2);
+        assertThat(alteration.getMember().getRoutine().getArguments().get(1).getDataType()
+                .getArrayData()).hasSize(1);
+        assertThat(TablesNamesFinder.findTables(alteration.toString())).isEmpty();
+        assertThat(TablesNamesFinder.findTables("ALTER EXTENSION hstore ADD TABLE app.settings"))
+                .containsExactly("app.settings");
+        assertThat(TablesNamesFinder.findTables("CREATE TYPE item AS (id integer)")).isEmpty();
+        assertThat(TablesNamesFinder.findTables("ALTER TYPE item SET SCHEMA app")).isEmpty();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"CREATE OR REPLACE TYPE t AS ENUM ('a')",
+            "CREATE OR REPLACE DOMAIN d AS integer", "CREATE OR REPLACE EXTENSION e",
+            "CREATE TYPE r AS RANGE (UNKNOWN = integer)",
+            "CREATE TYPE r AS RANGE (CANONICAL = f)",
+            "ALTER TYPE mood ADD VALUE ok", "ALTER TYPE item ADD ATTRIBUTE x",
+            "CREATE DOMAIN positive AS integer CHECK ()",
+            "ALTER DOMAIN positive ADD NULL", "ALTER DOMAIN positive ADD NOT NULL NOT VALID",
+            "CREATE EXTENSION hstore FROM '1.0'", "ALTER EXTENSION hstore ADD UNKNOWN app.x",
+            "ALTER EXTENSION hstore ADD FUNCTION f(*)", "ALTER EXTENSION hstore ADD AGGREGATE f"})
+    void testInvalidSyntax(String sql) {
+        assertThatThrownBy(() -> CCJSqlParserUtil.parse(sql))
+                .isInstanceOf(JSQLParserException.class);
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/statement/create/PostgreSqlTypeDdlTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/PostgreSqlTypeDdlTest.java
@@ -56,7 +56,9 @@ class PostgreSqlTypeDdlTest {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(
                 PostgreSqlTypeDdlTest.class.getResourceAsStream("/postgresql/type-ddl.sql"),
                 StandardCharsets.UTF_8))) {
-            return reader.lines().filter(line -> !line.isEmpty()).collect(Collectors.toList())
+            return reader.lines()
+                    .filter(line -> !line.trim().isEmpty() && !line.trim().startsWith("--"))
+                    .collect(Collectors.toList())
                     .stream();
         }
     }

--- a/src/test/resources/postgresql/type-ddl.sql
+++ b/src/test/resources/postgresql/type-ddl.sql
@@ -1,0 +1,75 @@
+CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')
+CREATE TYPE app."Mood" AS ENUM ('can''t', 'OK')
+CREATE TYPE empty_enum AS ENUM ()
+CREATE TYPE shell_type
+CREATE TYPE inventory_item AS (name text, supplier_id integer, price numeric(10, 2))
+CREATE TYPE empty_composite AS ()
+CREATE TYPE localized AS (label text COLLATE pg_catalog."C", tags text[], created timestamp with time zone)
+CREATE TYPE float8range AS RANGE (SUBTYPE = float8, SUBTYPE_DIFF = float8mi)
+CREATE TYPE app.r AS RANGE (SUBTYPE_OPCLASS = pg_catalog.text_ops, SUBTYPE = text, COLLATION = pg_catalog."C", CANONICAL = app.canonical, MULTIRANGE_TYPE_NAME = app.mr)
+ALTER TYPE mood ADD VALUE IF NOT EXISTS 'great' AFTER 'happy'
+ALTER TYPE mood ADD VALUE 'bad' BEFORE 'sad'
+ALTER TYPE mood ADD VALUE 'new'
+ALTER TYPE mood RENAME VALUE 'ok' TO 'fine'
+ALTER TYPE mood OWNER TO CURRENT_USER
+ALTER TYPE mood RENAME TO feeling
+ALTER TYPE mood SET SCHEMA app
+ALTER TYPE inventory_item RENAME ATTRIBUTE name TO title CASCADE
+ALTER TYPE inventory_item ADD ATTRIBUTE sku text COLLATE "C" RESTRICT
+ALTER TYPE inventory_item DROP ATTRIBUTE IF EXISTS price CASCADE
+ALTER TYPE inventory_item ALTER ATTRIBUTE supplier_id SET DATA TYPE bigint RESTRICT
+ALTER TYPE inventory_item ADD ATTRIBUTE sku text, DROP ATTRIBUTE price, ALTER ATTRIBUTE name TYPE varchar(80)
+CREATE DOMAIN positive_integer AS integer CHECK (VALUE > 0)
+CREATE DOMAIN app.label text COLLATE "C" DEFAULT 'ok' CONSTRAINT required NOT NULL CONSTRAINT nonempty CHECK (VALUE <> '')
+CREATE DOMAIN nullable_integer AS integer NULL
+CREATE DOMAIN percent AS numeric(5, 2) DEFAULT 0 CHECK (VALUE >= 0) CHECK (VALUE <= 100)
+ALTER DOMAIN positive_integer ADD CONSTRAINT positive CHECK (VALUE > 0) NOT VALID
+ALTER DOMAIN positive_integer ADD CHECK (VALUE < 100)
+ALTER DOMAIN positive_integer ADD CONSTRAINT required NOT NULL
+ALTER DOMAIN positive_integer SET DEFAULT 1 + 2
+ALTER DOMAIN positive_integer DROP DEFAULT
+ALTER DOMAIN positive_integer SET NOT NULL
+ALTER DOMAIN positive_integer DROP NOT NULL
+ALTER DOMAIN positive_integer DROP CONSTRAINT IF EXISTS positive CASCADE
+ALTER DOMAIN positive_integer DROP CONSTRAINT positive RESTRICT
+ALTER DOMAIN positive_integer RENAME CONSTRAINT positive TO strictly_positive
+ALTER DOMAIN positive_integer VALIDATE CONSTRAINT positive
+ALTER DOMAIN positive_integer OWNER TO SESSION_USER
+ALTER DOMAIN positive_integer RENAME TO positive_number
+ALTER DOMAIN positive_integer SET SCHEMA app
+CREATE EXTENSION hstore
+CREATE EXTENSION IF NOT EXISTS hstore WITH SCHEMA public
+CREATE EXTENSION hstore VERSION '1.8' SCHEMA public CASCADE
+CREATE EXTENSION hstore WITH VERSION version_two
+ALTER EXTENSION hstore UPDATE
+ALTER EXTENSION hstore UPDATE TO '1.8'
+ALTER EXTENSION hstore UPDATE TO version_two
+ALTER EXTENSION hstore SET SCHEMA app
+ALTER EXTENSION hstore ADD TABLE app.settings
+ALTER EXTENSION hstore DROP VIEW app.settings_view
+ALTER EXTENSION hstore ADD MATERIALIZED VIEW app.cached_settings
+ALTER EXTENSION hstore ADD FOREIGN TABLE app.remote_settings
+ALTER EXTENSION hstore ADD FUNCTION app.populate_record(anyelement, hstore)
+ALTER EXTENSION hstore DROP FUNCTION app.populate_record
+ALTER EXTENSION hstore ADD FUNCTION app.f(IN input integer, OUT result text, VARIADIC rest text[])
+ALTER EXTENSION hstore ADD PROCEDURE app.refresh()
+ALTER EXTENSION hstore ADD ROUTINE app.f(double precision, timestamp with time zone)
+ALTER EXTENSION hstore ADD AGGREGATE app.total(integer)
+ALTER EXTENSION hstore ADD AGGREGATE app.count_all(*)
+ALTER EXTENSION hstore ADD AGGREGATE app.percentile(double precision ORDER BY double precision)
+ALTER EXTENSION hstore ADD CAST (text AS hstore)
+ALTER EXTENSION hstore ADD TYPE app.mood
+ALTER EXTENSION hstore ADD DOMAIN app.positive
+ALTER EXTENSION hstore ADD COLLATION app.localized
+ALTER EXTENSION hstore ADD TEXT SEARCH CONFIGURATION app.search
+ALTER EXTENSION hstore ADD TEXT SEARCH DICTIONARY app.words
+ALTER EXTENSION hstore ADD OPERATOR CLASS app.ops USING btree
+ALTER EXTENSION hstore ADD OPERATOR FAMILY app.ops USING gist
+ALTER EXTENSION hstore ADD ACCESS METHOD my_index
+ALTER EXTENSION hstore ADD FOREIGN DATA WRAPPER my_wrapper
+ALTER EXTENSION hstore ADD EVENT TRIGGER install_hook
+ALTER EXTENSION hstore ADD PROCEDURAL LANGUAGE plpgsql
+ALTER EXTENSION hstore ADD TRANSFORM FOR hstore LANGUAGE plpython3u
+ALTER EXTENSION hstore ADD OPERATOR app.&& (integer, integer)
+ALTER EXTENSION hstore DROP OPERATOR = (hstore, hstore)
+ALTER EXTENSION hstore ADD OPERATOR - (NONE, integer)

--- a/src/test/resources/postgresql/type-ddl.sql
+++ b/src/test/resources/postgresql/type-ddl.sql
@@ -1,3 +1,12 @@
+---
+-- #%L
+-- JSQLParser library
+-- %%
+-- Copyright (C) 2004 - 2026 JSQLParser
+-- %%
+-- Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+-- #L%
+---
 CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy')
 CREATE TYPE app."Mood" AS ENUM ('can''t', 'OK')
 CREATE TYPE empty_enum AS ENUM ()


### PR DESCRIPTION
## Summary

Add structured PostgreSQL CREATE/ALTER TYPE, DOMAIN and EXTENSION statements on top of master, independently of the schema DDL PR #2552.

* Enum, composite, range and shell type definitions; enum value placement/renaming, composite attribute changes, ownership, renaming and schema moves.
* Domain defaults, named nullability/check constraints and the corresponding ALTER DOMAIN operations, including NOT VALID.
* Extension schema/version/cascade options, updates, schema moves and typed member targets, including routine signatures, casts and operator classes/families.
* Visitor, deparser, table-name discovery, feature classification and PostgreSQL validation integration, with usage examples.

Type names and routine signatures are not treated as table references. Domain expressions remain editable through expression visitors and deparsers. New StatementVisitor overloads have defaults to preserve compatibility with existing implementations.

Base-type I/O definitions and base-type ALTER TYPE SET properties are outside this PR. The obsolete CREATE EXTENSION FROM form is not included.

## Validation

* Full Gradle check, including formatting, static analysis and tests (Spotless ratcheted against upstream/master locally).
* Maven clean verify and Javadoc generation: 5,455 tests, zero failures/errors, 26 skipped.
* 94 new regression cases, including 75 SQL round trips and additional AST, construction, traversal and rejection tests.
* All 75 inputs and regenerated SQL verified with the PostgreSQL 18 grammar through pglast.
* Seven previously unsupported corpus cases now have concrete ASTs; no regressions among previously modeled cases.
* Parser generation retains the existing 11 warnings.

References: [CREATE TYPE](https://www.postgresql.org/docs/18/sql-createtype.html), [ALTER TYPE](https://www.postgresql.org/docs/18/sql-altertype.html), [CREATE DOMAIN](https://www.postgresql.org/docs/18/sql-createdomain.html), [ALTER DOMAIN](https://www.postgresql.org/docs/18/sql-alterdomain.html), [CREATE EXTENSION](https://www.postgresql.org/docs/18/sql-createextension.html), [ALTER EXTENSION](https://www.postgresql.org/docs/18/sql-alterextension.html).
