### PR TITLE
fix(parser): parse stacked NOT prefixes as nested NotExpression (#1170)

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -7812,13 +7812,16 @@ Expression Condition():
 {
     Expression result;
     Expression left;
-    boolean not = false;
-    boolean exclamationMarkNot = false;
+    // Leading NOT / ! prefixes, leftmost token wraps outermost (issue #1170).
+    final Deque<Boolean> exclamationMarks = new ArrayDeque<Boolean>();
     int oraclePrior = EqualsTo.NO_ORACLE_PRIOR;
     int oracleJoin = EqualsTo.NO_ORACLE_JOIN;
 }
 {
-    [ LOOKAHEAD(2, { getToken(1).kind == K_NOT || "!".equals(getToken(1).image) }) (<K_NOT> { not=true; } | "!" { not=true; exclamationMarkNot=true; })]
+    (
+        LOOKAHEAD({ getToken(1).kind == K_NOT || "!".equals(getToken(1).image) })
+        ( <K_NOT> { exclamationMarks.addFirst(Boolean.FALSE); } | "!" { exclamationMarks.addFirst(Boolean.TRUE); } )
+    )*
     (
         result=ExistsExpression()
         |
@@ -7863,7 +7866,10 @@ Expression Condition():
                 && result instanceof SupportsOldOracleJoinSyntax) {
             ((SupportsOldOracleJoinSyntax) result).setOraclePriorPosition(oraclePrior);
         }
-        return not ? new NotExpression(result, exclamationMarkNot) : result;
+        while (!exclamationMarks.isEmpty()) {
+            result = new NotExpression(result, exclamationMarks.pollFirst());
+        }
+        return result;
     }
 }
 

--- a/src/test/java/net/sf/jsqlparser/expression/ExpressionPrecedenceTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/ExpressionPrecedenceTest.java
@@ -10,9 +10,20 @@
 package net.sf.jsqlparser.expression;
 
 import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.operators.arithmetic.Addition;
 import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseAnd;
 import net.sf.jsqlparser.expression.operators.arithmetic.Concat;
+import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
+import net.sf.jsqlparser.expression.operators.relational.Between;
+import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
+import net.sf.jsqlparser.expression.operators.relational.ExistsExpression;
+import net.sf.jsqlparser.expression.operators.relational.InExpression;
+import net.sf.jsqlparser.expression.operators.relational.IsNullExpression;
+import net.sf.jsqlparser.expression.operators.relational.LikeExpression;
+import net.sf.jsqlparser.expression.operators.relational.ParenthesedExpressionList;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.test.TestUtils;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -29,5 +40,181 @@ public class ExpressionPrecedenceTest {
         Assertions.assertInstanceOf(Concat.class, expr);
         Assertions.assertInstanceOf(BitwiseAnd.class, ((Concat) expr).getLeftExpression());
         Assertions.assertInstanceOf(LongValue.class, ((Concat) expr).getRightExpression());
+    }
+
+    @Test
+    public void testNotNotConditionIssue1170() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil.parseCondExpression("not not 1 = 1");
+        NotExpression outer = Assertions.assertInstanceOf(NotExpression.class, expr);
+        NotExpression inner = Assertions.assertInstanceOf(NotExpression.class,
+                outer.getExpression());
+        Assertions.assertInstanceOf(EqualsTo.class, inner.getExpression());
+        Assertions.assertEquals("NOT NOT 1 = 1", expr.toString());
+    }
+
+    @Test
+    public void testNotNotNotConditionIssue1170() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil.parseCondExpression("not not not 1 = 1");
+        NotExpression first = Assertions.assertInstanceOf(NotExpression.class, expr);
+        NotExpression second = Assertions.assertInstanceOf(NotExpression.class,
+                first.getExpression());
+        NotExpression third = Assertions.assertInstanceOf(NotExpression.class,
+                second.getExpression());
+        Assertions.assertInstanceOf(EqualsTo.class, third.getExpression());
+        Assertions.assertEquals("NOT NOT NOT 1 = 1", expr.toString());
+    }
+
+    @Test
+    public void testNotNotExistsIssue1170() throws JSQLParserException {
+        Expression expr =
+                CCJSqlParserUtil.parseCondExpression("not not exists (select 1 from mytable)");
+        NotExpression outer = Assertions.assertInstanceOf(NotExpression.class, expr);
+        NotExpression inner = Assertions.assertInstanceOf(NotExpression.class,
+                outer.getExpression());
+        Assertions.assertInstanceOf(ExistsExpression.class, inner.getExpression());
+    }
+
+    @Test
+    public void testNotNotInIssue1170() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil.parseCondExpression("not not a in (1, 2)");
+        NotExpression outer = Assertions.assertInstanceOf(NotExpression.class, expr);
+        NotExpression inner = Assertions.assertInstanceOf(NotExpression.class,
+                outer.getExpression());
+        Assertions.assertInstanceOf(InExpression.class, inner.getExpression());
+    }
+
+    @Test
+    public void testNotNotNotBetweenIssue1170() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil.parseCondExpression("not not not a between 1 and 2");
+        NotExpression first = Assertions.assertInstanceOf(NotExpression.class, expr);
+        NotExpression second = Assertions.assertInstanceOf(NotExpression.class,
+                first.getExpression());
+        NotExpression third = Assertions.assertInstanceOf(NotExpression.class,
+                second.getExpression());
+        Assertions.assertInstanceOf(Between.class, third.getExpression());
+    }
+
+    @Test
+    public void testNotNotNotWhereClauseIssue1170() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM mytable WHERE NOT NOT NOT a = 1");
+    }
+
+    @Test
+    public void testMixedNotAndExclamationMarkIssue1170() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil.parseCondExpression("not !1 = 1");
+        NotExpression outer = Assertions.assertInstanceOf(NotExpression.class, expr);
+        Assertions.assertFalse(outer.isExclamationMark());
+        NotExpression inner = Assertions.assertInstanceOf(NotExpression.class,
+                outer.getExpression());
+        Assertions.assertTrue(inner.isExclamationMark());
+        Assertions.assertInstanceOf(EqualsTo.class, inner.getExpression());
+        Assertions.assertEquals("NOT ! 1 = 1", expr.toString());
+    }
+
+    @Test
+    public void testSingleNotConditionStaysFlat() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil.parseCondExpression("not 1 = 1");
+        NotExpression not = Assertions.assertInstanceOf(NotExpression.class, expr);
+        Assertions.assertInstanceOf(EqualsTo.class, not.getExpression());
+    }
+
+    @Test
+    public void testNotNotLikeIssue1170() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil.parseCondExpression("not not a like 'x'");
+        NotExpression outer = Assertions.assertInstanceOf(NotExpression.class, expr);
+        NotExpression inner = Assertions.assertInstanceOf(NotExpression.class,
+                outer.getExpression());
+        LikeExpression like = Assertions.assertInstanceOf(LikeExpression.class,
+                inner.getExpression());
+        Assertions.assertFalse(like.isNot());
+        Assertions.assertInstanceOf(Column.class, like.getLeftExpression());
+    }
+
+    @Test
+    public void testNotNotIsNullIssue1170() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil.parseCondExpression("not not a is null");
+        NotExpression outer = Assertions.assertInstanceOf(NotExpression.class, expr);
+        NotExpression inner = Assertions.assertInstanceOf(NotExpression.class,
+                outer.getExpression());
+        IsNullExpression isNull = Assertions.assertInstanceOf(IsNullExpression.class,
+                inner.getExpression());
+        Assertions.assertFalse(isNull.isNot());
+        Assertions.assertInstanceOf(Column.class, isNull.getLeftExpression());
+    }
+
+    @Test
+    public void testNotNotSimilarToIssue1170() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil.parseCondExpression("not not a similar to 'x'");
+        NotExpression outer = Assertions.assertInstanceOf(NotExpression.class, expr);
+        NotExpression inner = Assertions.assertInstanceOf(NotExpression.class,
+                outer.getExpression());
+        LikeExpression similar = Assertions.assertInstanceOf(LikeExpression.class,
+                inner.getExpression());
+        Assertions.assertFalse(similar.isNot());
+        Assertions.assertInstanceOf(Column.class, similar.getLeftExpression());
+    }
+
+    @Test
+    public void testNotNotInsideAndChainIssue1170() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil.parseCondExpression("a and not not b = 1");
+        AndExpression and = Assertions.assertInstanceOf(AndExpression.class, expr);
+        Assertions.assertInstanceOf(Column.class, and.getLeftExpression());
+        NotExpression outer = Assertions.assertInstanceOf(NotExpression.class,
+                and.getRightExpression());
+        NotExpression inner = Assertions.assertInstanceOf(NotExpression.class,
+                outer.getExpression());
+        EqualsTo equalsTo = Assertions.assertInstanceOf(EqualsTo.class, inner.getExpression());
+        Assertions.assertInstanceOf(Column.class, equalsTo.getLeftExpression());
+    }
+
+    @Test
+    public void testNotNotCaseInsensitiveIssue1170() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil.parseCondExpression("NoT nOt 1 = 1");
+        NotExpression outer = Assertions.assertInstanceOf(NotExpression.class, expr);
+        NotExpression inner = Assertions.assertInstanceOf(NotExpression.class,
+                outer.getExpression());
+        Assertions.assertInstanceOf(EqualsTo.class, inner.getExpression());
+    }
+
+    @Test
+    public void testEightNotIssue1170() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil
+                .parseCondExpression("not not not not not not not not 1 = 1");
+        int depth = 0;
+        while (expr instanceof NotExpression) {
+            expr = ((NotExpression) expr).getExpression();
+            depth++;
+        }
+        Assertions.assertEquals(8, depth);
+        Assertions.assertInstanceOf(EqualsTo.class, expr);
+    }
+
+    @Test
+    public void testNotNotParenthesizedConditionIssue1170() throws JSQLParserException {
+        Expression expr = CCJSqlParserUtil.parseCondExpression("not not (a = 1 and b = 2)");
+        NotExpression outer = Assertions.assertInstanceOf(NotExpression.class, expr);
+        NotExpression inner = Assertions.assertInstanceOf(NotExpression.class,
+                outer.getExpression());
+        Assertions.assertInstanceOf(ParenthesedExpressionList.class, inner.getExpression());
+    }
+
+    @Test
+    public void testNotNotInStatementPositionsIssue1170() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT * FROM t WHERE a IN (SELECT id FROM u WHERE NOT NOT x = 1)");
+        TestUtils.assertSqlCanBeParsedAndDeparsed("UPDATE t SET a = 1 WHERE NOT NOT b = 2");
+        TestUtils.assertSqlCanBeParsedAndDeparsed("DELETE FROM t WHERE NOT NOT b = 2");
+    }
+
+    @Test
+    public void testValuePositionNotStaysOnOperand() throws JSQLParserException {
+        Expression equalsTo = CCJSqlParserUtil.parseCondExpression("a = not 1");
+        EqualsTo eq = Assertions.assertInstanceOf(EqualsTo.class, equalsTo);
+        Assertions.assertInstanceOf(Column.class, eq.getLeftExpression());
+        Assertions.assertInstanceOf(NotExpression.class, eq.getRightExpression());
+
+        Expression addition = CCJSqlParserUtil.parseCondExpression("1 + not 2");
+        Addition add = Assertions.assertInstanceOf(Addition.class, addition);
+        Assertions.assertInstanceOf(NotExpression.class, add.getRightExpression());
     }
 }


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What
Parse stacked leading `NOT` / `!` prefixes as nested `NotExpression`s (one wrap per prefix token) instead of mis-nesting the second `NOT` onto the left operand or failing outright on the third.

## Why
Fixes #1170. `NOT` has the lowest operator precedence and is right-associative, so `not not 1 = 1` must be `NOT (NOT (1 = 1))`. Today the second `NOT` leaks into `PrimaryExpression()` and attaches to the left operand only, silently producing `NOT (NOT 1) = 1` (an `EqualsTo` between a boolean and a number), and a third prefix raises a `ParseException` (`NOT NOT EXISTS (...)` fails the same way).

## How
`Condition()` consumed at most one leading `NOT` / `!` token. The optional prefix is now a loop that consumes all consecutive leading `NOT` / `!` tokens (guarded by the same token check the previous `LOOKAHEAD` used, so the generated parser keeps 11 warnings / 0 choice conflicts) and wraps the parsed condition once per token, leftmost token outermost. The value-position `NOT` prefix in `PrimaryExpression()` (`a = NOT 1`, `1 + NOT 2`) is untouched.

## Root cause
`JSqlParserCC.jjt` `Condition()`: single optional `<K_NOT>` / `"!"` prefix instead of a repetition.

## Testing
- `ExpressionPrecedenceTest`: 17 new tests. On master, 13 fail (wrong tree for double `NOT` with `=` / `IN` / `LIKE` / `IS NULL` / `SIMILAR TO` / inside an `AND` chain / mixed case, and `ParseException` for triple prefix, `NOT NOT EXISTS`, deep stacking); 4 guards pass on both (single prefix stays flat, value-position `a = NOT 1` / `1 + NOT 2`, parenthesized `NOT NOT (...)`, round-trip in subquery / `UPDATE` / `DELETE` `WHERE`). Mutation check: reversing the wrap order fails exactly the mixed `NOT !` test, dropping the wrap loop fails all 16 `NOT`-family tests, removing the value-position `NOT` prefix in `PrimaryExpression()` fails exactly the value-position guard.
- Differential probe over 20+ adjacent forms (single `NOT` with `=` / `LIKE` / `IN` / `BETWEEN` / `IS NULL` / `EXISTS` / `SIMILAR TO`, `a NOT LIKE`, value-position `NOT`, parenthesized, `AND` / `OR` chains, `SELECT` item, `CASE WHEN`, `HAVING`, `JOIN ON`, `CHECK`): master and this branch produce byte-identical trees, so the change only affects stacked-prefix inputs.
- Token audit for the touched tokens: leading `NOT` / `!` uniformly mean logical negation in every supported dialect; `!=` is its own token (`OP_NOTEQUALSBANG`), so the loop can never swallow it; the suffix forms (`NOT IN` / `NOT BETWEEN` / `NOT LIKE` / `IS NOT NULL`) and DDL `NOT` (`NOT NULL`, `NOT DEFERRABLE`) go through other productions and are untouched.
- `./gradlew check`: 5330 tests, 0 failures.
- `gradle jmh`, `JSQLParserBenchmark.parseSQLStatements` on `performance.sql`, `version=latest`, 10 forks × 10 iterations (100 samples), interleaved M→B→M→B on a 32-core host:

| build | ms/op |
|---|---|
| master | 3.895 ± 0.032 |
| branch | 3.916 ± 0.032 |
| master | 3.906 ± 0.031 |
| branch | 3.932 ± 0.040 |

Paired deltas +0.021 / +0.026 ms/op (+0.5 % / +0.7 %) stay inside the run-level confidence intervals in both interleaved pairs → no regression.

## Verification of the original issue
```
// master
CCJSqlParserUtil.parseCondExpression("not not 1 = 1")
  → NotExpression(EqualsTo(NotExpression(1), 1))        // wrong: NOT sits on the left operand
CCJSqlParserUtil.parseCondExpression("not not not 1 = 1")
  → ParseException: Encountered unexpected token: "not" "NOT"

// branch
CCJSqlParserUtil.parseCondExpression("not not 1 = 1")
  → NotExpression(NotExpression(EqualsTo(1, 1)))        // NOT NOT 1 = 1
CCJSqlParserUtil.parseCondExpression("not not not 1 = 1")
  → NotExpression(NotExpression(NotExpression(EqualsTo(1, 1))))  // NOT NOT NOT 1 = 1
```

Fixes #1170
