### PR TITLE
Support Oracle XMLSERIALIZE CONTENT and DOCUMENT forms

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitorAdapter.java
@@ -713,13 +713,7 @@ public class ExpressionVisitorAdapter<T>
 
     @Override
     public <S> T visit(XMLSerializeExpr xmlSerializeExpr, S context) {
-        ArrayList<Expression> subExpressions = new ArrayList<>();
-
-        subExpressions.add(xmlSerializeExpr.getExpression());
-        for (OrderByElement orderByElement : xmlSerializeExpr.getOrderByElements()) {
-            subExpressions.add(orderByElement.getExpression());
-        }
-        return visitExpressions(xmlSerializeExpr, context, subExpressions);
+        return visitExpressions(xmlSerializeExpr, context, xmlSerializeExpr.getExpressions());
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/expression/XMLSerializeExpr.java
+++ b/src/main/java/net/sf/jsqlparser/expression/XMLSerializeExpr.java
@@ -9,7 +9,9 @@
  */
 package net.sf.jsqlparser.expression;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import static java.util.stream.Collectors.joining;
 
@@ -19,9 +21,19 @@ import net.sf.jsqlparser.statement.select.OrderByElement;
 
 public class XMLSerializeExpr extends ASTNodeAccessImpl implements Expression {
 
+    public enum SerializationMode {
+        CONTENT, DOCUMENT
+    }
+
     private Expression expression;
     private List<OrderByElement> orderByElements;
     private ColDataType dataType;
+    private SerializationMode serializationMode;
+    private StringValue encoding;
+    private StringValue version;
+    private Boolean indent;
+    private LongValue indentSize;
+    private Boolean showDefaults;
 
     @Override
     public <T, S> T accept(ExpressionVisitor<T> expressionVisitor, S context) {
@@ -52,11 +64,141 @@ public class XMLSerializeExpr extends ASTNodeAccessImpl implements Expression {
         this.dataType = dataType;
     }
 
+    /** Null retains the legacy XMLAGG(XMLTEXT(...)) form and its existing expression getter. */
+    public SerializationMode getSerializationMode() {
+        return serializationMode;
+    }
+
+    public void setSerializationMode(SerializationMode serializationMode) {
+        this.serializationMode = serializationMode;
+    }
+
+    public StringValue getEncoding() {
+        return encoding;
+    }
+
+    public void setEncoding(StringValue encoding) {
+        this.encoding = encoding;
+    }
+
+    public StringValue getVersion() {
+        return version;
+    }
+
+    public void setVersion(StringValue version) {
+        this.version = version;
+    }
+
+    /** Null preserves omission, true is INDENT, and false is NO INDENT. */
+    public Boolean getIndent() {
+        return indent;
+    }
+
+    public void setIndent(Boolean indent) {
+        this.indent = indent;
+    }
+
+    public LongValue getIndentSize() {
+        return indentSize;
+    }
+
+    public void setIndentSize(LongValue indentSize) {
+        this.indentSize = indentSize;
+    }
+
+    /** Null preserves omission, true is SHOW DEFAULTS, and false is HIDE DEFAULTS. */
+    public Boolean getShowDefaults() {
+        return showDefaults;
+    }
+
+    public void setShowDefaults(Boolean showDefaults) {
+        this.showDefaults = showDefaults;
+    }
+
+    /** Shared child discovery for expression, table-name and validation visitors. */
+    public List<Expression> getExpressions() {
+        List<Expression> result = new ArrayList<>();
+        if (expression != null) {
+            result.add(expression);
+        }
+        if (orderByElements != null) {
+            for (OrderByElement orderBy : orderByElements) {
+                result.add(orderBy.getExpression());
+            }
+        }
+        if (encoding != null) {
+            result.add(encoding);
+        }
+        if (version != null) {
+            result.add(version);
+        }
+        if (indentSize != null) {
+            result.add(indentSize);
+        }
+        return result;
+    }
+
+    /** Render both forms without bypassing custom expression or ORDER BY deparsers. */
+    public StringBuilder appendTo(StringBuilder sql, Consumer<Expression> expressionWriter,
+            Consumer<List<OrderByElement>> orderByWriter) {
+        validateOptions();
+        sql.append("xmlserialize(");
+        if (serializationMode == null) {
+            sql.append("xmlagg(xmltext(");
+            expressionWriter.accept(expression);
+            sql.append(")");
+            if (orderByElements != null) {
+                orderByWriter.accept(orderByElements);
+            }
+            sql.append(") AS ").append(dataType);
+        } else {
+            sql.append(serializationMode).append(" ");
+            expressionWriter.accept(expression);
+            if (dataType != null) {
+                sql.append(" AS ").append(dataType);
+            }
+            if (encoding != null) {
+                sql.append(" ENCODING ");
+                expressionWriter.accept(encoding);
+            }
+            if (version != null) {
+                sql.append(" VERSION ");
+                expressionWriter.accept(version);
+            }
+            if (indent != null) {
+                sql.append(indent ? " INDENT" : " NO INDENT");
+                if (indent && indentSize != null) {
+                    sql.append(" SIZE = ");
+                    expressionWriter.accept(indentSize);
+                }
+            }
+            if (showDefaults != null) {
+                sql.append(showDefaults ? " SHOW DEFAULTS" : " HIDE DEFAULTS");
+            }
+        }
+        return sql.append(")");
+    }
+
+    public void validateOptions() {
+        if (indentSize != null && (!Boolean.TRUE.equals(indent) || indentSize.getValue() < 0)) {
+            throw new IllegalArgumentException(
+                    "An indentation size requires INDENT and must be nonnegative");
+        }
+        if (serializationMode == null && (encoding != null || version != null || indent != null
+                || indentSize != null || showDefaults != null)) {
+            throw new IllegalArgumentException("Serialization options require CONTENT or DOCUMENT");
+        }
+        if (serializationMode != null && orderByElements != null && !orderByElements.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "ORDER BY belongs inside the serialized XMLAGG expression");
+        }
+    }
+
     @Override
     public String toString() {
-        return "xmlserialize(xmlagg(xmltext(" + expression + ")"
-                + (orderByElements != null ? " ORDER BY " + orderByElements.stream()
-                        .map(OrderByElement::toString).collect(joining(", ")) : "")
-                + ") AS " + dataType + ")";
+        StringBuilder sql = new StringBuilder();
+        return appendTo(sql, sql::append, orderBy -> sql.append(" ORDER BY ")
+                .append(orderBy.stream().map(OrderByElement::toString).collect(joining(", "))))
+                .toString();
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -2213,7 +2213,9 @@ public class TablesNamesFinder<Void>
 
     @Override
     public <S> Void visit(XMLSerializeExpr xmlSerializeExpr, S context) {
-
+        for (Expression expression : xmlSerializeExpr.getExpressions()) {
+            expression.accept(this, context);
+        }
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -1653,21 +1653,8 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
 
     @Override
     public <S> StringBuilder visit(XMLSerializeExpr expr, S context) {
-        // xmlserialize(xmlagg(xmltext(COMMENT_LINE) ORDER BY COMMENT_SEQUENCE) as varchar(1024))
-        builder.append("xmlserialize(xmlagg(xmltext(");
-        expr.getExpression().accept(this, context);
-        builder.append(")");
-        if (expr.getOrderByElements() != null) {
-            builder.append(" ORDER BY ");
-            for (Iterator<OrderByElement> i = expr.getOrderByElements().iterator(); i.hasNext();) {
-                builder.append(i.next().toString());
-                if (i.hasNext()) {
-                    builder.append(", ");
-                }
-            }
-        }
-        builder.append(") AS ").append(expr.getDataType()).append(")");
-        return builder;
+        return expr.appendTo(builder, expression -> expression.accept(this, context),
+                orderBy -> new OrderByDeParser(this, builder).deParse(false, orderBy, context));
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/deparser/OrderByDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/OrderByDeParser.java
@@ -36,6 +36,11 @@ public class OrderByDeParser extends AbstractDeParser<List<OrderByElement>> {
     }
 
     public void deParse(boolean oracleSiblings, List<OrderByElement> orderByElementList) {
+        deParse(oracleSiblings, orderByElementList, null);
+    }
+
+    public <S> void deParse(boolean oracleSiblings, List<OrderByElement> orderByElementList,
+            S context) {
         if (oracleSiblings) {
             builder.append(" ORDER SIBLINGS BY ");
         } else {
@@ -45,7 +50,12 @@ public class OrderByDeParser extends AbstractDeParser<List<OrderByElement>> {
         for (Iterator<OrderByElement> iterator = orderByElementList.iterator(); iterator
                 .hasNext();) {
             OrderByElement orderByElement = iterator.next();
-            deParseElement(orderByElement);
+            if (context == null) {
+                // Preserve the customization point used by existing subclasses.
+                deParseElement(orderByElement);
+            } else {
+                deParseElement(orderByElement, context);
+            }
             if (iterator.hasNext()) {
                 builder.append(", ");
             }
@@ -53,7 +63,11 @@ public class OrderByDeParser extends AbstractDeParser<List<OrderByElement>> {
     }
 
     public void deParseElement(OrderByElement orderBy) {
-        orderBy.getExpression().accept(expressionVisitor, null);
+        deParseElement(orderBy, null);
+    }
+
+    public <S> void deParseElement(OrderByElement orderBy, S context) {
+        orderBy.getExpression().accept(expressionVisitor, context);
         if (!orderBy.isAsc()) {
             builder.append(" DESC");
         } else if (orderBy.isAscDescPresent()) {
@@ -67,30 +81,30 @@ public class OrderByDeParser extends AbstractDeParser<List<OrderByElement>> {
         }
         if (orderBy.getWithFill() != null) {
             builder.append(' ');
-            deParseWithFill(orderBy.getWithFill());
+            deParseWithFill(orderBy.getWithFill(), context);
         }
         if (orderBy.isMysqlWithRollup()) {
             builder.append(" WITH ROLLUP");
         }
     }
 
-    private void deParseWithFill(WithFill withFill) {
+    private <S> void deParseWithFill(WithFill withFill, S context) {
         builder.append("WITH FILL");
         if (withFill.getFrom() != null) {
             builder.append(" FROM ");
-            withFill.getFrom().accept(expressionVisitor, null);
+            withFill.getFrom().accept(expressionVisitor, context);
         }
         if (withFill.getTo() != null) {
             builder.append(" TO ");
-            withFill.getTo().accept(expressionVisitor, null);
+            withFill.getTo().accept(expressionVisitor, context);
         }
         if (withFill.getStep() != null) {
             builder.append(" STEP ");
-            withFill.getStep().accept(expressionVisitor, null);
+            withFill.getStep().accept(expressionVisitor, context);
         }
         if (withFill.getStaleness() != null) {
             builder.append(" STALENESS ");
-            withFill.getStaleness().accept(expressionVisitor, null);
+            withFill.getStaleness().accept(expressionVisitor, context);
         }
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/ExpressionValidator.java
@@ -1052,6 +1052,10 @@ public class ExpressionValidator extends AbstractValidator<Expression>
 
     @Override
     public <S> Void visit(XMLSerializeExpr xml, S context) {
+        xml.validateOptions();
+        for (Expression expression : xml.getExpressions()) {
+            expression.accept(this, context);
+        }
         return null;
     }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -10751,26 +10751,51 @@ ExpressionList FunctionArgumentList(Function retval):
 }
 
 XMLSerializeExpr XMLSerializeExpr(): {
-   XMLSerializeExpr result;
+   XMLSerializeExpr result = new XMLSerializeExpr();
    Expression expression;
    List<OrderByElement> orderByElements = null;
    ColDataType dataType;
+   Token token;
 }
 {
-    <K_XMLSERIALIZE>
-        "(" <K_XMLAGG>
+    <K_XMLSERIALIZE> "("
+    (
+        LOOKAHEAD({ isKeywordAhead("CONTENT") || isKeywordAhead("DOCUMENT") })
+        token=<S_IDENTIFIER>
+        { result.setSerializationMode(XMLSerializeExpr.SerializationMode.valueOf(token.image.toUpperCase(Locale.ROOT))); }
+        expression=Expression() { result.setExpression(expression); }
+        [ <K_AS> dataType=ColDataType() { result.setDataType(dataType); } ]
+        [ <K_ENCODING> token=<S_CHAR_LITERAL> { result.setEncoding(new StringValue(token.image)); } ]
+        [ <K_VERSION> token=<S_CHAR_LITERAL> { result.setVersion(new StringValue(token.image)); } ]
+        [
+            LOOKAHEAD(2) <K_NO> token=<S_IDENTIFIER> {
+                requireDdlSyntax("INDENT".equalsIgnoreCase(token.image), "Expected INDENT after NO");
+                result.setIndent(false);
+            }
+            |
+            LOOKAHEAD({ isKeywordAhead("INDENT") }) token=<S_IDENTIFIER> { result.setIndent(true); }
+            [ <K_SIZE> "=" token=<S_LONG> { result.setIndentSize(new LongValue(token.image)); } ]
+        ]
+        [
+            <K_SHOW> <K_DEFAULTS> { result.setShowDefaults(true); }
+            |
+            LOOKAHEAD({ isKeywordAhead("HIDE") }) token=<S_IDENTIFIER> <K_DEFAULTS>
+                { result.setShowDefaults(false); }
+        ]
+        |
+        <K_XMLAGG>
                 "(" <K_XMLTEXT>
                         "(" expression=SimpleExpression() ")"
                 [ orderByElements=OrderByElements() ]
         ")"
-        <K_AS> dataType=ColDataType() ")"
-    {
-        result = new XMLSerializeExpr();
-        result.setExpression(expression);
-        result.setOrderByElements(orderByElements);
-        result.setDataType(dataType);
-        return result;
-    }
+        <K_AS> dataType=ColDataType() {
+            result.setExpression(expression);
+            result.setOrderByElements(orderByElements);
+            result.setDataType(dataType);
+        }
+    )
+    ")"
+    { return result; }
 }
 
 

--- a/src/test/java/net/sf/jsqlparser/expression/XMLSerializeExprTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/XMLSerializeExprTest.java
@@ -1,0 +1,151 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.OrderByElement;
+import net.sf.jsqlparser.test.TestUtils;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.OrderByDeParser;
+import net.sf.jsqlparser.util.validation.validator.ExpressionValidator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class XMLSerializeExprTest {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "SELECT XMLSERIALIZE(CONTENT XMLTYPE('<Owner>Grandco</Owner>')) AS xmlserialize_doc FROM DUAL",
+            "SELECT XMLSERIALIZE(DOCUMENT payload AS CLOB) FROM docs",
+            "SELECT XMLSERIALIZE(CONTENT payload AS VARCHAR2(4000)) FROM docs",
+            "SELECT XMLSERIALIZE(CONTENT payload AS BLOB ENCODING 'UTF-8' VERSION '1.0' INDENT SIZE = 2 SHOW DEFAULTS) FROM docs",
+            "SELECT XMLSERIALIZE(DOCUMENT payload NO INDENT HIDE DEFAULTS) FROM docs",
+            "SELECT XMLSERIALIZE(CONTENT payload INDENT) FROM docs",
+            "SELECT XMLSERIALIZE(CONTENT payload INDENT SIZE = 0) FROM docs",
+            "SELECT XMLSERIALIZE(CONTENT XMLAGG(XMLELEMENT(NAME e, payload) ORDER BY id) AS CLOB) FROM docs",
+            "SELECT XMLSERIALIZE(CONTENT (SELECT payload FROM docs)) FROM DUAL",
+            "SELECT XMLSERIALIZE(CONTENT XMLTYPE('<x>it''s XML</x>') VERSION '1.1') FROM DUAL"
+    })
+    void roundTripOracleSyntax(String sql) throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed(sql);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "XMLSERIALIZE(CONTENT)",
+            "XMLSERIALIZE(DOCUMENT x AS)",
+            "XMLSERIALIZE(CONTENT x NO INDENT SIZE = 2)",
+            "XMLSERIALIZE(CONTENT x INDENT SIZE = -1)",
+            "XMLSERIALIZE(CONTENT x ENCODING UTF8)",
+            "XMLSERIALIZE(CONTENT x VERSION 1)",
+            "XMLSERIALIZE(CONTENT x SHOW)",
+            "XMLSERIALIZE(CONTENT x NO SOMETHING)",
+            "XMLSERIALIZE(CONTENT x INDENT INDENT)"
+    })
+    void rejectMalformedSyntax(String expression) {
+        assertThrows(JSQLParserException.class, () -> CCJSqlParserUtil.parseExpression(expression));
+    }
+
+    @Test
+    void inspectOptionsAndOmission() throws JSQLParserException {
+        XMLSerializeExpr xml = (XMLSerializeExpr) CCJSqlParserUtil.parseExpression(
+                "XMLSERIALIZE(CONTENT payload ENCODING 'UTF-8' VERSION '1.0' INDENT SIZE = 4 SHOW DEFAULTS)");
+        assertEquals(XMLSerializeExpr.SerializationMode.CONTENT, xml.getSerializationMode());
+        assertNull(xml.getDataType());
+        assertEquals("UTF-8", xml.getEncoding().getValue());
+        assertEquals("1.0", xml.getVersion().getValue());
+        assertEquals(Boolean.TRUE, xml.getIndent());
+        assertEquals(4, xml.getIndentSize().getValue());
+        assertEquals(Boolean.TRUE, xml.getShowDefaults());
+        assertEquals(4, xml.getExpressions().size());
+        XMLSerializeExpr omitted = (XMLSerializeExpr) CCJSqlParserUtil.parseExpression(
+                "XMLSERIALIZE(DOCUMENT payload)");
+        assertNull(omitted.getIndent());
+        assertNull(omitted.getShowDefaults());
+        omitted.setIndentSize(new LongValue(2));
+        assertThrows(IllegalArgumentException.class, omitted::validateOptions);
+    }
+
+    @Test
+    void legacyVisitorsHandleAbsentOrderBy() throws JSQLParserException {
+        XMLSerializeExpr xml = (XMLSerializeExpr) CCJSqlParserUtil.parseExpression(
+                "XMLSERIALIZE(XMLAGG(XMLTEXT(payload)) AS VARCHAR(100))");
+        assertNull(xml.getSerializationMode());
+        assertNull(xml.getOrderByElements());
+        List<String> seen = new ArrayList<>();
+        xml.accept(new ExpressionVisitorAdapter<Void>() {
+            @Override
+            public <S> Void visit(Column column, S context) {
+                seen.add(column.getColumnName() + ":" + context);
+                return null;
+            }
+        }, "context");
+        assertEquals(List.of("payload:context"), seen);
+    }
+
+    @Test
+    void visitAndRewriteLegacyOrderByWithContext() throws JSQLParserException {
+        XMLSerializeExpr xml = (XMLSerializeExpr) CCJSqlParserUtil.parseExpression(
+                "XMLSERIALIZE(XMLAGG(XMLTEXT(payload) ORDER BY id DESC NULLS LAST) AS VARCHAR(100))");
+        StringBuilder sql = new StringBuilder();
+        ExpressionDeParser writer = new ExpressionDeParser() {
+            @Override
+            public <S> StringBuilder visit(Column column, S context) {
+                assertEquals("context", context);
+                return getBuilder().append("new_").append(column.getColumnName());
+            }
+        };
+        writer.setBuilder(sql);
+        xml.accept(writer, "context");
+        assertEquals(
+                "xmlserialize(xmlagg(xmltext(new_payload) ORDER BY new_id DESC NULLS LAST) AS VARCHAR (100))",
+                sql.toString());
+        List<String> seen = new ArrayList<>();
+        xml.accept(new ExpressionValidator() {
+            @Override
+            public <S> Void visit(Column column, S context) {
+                seen.add(column.getColumnName());
+                assertEquals("context", context);
+                return null;
+            }
+        }, "context");
+        assertEquals(List.of("payload", "id"), seen);
+    }
+
+    @Test
+    void discoverTablesInSerializedSubquery() throws JSQLParserException {
+        PlainSelect select = (PlainSelect) CCJSqlParserUtil.parse(
+                "SELECT XMLSERIALIZE(CONTENT (SELECT payload FROM docs)) FROM outer_source");
+        assertTrue(
+                new TablesNamesFinder().getTableList((net.sf.jsqlparser.statement.Statement) select)
+                        .containsAll(List.of("docs", "outer_source")));
+    }
+
+    @Test
+    void preserveLegacyOrderByCustomization() {
+        StringBuilder sql = new StringBuilder();
+        OrderByDeParser writer = new OrderByDeParser(new ExpressionDeParser(), sql) {
+            @Override
+            public void deParseElement(OrderByElement element) {
+                getBuilder().append("custom_order");
+            }
+        };
+        writer.deParse(false, List.of(new OrderByElement().withExpression(new Column("id"))));
+        assertEquals(" ORDER BY custom_order", sql.toString());
+    }
+}


### PR DESCRIPTION
Fixes #1564

### Changes

- Extend XMLSerializeExpr with Oracle CONTENT/DOCUMENT value expressions, optional datatype, ENCODING, VERSION, indentation, and HIDE/SHOW DEFAULTS.
- Keep the existing XMLAGG(XMLTEXT(...)) form and its expression/order-by getters compatible. Omitted Oracle options remain omitted in the AST and output.
- Share rendering between toString and ExpressionDeParser, and share child discovery across expression, table-name, and validation visitors.
- Fix the absent-ORDER-BY visitor null dereference and traverse serialized subqueries/options. Honor custom expression deparsers for legacy ORDER BY expressions with visitor context.
- Add context-aware OrderByDeParser overloads while preserving existing subclass customization points.

### Verification

- Full Gradle check (tests, Checkstyle, PMD, Spotless).
- Maven clean verify with Java 17.
- Oracle and legacy round-trips, malformed options, omission/AST inspection, visitor and custom deparser regressions, and table discovery in serialized subqueries.

Reference: [Oracle XMLSERIALIZE](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/XMLSERIALIZE.html).
