### PR TITLE
Support PostgreSQL conflict index elements, OVERRIDING USER and MERGE RETURNING

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/ReturningClause.java
+++ b/src/main/java/net/sf/jsqlparser/statement/ReturningClause.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.MultiPartName;
@@ -86,6 +87,10 @@ public class ReturningClause extends ArrayList<SelectItem<?>> {
     }
 
     public StringBuilder appendTo(StringBuilder builder) {
+        return appendTo(builder, item -> builder.append(item));
+    }
+
+    public StringBuilder appendTo(StringBuilder builder, Consumer<SelectItem<?>> itemPrinter) {
         builder.append(" ").append(keyword).append(" ");
         if (outputAliases != null && !outputAliases.isEmpty()) {
             builder.append("WITH (");
@@ -101,7 +106,7 @@ public class ReturningClause extends ArrayList<SelectItem<?>> {
             if (i > 0) {
                 builder.append(", ");
             }
-            builder.append(get(i));
+            itemPrinter.accept(get(i));
         }
 
         if (dataItems != null && !dataItems.isEmpty()) {

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
@@ -296,6 +296,9 @@ public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
             expressionVisitor.visitUpdateSets(conflictAction.getUpdateSets(), context);
         }
 
+        if (insert.getConflictTarget() != null) {
+            insert.getConflictTarget().accept(expressionVisitor, context);
+        }
         visitReturningClause(insert.getReturningClause(), context);
         return null;
     }
@@ -457,6 +460,7 @@ public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
         expressionVisitor.visitExpression(merge.getOnCondition(), context);
         mergeOperationVisitor.visit(merge.getOperations(), context);
         selectVisitor.visitOutputClause(merge.getOutputClause(), context);
+        visitReturningClause(merge.getReturningClause(), context);
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
@@ -331,6 +331,7 @@ public class Index implements TableElement, Serializable {
         public final String columnName;
         public final List<String> params;
         private final Expression expression;
+        private boolean expressionParenthesized = true;
         private String collation;
         private String operatorClass;
         private List<Option> operatorClassParameters;
@@ -384,6 +385,19 @@ public class Index implements TableElement, Serializable {
 
         public boolean isExpression() {
             return expression != null;
+        }
+
+        public boolean isExpressionParenthesized() {
+            return expressionParenthesized;
+        }
+
+        public void setExpressionParenthesized(boolean expressionParenthesized) {
+            this.expressionParenthesized = expressionParenthesized;
+        }
+
+        public ColumnParams withExpressionParenthesized(boolean expressionParenthesized) {
+            setExpressionParenthesized(expressionParenthesized);
+            return this;
         }
 
         public String getCollation() {
@@ -461,9 +475,13 @@ public class Index implements TableElement, Serializable {
         /** Renders expression keys through the caller's expression printer. */
         public void appendTo(StringBuilder builder, Consumer<Expression> expressionPrinter) {
             if (expression != null) {
-                builder.append('(');
+                if (expressionParenthesized) {
+                    builder.append('(');
+                }
                 expressionPrinter.accept(expression);
-                builder.append(')');
+                if (expressionParenthesized) {
+                    builder.append(')');
+                }
             } else {
                 builder.append(columnName);
             }

--- a/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/Insert.java
@@ -40,7 +40,12 @@ public class Insert implements Statement {
     private List<Partition> partitions;
     private Select select;
     private boolean onlyDefaultValues = false;
-    private boolean overriding = false;
+
+    public enum OverridingMode {
+        NONE, SYSTEM, USER
+    }
+
+    private OverridingMode overridingMode = OverridingMode.NONE;
     private List<UpdateSet> duplicateUpdateSets = null;
     private InsertModifierPriority modifierPriority = null;
     private boolean modifierIgnore = false;
@@ -226,12 +231,25 @@ public class Insert implements Statement {
         this.withItemsList = withItemsList;
     }
 
+    public OverridingMode getOverridingMode() {
+        return overridingMode;
+    }
+
+    public void setOverridingMode(OverridingMode overridingMode) {
+        this.overridingMode = java.util.Objects.requireNonNull(overridingMode);
+    }
+
+    public Insert withOverridingMode(OverridingMode overridingMode) {
+        setOverridingMode(overridingMode);
+        return this;
+    }
+
     public boolean isOverriding() {
-        return overriding;
+        return overridingMode != OverridingMode.NONE;
     }
 
     public void setOverriding(boolean overriding) {
-        this.overriding = overriding;
+        this.overridingMode = overriding ? OverridingMode.SYSTEM : OverridingMode.NONE;
     }
 
     public Insert withOverriding(boolean overriding) {
@@ -388,8 +406,8 @@ public class Insert implements Statement {
             sql.append(") ");
         }
 
-        if (overriding) {
-            sql.append("OVERRIDING SYSTEM VALUE ");
+        if (isOverriding()) {
+            sql.append("OVERRIDING ").append(overridingMode).append(" VALUE ");
         }
 
         if (partitions != null) {

--- a/src/main/java/net/sf/jsqlparser/statement/insert/InsertConflictTarget.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/InsertConflictTarget.java
@@ -10,6 +10,9 @@
 package net.sf.jsqlparser.statement.insert;
 
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.statement.create.table.Index;
+import java.util.function.Consumer;
 
 import java.io.Serializable;
 import java.util.*;
@@ -23,75 +26,130 @@ import java.util.*;
  *     ( { index_column_name | ( index_expression ) } [ COLLATE collation ] [ opclass ] [, ...] ) [ WHERE index_predicate ]
  *     ON CONSTRAINT constraint_name
  * </pre>
- * <p>
- * Currently, COLLATE is not supported yet.
  */
 public class InsertConflictTarget implements Serializable {
+    private final List<Index.ColumnParams> indexElements = new ArrayList<>();
+    private Expression whereExpression;
+    private String constraintName;
 
-    ArrayList<String> indexColumnNames = new ArrayList<>();
-    Expression indexExpression;
-    Expression whereExpression;
-    String constraintName;
+    public InsertConflictTarget() {}
 
     public InsertConflictTarget(String indexColumnName, Expression indexExpression,
             Expression whereExpression, String constraintName) {
-        this.indexColumnNames.add(indexColumnName);
-        this.indexExpression = indexExpression;
-
-        this.whereExpression = whereExpression;
-        this.constraintName = constraintName;
+        this(indexColumnName == null ? Collections.emptyList()
+                : Collections.singletonList(indexColumnName),
+                indexExpression, whereExpression, constraintName);
     }
 
-    public InsertConflictTarget(Collection<String> indexColumnName, Expression indexExpression,
+    public InsertConflictTarget(Collection<String> indexColumnNames, Expression indexExpression,
             Expression whereExpression, String constraintName) {
-        this.indexColumnNames.addAll(indexColumnName);
-        this.indexExpression = indexExpression;
-
+        if (indexColumnNames != null && !indexColumnNames.isEmpty()) {
+            addAllIndexColumnNames(indexColumnNames);
+        } else if (indexExpression != null) {
+            setIndexExpression(indexExpression);
+        }
         this.whereExpression = whereExpression;
         this.constraintName = constraintName;
     }
 
+    /** Ordered column and expression keys, including their collation and operator class. */
+    public List<Index.ColumnParams> getIndexElements() {
+        return indexElements;
+    }
+
+    public void setIndexElements(List<Index.ColumnParams> elements) {
+        List<Index.ColumnParams> copy = new ArrayList<>(elements);
+        indexElements.clear();
+        indexElements.addAll(copy);
+    }
+
+    public InsertConflictTarget withIndexElements(List<Index.ColumnParams> elements) {
+        setIndexElements(elements);
+        return this;
+    }
+
+    /** A mutable view of the column keys; expression keys are available via getIndexElements(). */
     public List<String> getIndexColumnNames() {
-        return indexColumnNames;
+        return new AbstractList<String>() {
+            private int elementIndex(int index) {
+                int columnIndex = 0;
+                for (int i = 0; i < indexElements.size(); i++) {
+                    if (!indexElements.get(i).isExpression() && columnIndex++ == index) {
+                        return i;
+                    }
+                }
+                throw new IndexOutOfBoundsException("Column index: " + index);
+            }
+
+            @Override
+            public String get(int index) {
+                return indexElements.get(elementIndex(index)).getColumnName();
+            }
+
+            @Override
+            public int size() {
+                return (int) indexElements.stream().filter(key -> !key.isExpression()).count();
+            }
+
+            @Override
+            public String set(int index, String name) {
+                return indexElements.set(elementIndex(index), new Index.ColumnParams(name))
+                        .getColumnName();
+            }
+
+            @Override
+            public void add(int index, String name) {
+                indexElements.add(index == size() ? indexElements.size() : elementIndex(index),
+                        new Index.ColumnParams(name));
+            }
+
+            @Override
+            public String remove(int index) {
+                return indexElements.remove(elementIndex(index)).getColumnName();
+            }
+        };
     }
 
     @Deprecated
     public String getIndexColumnName() {
-        return indexColumnNames.isEmpty() ? null : indexColumnNames.get(0);
+        return getIndexColumnName(0);
     }
 
     public String getIndexColumnName(int index) {
-        return indexColumnNames.size() > index ? indexColumnNames.get(index) : null;
+        List<String> names = getIndexColumnNames();
+        return names.size() > index ? names.get(index) : null;
     }
 
-    public boolean addIndexColumnName(String indexColumnName) {
-        this.indexExpression = null;
-        return this.indexColumnNames.add(indexColumnName);
+    public boolean addIndexColumnName(String name) {
+        indexElements.removeIf(Index.ColumnParams::isExpression);
+        return indexElements.add(new Index.ColumnParams(name));
     }
 
-    public InsertConflictTarget withIndexColumnName(String indexColumnName) {
-        this.indexExpression = null;
-        this.indexColumnNames.add(indexColumnName);
+    public InsertConflictTarget withIndexColumnName(String name) {
+        addIndexColumnName(name);
         return this;
     }
 
-    public boolean addAllIndexColumnNames(Collection<String> indexColumnName) {
-        this.indexExpression = null;
-        return this.indexColumnNames.addAll(indexColumnName);
+    public boolean addAllIndexColumnNames(Collection<String> names) {
+        indexElements.removeIf(Index.ColumnParams::isExpression);
+        return getIndexColumnNames().addAll(names);
     }
 
-
+    /** Returns the first expression key, or null for a column-only target. */
     public Expression getIndexExpression() {
-        return indexExpression;
+        return indexElements.stream().filter(Index.ColumnParams::isExpression)
+                .map(Index.ColumnParams::getExpression).findFirst().orElse(null);
     }
 
-    public void setIndexExpression(Expression indexExpression) {
-        this.indexExpression = indexExpression;
-        this.indexColumnNames.clear();
+    public void setIndexExpression(Expression expression) {
+        indexElements.clear();
+        if (expression != null) {
+            indexElements.add(new Index.ColumnParams(expression));
+        }
     }
 
-    public InsertConflictTarget withIndexExpression(Expression indexExpression) {
-        setIndexExpression(indexExpression);
+    public InsertConflictTarget withIndexExpression(Expression expression) {
+        setIndexExpression(expression);
         return this;
     }
 
@@ -121,35 +179,42 @@ public class InsertConflictTarget implements Serializable {
         return this;
     }
 
+    /** Visits expression keys and the optional index predicate. */
+    public <S> void accept(ExpressionVisitor<?> visitor, S context) {
+        for (Index.ColumnParams element : indexElements) {
+            if (element.getExpression() != null) {
+                element.getExpression().accept(visitor, context);
+            }
+        }
+        if (whereExpression != null) {
+            whereExpression.accept(visitor, context);
+        }
+    }
+
     public StringBuilder appendTo(StringBuilder builder) {
-        if (constraintName == null) {
-            builder.append(" ( ");
+        return appendTo(builder, expression -> builder.append(expression));
+    }
 
-            // @todo: Index Expression is not supported yet
-            if (!indexColumnNames.isEmpty()) {
-                boolean insertComma = false;
-                for (String s : indexColumnNames) {
-                    builder.append(insertComma ? ", " : " ").append(s);
-                    insertComma |= true;
-                }
-            } else {
-                builder.append(" ( ").append(indexExpression).append(" )");
+    public StringBuilder appendTo(StringBuilder builder, Consumer<Expression> expressionPrinter) {
+        if (constraintName != null) {
+            return builder.append(" ON CONSTRAINT ").append(constraintName);
+        }
+        builder.append(" (");
+        for (int i = 0; i < indexElements.size(); i++) {
+            if (i > 0) {
+                builder.append(", ");
             }
-            builder.append(" ");
-
-            // @todo: Collate is not supported yet
-
-            builder.append(") ");
-
-            if (whereExpression != null) {
-                builder.append(" WHERE ").append(whereExpression);
-            }
-        } else {
-            builder.append(" ON CONSTRAINT ").append(constraintName);
+            indexElements.get(i).appendTo(builder, expressionPrinter);
+        }
+        builder.append(")");
+        if (whereExpression != null) {
+            builder.append(" WHERE ");
+            expressionPrinter.accept(whereExpression);
         }
         return builder;
     }
 
+    @Override
     public String toString() {
         return appendTo(new StringBuilder()).toString();
     }

--- a/src/main/java/net/sf/jsqlparser/statement/insert/InsertConflictTarget.java
+++ b/src/main/java/net/sf/jsqlparser/statement/insert/InsertConflictTarget.java
@@ -104,6 +104,21 @@ public class InsertConflictTarget implements Serializable {
             }
 
             @Override
+            public boolean addAll(Collection<? extends String> names) {
+                return addAll(size(), names);
+            }
+
+            @Override
+            public boolean addAll(int index, Collection<? extends String> names) {
+                int insertionIndex = index == size() ? indexElements.size() : elementIndex(index);
+                List<Index.ColumnParams> additions = new ArrayList<>();
+                for (String name : names) {
+                    additions.add(new Index.ColumnParams(name));
+                }
+                return indexElements.addAll(insertionIndex, additions);
+            }
+
+            @Override
             public String remove(int index) {
                 return indexElements.remove(elementIndex(index)).getColumnName();
             }

--- a/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
+++ b/src/main/java/net/sf/jsqlparser/statement/merge/Merge.java
@@ -14,6 +14,7 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.OutputClause;
+import net.sf.jsqlparser.statement.ReturningClause;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.StatementVisitor;
 import net.sf.jsqlparser.statement.select.FromItem;
@@ -41,8 +42,22 @@ public class Merge implements Statement {
     private boolean insertFirst = false;
     private List<MergeOperation> operations;
 
+    private ReturningClause returningClause;
     private OutputClause outputClause;
     private OptionClause option;
+
+    public ReturningClause getReturningClause() {
+        return returningClause;
+    }
+
+    public Merge setReturningClause(ReturningClause returningClause) {
+        this.returningClause = returningClause;
+        return this;
+    }
+
+    public Merge withReturningClause(ReturningClause returningClause) {
+        return setReturningClause(returningClause);
+    }
 
     private void deriveOperationsFromStandardClauses() {
         List<MergeOperation> operations = new ArrayList<>();
@@ -257,6 +272,10 @@ public class Merge implements Statement {
 
         if (operations != null && !operations.isEmpty()) {
             operations.forEach(b::append);
+        }
+
+        if (returningClause != null) {
+            returningClause.appendTo(b);
         }
 
         if (outputClause != null) {

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -1458,6 +1458,9 @@ public class TablesNamesFinder<Void>
         if (insert.getConflictAction() != null) {
             visitInsertAction(insert.getConflictAction(), context);
         }
+        if (insert.getConflictTarget() != null) {
+            insert.getConflictTarget().accept(this, context);
+        }
         visitOutputClause(insert.getOutputClause(), context);
         visitReturningClause(insert.getReturningClause(), context);
         if (insert.getSelect() != null) {
@@ -1786,6 +1789,7 @@ public class TablesNamesFinder<Void>
                 operation.accept(this, context);
             }
         }
+        visitReturningClause(merge.getReturningClause(), context);
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -842,7 +842,9 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
                 tableName = table.getFullyQualifiedName();
             }
         }
-        if (tableName != null && !tableName.isEmpty()) {
+        if (tableColumn.getReturningQualifier() != null) {
+            builder.append(tableColumn.getReturningQualifier()).append(".");
+        } else if (tableName != null && !tableName.isEmpty()) {
             builder.append(tableName).append(tableColumn.getTableDelimiter());
         }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/InsertDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/InsertDeParser.java
@@ -105,7 +105,7 @@ public class InsertDeParser extends AbstractDeParser<Insert> {
         }
 
         if (insert.isOverriding()) {
-            builder.append("OVERRIDING SYSTEM VALUE ");
+            builder.append(" OVERRIDING ").append(insert.getOverridingMode()).append(" VALUE");
         }
 
         if (insert.getPartitions() != null) {
@@ -147,7 +147,8 @@ public class InsertDeParser extends AbstractDeParser<Insert> {
             builder.append(" ON CONFLICT");
 
             if (insert.getConflictTarget() != null) {
-                insert.getConflictTarget().appendTo(builder);
+                insert.getConflictTarget().appendTo(builder,
+                        expression -> expression.accept(expressionVisitor, null));
             }
             insert.getConflictAction().appendTo(builder);
         }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/MergeDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/MergeDeParser.java
@@ -60,6 +60,11 @@ public class MergeDeParser extends AbstractDeParser<Merge>
             operations.forEach(operation -> operation.accept(this, null));
         }
 
+        if (merge.getReturningClause() != null) {
+            merge.getReturningClause().appendTo(builder,
+                    item -> item.accept(selectDeParser, null));
+        }
+
         if (merge.getOutputClause() != null) {
             merge.getOutputClause().appendTo(builder);
         }

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/InsertValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/InsertValidator.java
@@ -94,6 +94,10 @@ public class InsertValidator extends AbstractValidator<Insert> {
             }
         }
 
+        if (insert.getConflictTarget() != null) {
+            insert.getConflictTarget().accept(getValidator(ExpressionValidator.class), null);
+        }
+
         if (insert.getReturningClause() != null) {
             SelectValidator v = getValidator(SelectValidator.class);
             insert.getReturningClause().forEach(c -> c.accept(v, null));

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/MergeValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/MergeValidator.java
@@ -27,6 +27,10 @@ public class MergeValidator<Void> extends AbstractValidator<Merge>
         for (ValidationCapability c : getCapabilities()) {
             validateFeature(c, Feature.merge);
         }
+        if (merge.getReturningClause() != null) {
+            SelectValidator validator = getValidator(SelectValidator.class);
+            merge.getReturningClause().forEach(item -> item.accept(validator, null));
+        }
         validateOptionalExpression(merge.getOnCondition());
         if (merge.getOperations() != null) {
             merge.getOperations().forEach(operation -> operation.accept(this, null));

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4640,11 +4640,15 @@ Insert Insert():
             ]   table=Table()
             [ LOOKAHEAD(2) <K_PARTITION> "(" partitions=Partitions() ")" ]
 
-            [ LOOKAHEAD({ isAliasAhead() }) [<K_AS> { useAs = true; } ] name=RelObjectName() { table.setAlias(new Alias(name,useAs)); }]
+            [ LOOKAHEAD({ isAliasAhead() && !(getToken(1).kind == K_OVERRIDING
+                    && (getToken(2).kind == K_SYSTEM || getToken(2).kind == K_USER)) })
+                [<K_AS> { useAs = true; } ] name=RelObjectName() { table.setAlias(new Alias(name,useAs)); }]
 
             [ LOOKAHEAD(2) "(" columns=ColumnList() ")"  ]
 
-            [ LOOKAHEAD(2) <K_OVERRIDING> <K_SYSTEM> <K_VALUE> { insert.setOverriding(true); } ]
+            [ LOOKAHEAD(2) <K_OVERRIDING>
+                ( <K_SYSTEM> { insert.setOverridingMode(Insert.OverridingMode.SYSTEM); }
+                | <K_USER> { insert.setOverridingMode(Insert.OverridingMode.USER); } ) <K_VALUE> ]
 
             [ outputClause = OutputClause() { insert.setOutputClause(outputClause); } ]
 
@@ -4762,35 +4766,46 @@ List<OracleMultiInsertClause> OracleMultiInsertClauseList():
     }
 }
 
-InsertConflictTarget  InsertConflictTarget():
+InsertConflictTarget InsertConflictTarget():
 {
-    String indexColumnName;
-    ArrayList<String> indexColumnNames = new ArrayList<String>();
-    Expression indexExpression = null;
-    Expression whereExpression = null;
-    String constraintName = null ;
+    InsertConflictTarget target = new InsertConflictTarget();
+    List<Index.ColumnParams> elements = new ArrayList<Index.ColumnParams>();
+    Index.ColumnParams element;
+    Expression whereExpression;
+    String constraintName;
 }
 {
     (
-        (
-            "("
-            indexColumnName = RelObjectNameExt() { indexColumnNames.add(indexColumnName); }
-            ( "," indexColumnName = RelObjectNameExt() { indexColumnNames.add(indexColumnName); } )*
-//            |
-//            (
-//                "(" indexExpression = Expression() ")"
-//            )
-
-            ")"
-            [ whereExpression = WhereClause() ]
-        )
+        "(" element=InsertConflictIndexElement() { elements.add(element); }
+        ( "," element=InsertConflictIndexElement() { elements.add(element); } )* ")"
+        { target.setIndexElements(elements); }
+        [ whereExpression=WhereClause() { target.setWhereExpression(whereExpression); } ]
         |
-        (
-         <K_ON> <K_CONSTRAINT> constraintName = RelObjectNameExt()
-        )
+        <K_ON> <K_CONSTRAINT> constraintName=RelObjectNameExt()
+        { target.setConstraintName(constraintName); }
     )
+    { return target; }
+}
 
-    { return new InsertConflictTarget(indexColumnNames, indexExpression, whereExpression, constraintName); }
+Index.ColumnParams InsertConflictIndexElement():
+{
+    Index.ColumnParams element;
+    String name;
+    Expression expression;
+    ObjectNames collation;
+    ObjectNames operatorClass;
+}
+{
+    (
+        LOOKAHEAD({ isFunctionAhead() }) expression=Function()
+        { element = new Index.ColumnParams(expression).withExpressionParenthesized(false); }
+        | name=RelObjectNameExt() { element = new Index.ColumnParams(name); }
+        | "(" expression=Expression() ")" { element = new Index.ColumnParams(expression); }
+    )
+    [ LOOKAHEAD(2) <K_COLLATE> collation=RelObjectNames()
+        { element.setCollation(new Table(collation.getNames()).getFullyQualifiedName()); } ]
+    [ LOOKAHEAD(2) operatorClass=RelObjectNames() { element.setOperatorClass(new Table(operatorClass.getNames()).getFullyQualifiedName()); } ]
+    { return element; }
 }
 
 InsertConflictAction InsertConflictAction():
@@ -4989,6 +5004,7 @@ Statement Merge( List<WithItem<?>> with ) : {
     Expression condition;
     List<MergeOperation> operations;
     OutputClause outputClause;
+    ReturningClause returningClause;
     OptionClause optionClause = null;
 }
 {
@@ -4997,6 +5013,8 @@ Statement Merge( List<WithItem<?>> with ) : {
     <K_ON> condition = Expression() { merge.setOnCondition(condition); }
 
     operations = MergeOperations() { merge.setOperations(operations); }
+
+    [ returningClause = ReturningClause() { merge.setReturningClause(returningClause); } ]
 
     [ outputClause = OutputClause() { merge.setOutputClause(outputClause); } ]
 

--- a/src/test/java/net/sf/jsqlparser/statement/insert/PostgreSQLConflictTargetTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/insert/PostgreSQLConflictTargetTest.java
@@ -111,6 +111,19 @@ class PostgreSQLConflictTargetTest {
     }
 
     @Test
+    void bulkColumnAdditionsSnapshotTheMutableView() {
+        InsertConflictTarget target = new InsertConflictTarget("id", null, null, null);
+        List<String> names = target.getIndexColumnNames();
+        assertTrue(target.addAllIndexColumnNames(names));
+        assertEquals(List.of("id", "id"), names);
+        assertTrue(names.addAll(names));
+        assertEquals(4, names.size());
+        assertTrue(names.addAll(1, names.subList(0, 2)));
+        assertEquals(6, names.size());
+        assertFalse(names.addAll(List.of()));
+    }
+
+    @Test
     void statementVisitorTraversesTargetExpressions() throws Exception {
         Insert insert = (Insert) CCJSqlParserUtil.parse("INSERT INTO users VALUES (1) "
                 + "ON CONFLICT ((lower(email))) WHERE active DO NOTHING");

--- a/src/test/java/net/sf/jsqlparser/statement/insert/PostgreSQLConflictTargetTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/insert/PostgreSQLConflictTargetTest.java
@@ -1,0 +1,164 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.insert;
+
+import java.util.ArrayList;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.statement.StatementVisitorAdapter;
+import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+
+import net.sf.jsqlparser.expression.Function;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.create.table.Index;
+import net.sf.jsqlparser.test.TestUtils;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PostgreSQLConflictTargetTest {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "(id, (lower(email)))",
+            "(id, lower(email))",
+            "(pg_catalog.lower(email) COLLATE pg_catalog.\"C\" pg_catalog.text_pattern_ops, id)",
+            "((lower(email)), id, (abs(region))) WHERE active",
+            "(email COLLATE \"C\" text_pattern_ops, id)",
+            "((lower(email)) COLLATE pg_catalog.\"C\" pg_catalog.text_pattern_ops)",
+            "ON CONSTRAINT users_pkey"
+    })
+    void parsesAndReparsesConflictTargets(String target) throws Exception {
+        String sql = "INSERT INTO users (id, email) VALUES (1, 'a') ON CONFLICT "
+                + target + " DO UPDATE SET email = excluded.email RETURNING id";
+        Insert insert = (Insert) TestUtils.assertSqlCanBeParsedAndDeparsed(sql, true);
+        assertEquals(insert.toString(), CCJSqlParserUtil.parse(insert.toString()).toString());
+    }
+
+    @Test
+    void preservesFunctionKeyParentheses() throws Exception {
+        Insert insert = (Insert) TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO users VALUES (1) ON CONFLICT (lower(email), (abs(region))) DO NOTHING",
+                true);
+        List<Index.ColumnParams> keys = insert.getConflictTarget().getIndexElements();
+        assertInstanceOf(Function.class, keys.get(0).getExpression());
+        assertFalse(keys.get(0).isExpressionParenthesized());
+        assertTrue(keys.get(1).isExpressionParenthesized());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"SYSTEM", "USER"})
+    void acceptsOverridingWithoutColumnList(String mode) throws Exception {
+        Insert insert = (Insert) TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO users OVERRIDING " + mode + " VALUE VALUES (42, 'a@example.org', 'A')",
+                true);
+        assertNull(insert.getTable().getAlias());
+        assertEquals(Insert.OverridingMode.valueOf(mode), insert.getOverridingMode());
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO users overriding VALUES (1)", true);
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "INSERT INTO users AS overriding OVERRIDING " + mode
+                        + " VALUE SELECT * FROM source",
+                true);
+    }
+
+    @Test
+    void exposesOrderedTypedKeys() throws Exception {
+        Insert insert = (Insert) CCJSqlParserUtil.parse("INSERT INTO users VALUES (1) "
+                + "ON CONFLICT (id, (lower(email)) COLLATE pg_catalog.\"C\" "
+                + "pg_catalog.text_pattern_ops, region) WHERE active DO NOTHING");
+        InsertConflictTarget target = insert.getConflictTarget();
+        List<Index.ColumnParams> keys = target.getIndexElements();
+        assertEquals(3, keys.size());
+        assertEquals("id", keys.get(0).getColumnName());
+        assertInstanceOf(Function.class, keys.get(1).getExpression());
+        assertEquals("pg_catalog.\"C\"", keys.get(1).getCollation());
+        assertEquals("pg_catalog.text_pattern_ops", keys.get(1).getOperatorClass());
+        assertEquals(Arrays.asList("id", "region"), target.getIndexColumnNames());
+        assertNotNull(target.getWhereExpression());
+    }
+
+    @Test
+    void retainsMutableLegacyColumnViewAndReplacementMethods() throws Exception {
+        InsertConflictTarget target = new InsertConflictTarget("id", null, null, null);
+        List<String> names = target.getIndexColumnNames();
+        names.add("region");
+        names.set(0, "tenant");
+        names.remove(1);
+        assertEquals(" (tenant)", target.toString());
+        target.setIndexExpression(CCJSqlParserUtil.parseExpression("lower(email)"));
+        assertTrue(names.isEmpty());
+        assertNotNull(target.getIndexExpression());
+        target.withIndexColumnName("id").addAllIndexColumnNames(Arrays.asList("region", "tenant"));
+        assertNull(target.getIndexExpression());
+        assertEquals(Arrays.asList("id", "region", "tenant"), names);
+        names.clear();
+        assertTrue(target.getIndexElements().isEmpty());
+    }
+
+    @Test
+    void statementVisitorTraversesTargetExpressions() throws Exception {
+        Insert insert = (Insert) CCJSqlParserUtil.parse("INSERT INTO users VALUES (1) "
+                + "ON CONFLICT ((lower(email))) WHERE active DO NOTHING");
+        List<String> columns = new ArrayList<>();
+        ExpressionVisitorAdapter<Void> expressions =
+                new ExpressionVisitorAdapter<Void>() {
+                    @Override
+                    public <S> Void visit(Column column, S context) {
+                        columns.add(column.getColumnName());
+                        return null;
+                    }
+                };
+        insert.accept(new StatementVisitorAdapter<Void>(
+                new SelectVisitorAdapter<>(expressions)), null);
+        assertEquals(List.of("email", "active"), columns);
+    }
+
+    @Test
+    void deparserVisitsConflictExpressionsAndPredicate() throws Exception {
+        Insert insert = (Insert) CCJSqlParserUtil.parse("INSERT INTO users VALUES (1) "
+                + "ON CONFLICT ((lower(email))) WHERE active DO NOTHING");
+        StringBuilder sql = new StringBuilder();
+        ExpressionDeParser expressions = new ExpressionDeParser() {
+            @Override
+            public <S> StringBuilder visit(Column column, S context) {
+                getBuilder().append("x_").append(column.getColumnName());
+                return getBuilder();
+            }
+        };
+        insert.accept(new StatementDeParser(expressions,
+                new SelectDeParser(), sql), null);
+        assertTrue(sql.toString().contains("lower(x_email)"), sql.toString());
+        assertTrue(sql.toString().contains("WHERE x_active"), sql.toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"VALUES (1)", "SELECT id FROM source"})
+    void distinguishesOverridingModes(String source) throws Exception {
+        for (Insert.OverridingMode mode : Arrays.asList(Insert.OverridingMode.SYSTEM,
+                Insert.OverridingMode.USER)) {
+            Insert insert = (Insert) TestUtils.assertSqlCanBeParsedAndDeparsed(
+                    "INSERT INTO users (id) OVERRIDING " + mode + " VALUE " + source, true);
+            assertEquals(mode, insert.getOverridingMode());
+            assertTrue(insert.isOverriding());
+            insert.setOverriding(false);
+            assertEquals(Insert.OverridingMode.NONE, insert.getOverridingMode());
+            insert.setOverriding(true);
+            assertEquals(Insert.OverridingMode.SYSTEM, insert.getOverridingMode());
+        }
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/statement/merge/PostgreSQLMergeReturningTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/merge/PostgreSQLMergeReturningTest.java
@@ -1,0 +1,78 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.merge;
+
+import java.util.List;
+import java.util.ArrayList;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.expression.Function;
+import net.sf.jsqlparser.statement.StatementVisitorAdapter;
+import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
+
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.ReturningReferenceType;
+import net.sf.jsqlparser.test.TestUtils;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PostgreSQLMergeReturningTest {
+    private static final String MERGE = "MERGE INTO products p USING incoming i ON p.id = i.id "
+            + "WHEN MATCHED THEN UPDATE SET price = i.price "
+            + "WHEN NOT MATCHED THEN INSERT (id, price) VALUES (i.id, i.price) ";
+
+    @ParameterizedTest
+    @ValueSource(strings = {"RETURNING *", "RETURNING merge_action(), p.id, old.price, new.price",
+            "RETURNING WITH (OLD AS o, NEW AS n) o.price, n.price, n.*"})
+    void parsesAndReparsesReturning(String returning) throws Exception {
+        Merge merge = (Merge) TestUtils.assertSqlCanBeParsedAndDeparsed(MERGE + returning, true);
+        assertNotNull(merge.getReturningClause());
+        assertEquals(merge.toString(), CCJSqlParserUtil.parse(merge.toString()).toString());
+    }
+
+    @Test
+    void normalizesOldAndNewReferences() throws Exception {
+        Merge merge = (Merge) CCJSqlParserUtil.parse(MERGE
+                + "RETURNING WITH (OLD AS o, NEW AS n) o.price, n.price");
+        Column oldPrice = merge.getReturningClause().get(0).getExpression(Column.class);
+        assertEquals(ReturningReferenceType.OLD, oldPrice.getReturningReferenceType());
+        assertNull(oldPrice.getTable());
+        assertEquals(ReturningReferenceType.NEW,
+                merge.getReturningClause().get(1).getExpression(Column.class)
+                        .getReturningReferenceType());
+    }
+
+    @Test
+    void statementVisitorTraversesReturningExpressions() throws Exception {
+        Merge merge = (Merge) CCJSqlParserUtil.parse(MERGE + "RETURNING merge_action()");
+        List<String> functions = new ArrayList<>();
+        ExpressionVisitorAdapter<Void> expressions =
+                new ExpressionVisitorAdapter<Void>() {
+                    @Override
+                    public <S> Void visit(Function function, S context) {
+                        functions.add(function.getName());
+                        return super.visit(function, context);
+                    }
+                };
+        merge.accept(new StatementVisitorAdapter<Void>(
+                new SelectVisitorAdapter<>(expressions)), null);
+        assertEquals(List.of("merge_action"), functions);
+    }
+
+    @Test
+    void discoversTablesInReturningSubquery() throws Exception {
+        assertTrue(TablesNamesFinder.findTables(MERGE
+                + "RETURNING (SELECT max(price) FROM history)").contains("history"));
+    }
+}


### PR DESCRIPTION
PostgreSQL INSERT currently rejects conflict targets mixing columns and expressions, accepts only OVERRIDING SYSTEM VALUE, and MERGE has no RETURNING clause. This adds ordered conflict keys with COLLATE and schema-qualified operator classes, distinguishes USER/SYSTEM overriding, and connects MERGE to the existing ReturningClause (including OLD/NEW output aliases). Bare function keys and OVERRIDING without a column list are supported.

The target reuses Index.ColumnParams and centralizes expression traversal and rendering. Existing conflict-column getters remain mutable views, existing replacement methods remain available, and the boolean overriding API still maps true to SYSTEM. MERGE RETURNING uses visitor-based output; ExpressionDeParser now preserves normalized OLD/NEW qualifiers. Statement visitors, table discovery and validators visit the newly supported expressions.

Validation:

- Full Gradle check and Maven verify.
- Parsing, AST assertions, reparsing, deparser output, custom visitors and legacy mutation tests.
- Representative INSERT/MERGE statements executed on PostgreSQL 18.

References: [PostgreSQL INSERT](https://www.postgresql.org/docs/18/sql-insert.html), [PostgreSQL MERGE](https://www.postgresql.org/docs/18/sql-merge.html).
