### PR TITLE
Support PostgreSQL tagged dollar strings and preserve literal bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,9 @@ array-literal ambiguity. The complete reference is on the
 [syntax page](https://jsqlparser.github.io/JSqlParser/syntax.html).
 
 PostgreSQL dollar-quoted strings, including `$tag$…$tag$`, retain their delimiter and
-literal body in `StringValue`. For dialects that use the same spelling as an unquoted
-identifier, `parser.withDollarQuotedStringTags(false)` retains identifier parsing.
+literal body in `StringValue`. Tagged quotes are disabled by default to preserve
+identifier parsing. Enable them with `parser.withDialect(Dialect.POSTGRESQL)` or
+`parser.withDollarQuotedStringTags(true)`. Untagged `$$…$$` literals remain enabled.
 
 ## Statement classification
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Beyond statement shapes, the grammar handles nested sub-selects, bind parameters
 array-literal ambiguity. The complete reference is on the
 [syntax page](https://jsqlparser.github.io/JSqlParser/syntax.html).
 
+PostgreSQL dollar-quoted strings, including `$tag$…$tag$`, retain their delimiter and
+literal body in `StringValue`. For dialects that use the same spelling as an unquoted
+identifier, `parser.withDollarQuotedStringTags(false)` retains identifier parsing.
+
 ## Statement classification
 
 Any parsed statement can say what it actually does — no second parse, no visitor to write:

--- a/src/main/java/net/sf/jsqlparser/expression/StringValue.java
+++ b/src/main/java/net/sf/jsqlparser/expression/StringValue.java
@@ -42,10 +42,14 @@ public final class StringValue extends ASTNodeAccessImpl implements Expression {
             value = escapedValue.substring(1, escapedValue.length() - 1);
             quoteStr = "\"";
             return;
-        } else if (escapedValue.length() >= 4 && escapedValue.startsWith("$$")
-                && escapedValue.endsWith("$$")) {
-            value = escapedValue.substring(2, escapedValue.length() - 2);
-            quoteStr = "$$";
+        }
+
+        String delimiter = getDollarQuoteDelimiter(escapedValue);
+        if (delimiter != null && escapedValue.length() >= 2 * delimiter.length()
+                && escapedValue.endsWith(delimiter)) {
+            quoteStr = delimiter;
+            value = escapedValue.substring(delimiter.length(),
+                    escapedValue.length() - delimiter.length());
             return;
         }
 
@@ -62,6 +66,32 @@ public final class StringValue extends ASTNodeAccessImpl implements Expression {
         }
 
         value = escapedValue;
+    }
+
+    /**
+     * Returns the opening PostgreSQL dollar-quote delimiter, or null if there is none. A tag
+     * follows unquoted identifier rules, excluding dollar signs. This method does not require the
+     * closing delimiter or inspect the body.
+     */
+    public static String getDollarQuoteDelimiter(String text) {
+        if (text == null || text.length() < 2 || text.charAt(0) != '$') {
+            return null;
+        }
+        int end = text.indexOf('$', 1);
+        if (end < 0) {
+            return null;
+        }
+        for (int i = 1; i < end;) {
+            int character = text.codePointAt(i);
+            boolean valid =
+                    i == 1 ? Character.isUnicodeIdentifierStart(character) || character == '_'
+                            : Character.isUnicodeIdentifierPart(character);
+            if (!valid) {
+                return null;
+            }
+            i += Character.charCount(character);
+        }
+        return text.substring(0, end + 1);
     }
 
     public String getValue() {
@@ -90,6 +120,9 @@ public final class StringValue extends ASTNodeAccessImpl implements Expression {
     }
 
     public String getNotExcapedValue() {
+        if (quoteStr != null && quoteStr.startsWith("$")) {
+            return value;
+        }
         StringBuilder buffer = new StringBuilder(value);
         int index = 0;
         int deletesNum = 0;

--- a/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
+++ b/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
@@ -37,7 +37,8 @@ public abstract class AbstractJSqlParser<P> {
                         Feature.allowHashLineComments,
                         Feature.allowDoubleQuotedStrings), SQLSERVER(AdjacentStringLiterals.OFF,
                                 Feature.allowSquareBracketQuotation), POSTGRESQL(
-                                        AdjacentStringLiterals.NEWLINE), H2, EXASOL, BIGQUERY(
+                                        AdjacentStringLiterals.NEWLINE,
+                                        Feature.allowDollarQuotedStringTags), H2, EXASOL, BIGQUERY(
                                                 AdjacentStringLiterals.WHITESPACE,
                                                 Feature.allowDoubleQuotedStrings,
                                                 Feature.allowHashLineComments,
@@ -143,7 +144,10 @@ public abstract class AbstractJSqlParser<P> {
         return withFeature(Feature.allowBackslashEscapeCharacter, allowBackslashEscapeCharacter);
     }
 
-    /** Controls tagged dollar quotes; false preserves dollar-containing identifier spellings. */
+    /**
+     * Controls tagged dollar quotes; disabled by default, enabled by the PostgreSQL dialect preset.
+     * False preserves dollar-containing identifier spellings.
+     */
     public P withDollarQuotedStringTags(boolean allowDollarQuotedStringTags) {
         return withFeature(Feature.allowDollarQuotedStringTags, allowDollarQuotedStringTags);
     }

--- a/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
+++ b/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
@@ -143,6 +143,11 @@ public abstract class AbstractJSqlParser<P> {
         return withFeature(Feature.allowBackslashEscapeCharacter, allowBackslashEscapeCharacter);
     }
 
+    /** Controls tagged dollar quotes; false preserves dollar-containing identifier spellings. */
+    public P withDollarQuotedStringTags(boolean allowDollarQuotedStringTags) {
+        return withFeature(Feature.allowDollarQuotedStringTags, allowDollarQuotedStringTags);
+    }
+
     public P withDoubleQuotedStrings() {
         return withFeature(Feature.allowDoubleQuotedStrings, true);
     }

--- a/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
+++ b/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
@@ -809,10 +809,10 @@ public enum Feature {
     allowDoubleQuotedStrings(false),
 
     /**
-     * Recognizes PostgreSQL $tag$...$tag$ literals. Disable for dialects where these spellings are
-     * unquoted identifiers. Untagged $$ literals are unaffected.
+     * Recognizes PostgreSQL $tag$...$tag$ literals; disabled by default to preserve unquoted
+     * identifiers, enabled by the PostgreSQL dialect preset. Untagged $$ literals are unaffected.
      */
-    allowDollarQuotedStringTags(true),
+    allowDollarQuotedStringTags(false),
 
     /**
      * concatenates adjacent String Literals: NEWLINE when separated by whitespace with at least one

--- a/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
+++ b/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
@@ -809,6 +809,12 @@ public enum Feature {
     allowDoubleQuotedStrings(false),
 
     /**
+     * Recognizes PostgreSQL $tag$...$tag$ literals. Disable for dialects where these spellings are
+     * unquoted identifiers. Untagged $$ literals are unaffected.
+     */
+    allowDollarQuotedStringTags(true),
+
+    /**
      * concatenates adjacent String Literals: NEWLINE when separated by whitespace with at least one
      * newline (the SQL standard and PostgreSQL), WHITESPACE across any whitespace (GoogleSQL,
      * Spark/Databricks); OFF by default, where the second literal stays an alias (MySQL, SQL

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -1664,38 +1664,42 @@ TOKEN_MGR_DECLS : {
 		return -1;
 	}
 
-    private static boolean endsWithDelimiter(Deque<Character> windowQueue, String delimiter) {
-        if (windowQueue.size() != delimiter.length()) {
-            return false;
-        }
-
-        int i = 0;
-        for (char ch : windowQueue) {
-            if (ch != delimiter.charAt(i++)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
+    /** Scans a literal in linear time without tokenizing or rebuilding its whitespace. */
     public void consumeDollarQuotedString(String closingQuote) {
-        Deque<Character> windowQueue = new ArrayDeque<Character>();
-        int delimiterLength = closingQuote.length();
-
+        int[] prefix = new int[closingQuote.length()];
+        for (int i = 1, matched = 0; i < closingQuote.length(); i++) {
+            while (matched > 0 && closingQuote.charAt(i) != closingQuote.charAt(matched)) {
+                matched = prefix[matched - 1];
+            }
+            if (closingQuote.charAt(i) == closingQuote.charAt(matched)) {
+                matched++;
+            }
+            prefix[i] = matched;
+        }
         try {
-            while (true) {
+            int matched = 0;
+            while (matched < closingQuote.length()) {
                 char ch = input_stream.readChar();
-                windowQueue.addLast(ch);
-                if (windowQueue.size() > delimiterLength) {
-                    windowQueue.removeFirst();
+                while (matched > 0 && ch != closingQuote.charAt(matched)) {
+                    matched = prefix[matched - 1];
                 }
-                if (endsWithDelimiter(windowQueue, closingQuote)) {
-                    return;
+                if (ch == closingQuote.charAt(matched)) {
+                    matched++;
                 }
             }
         } catch (java.io.IOException e) {
             reportError(Math.max(closingQuote.length(), input_stream.GetImage().length()));
         }
+    }
+
+    /** Rewinds any identifier suffix consumed by longest-match lexing before scanning the body. */
+    private void consumeDollarQuotedToken(Token token, String delimiter) {
+        input_stream.backup(token.image.length() - delimiter.length());
+        consumeDollarQuotedString(delimiter);
+        token.image = input_stream.GetImage();
+        token.kind = charLiteralIndex;
+        token.endLine = input_stream.getEndLine();
+        token.endColumn = input_stream.getEndColumn();
     }
 
     /**
@@ -2407,9 +2411,7 @@ TOKEN:
 |
 <S_DOLLAR_QUOTED_STRING: "$$">
     {
-        consumeDollarQuotedString(matchedToken.image);
-        matchedToken.image = input_stream.GetImage();
-        matchedToken.kind = charLiteralIndex;
+        consumeDollarQuotedToken(matchedToken, matchedToken.image);
     }
 |
 // Bare `#` as a binary operator (PostgreSQL bitwise XOR / geometric
@@ -2420,6 +2422,13 @@ TOKEN:
 |
 <S_IDENTIFIER: (<LETTER> (<PART_LETTER>)*) | "$" | ("$" <PART_LETTER_NO_DOLLAR> (<PART_LETTER>)*)>
 {
+    if (matchedToken.image.charAt(0) == '$'
+            && Boolean.TRUE.equals(configuration.getValue(Feature.allowDollarQuotedStringTags))) {
+        String delimiter = StringValue.getDollarQuoteDelimiter(matchedToken.image);
+        if (delimiter != null) {
+            consumeDollarQuotedToken(matchedToken, delimiter);
+        }
+    }
     // MySQL `#` line comments (#2499): under the flag an unquoted identifier
     // ends at its first `#`, the rest of the line becomes a comment via the
     // stream-level substitution (real MySQL reads `42#24` as `42` plus
@@ -2428,7 +2437,7 @@ TOKEN:
     // that never opted in (the stream is only wired through the feature
     // consumers / withConfiguration); getValue avoids the String-based
     // getAsBoolean roundtrip
-    if (input_stream.featureConfiguration != null
+    if (matchedToken.kind == S_IDENTIFIER && input_stream.featureConfiguration != null
             && Boolean.TRUE.equals(configuration.getValue(Feature.allowHashLineComments))) {
         int hashIndex = matchedToken.image.indexOf('#');
         if (hashIndex > 0) {
@@ -16680,7 +16689,7 @@ List<String> captureFunctionBody() {
         tokens.add(tok.image);
     }
     foundEnd |= (tok.kind == K_END)
-        || ( tok.image.trim().startsWith("$$") && tok.image.trim().endsWith("$$")) ;
+        || (tok.kind == S_CHAR_LITERAL && StringValue.getDollarQuoteDelimiter(tok.image) != null);
 
     tok = getNextToken();
   }

--- a/src/test/java/net/sf/jsqlparser/expression/TaggedDollarStringTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/TaggedDollarStringTest.java
@@ -1,0 +1,154 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Stream;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.CCJSqlParser;
+import net.sf.jsqlparser.parser.CCJSqlParserConstants;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.parser.Token;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.statement.Statements;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.test.TestUtils;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TaggedDollarStringTest {
+    static Stream<String> tags() {
+        return Stream.of("", "tag", "Tag_123", "_", "한글", "étiquette");
+    }
+
+    @ParameterizedTest
+    @MethodSource("tags")
+    void preservesLiteralBodiesAndDelimiters(String tag) throws Exception {
+        String delimiter = "$" + tag + "$";
+        for (String body : List.of("", "abc", "a\nb\r\nc\t  ", "x 'one' ''two'' \\ end",
+                "/* comment */ -- more\n#hash", "[ {\"some\":\"json\",\"with\":\"properties$\"} ]",
+                "$1 $other$ こんにちは")) {
+            String literal = delimiter + body + delimiter;
+            String sql = "SELECT " + literal + " AS value, 2 FROM t";
+            PlainSelect select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(sql);
+            StringValue value =
+                    assertInstanceOf(StringValue.class, select.getSelectItem(0).getExpression());
+            assertEquals(body, value.getValue());
+            assertEquals(body, value.getNotExcapedValue());
+            assertEquals(delimiter, value.getQuoteStr());
+            assertEquals(literal, value.toString());
+            StringBuilder builder = new StringBuilder();
+            select.accept(new StatementDeParser(builder), null);
+            PlainSelect again = (PlainSelect) CCJSqlParserUtil.parse(builder.toString());
+            assertEquals(body, again.getSelectItem(0).getExpression(StringValue.class).getValue());
+            assertEquals(select.toString(), builder.toString());
+        }
+    }
+
+    @Test
+    void keepsDifferentTagsAndDollarSignsInsideBody() throws Exception {
+        String body = "$other$ text $Tag$ $$ $1 $t";
+        PlainSelect select =
+                (PlainSelect) CCJSqlParserUtil.parse("SELECT $tag$" + body + "$tag$::text, $1");
+        CastExpression cast = select.getSelectItem(0).getExpression(CastExpression.class);
+        assertEquals(body, ((StringValue) cast.getLeftExpression()).getValue());
+        assertInstanceOf(JdbcParameter.class, select.getSelectItem(1).getExpression());
+    }
+
+    @Test
+    void retainsIdentifiersAndSupportsOptOut() throws Exception {
+        PlainSelect select = (PlainSelect) CCJSqlParserUtil
+                .parse("SELECT $parameter, foo$bar, \"$tag$abc$tag$\", $1 FROM t");
+        for (int i = 0; i < 3; i++) {
+            assertInstanceOf(Column.class, select.getSelectItem(i).getExpression());
+        }
+        assertInstanceOf(JdbcParameter.class, select.getSelectItem(3).getExpression());
+        for (String identifier : List.of("$tag$abc$tag$", "$tag$identifier")) {
+            PlainSelect legacy = (PlainSelect) CCJSqlParserUtil.parse("SELECT " + identifier,
+                    parser -> parser.withDollarQuotedStringTags(false));
+            assertEquals(identifier,
+                    legacy.getSelectItem(0).getExpression(Column.class).getColumnName());
+        }
+        PlainSelect untagged = (PlainSelect) CCJSqlParserUtil.parse("SELECT $$text$$",
+                parser -> parser.withDollarQuotedStringTags(false));
+        assertEquals("text", untagged.getSelectItem(0).getExpression(StringValue.class).getValue());
+    }
+
+    @Test
+    void retainsBodyWithOtherLexerOptions() throws Exception {
+        PlainSelect select = (PlainSelect) CCJSqlParserUtil.parse(
+                "SELECT $t$#hash\n\\text't$tag$ \"q\"$t$",
+                parser -> parser
+                        .withDialect(net.sf.jsqlparser.parser.AbstractJSqlParser.Dialect.MYSQL));
+        assertEquals("#hash\n\\text't$tag$ \"q\"",
+                select.getSelectItem(0).getExpression(StringValue.class).getValue());
+    }
+
+    @Test
+    void keepsLineColumnAndAbsoluteTokenPositions() {
+        String literal = "$tag$a\nb$tag$";
+        CCJSqlParser parser = CCJSqlParserUtil.newParser("SELECT " + literal + ", 2");
+        parser.getNextToken();
+        Token value = parser.getNextToken();
+        Token comma = parser.getNextToken();
+        assertEquals(CCJSqlParserConstants.S_CHAR_LITERAL, value.kind);
+        assertEquals(literal, value.image);
+        assertEquals(1, value.beginLine);
+        assertEquals(8, value.beginColumn);
+        assertEquals(2, value.endLine);
+        assertEquals(6, value.endColumn);
+        assertEquals(8, value.absoluteBegin);
+        assertEquals(8 + literal.length(), value.absoluteEnd);
+        assertEquals(value.absoluteEnd, comma.absoluteBegin);
+        assertEquals(7, comma.beginColumn);
+    }
+
+    @Test
+    void recognizesFunctionBodyAndFollowingStatement() throws Exception {
+        String body = "SELECT 'a;''b'::text;\n";
+        String sql =
+                "CREATE FUNCTION f() RETURNS text AS $fn$" + body + "$fn$ LANGUAGE SQL; SELECT 42;";
+        Statements statements = CCJSqlParserUtil.parseStatements(sql);
+        assertEquals(2, statements.size());
+        assertEquals("SELECT 42", statements.get(1).toString());
+        org.junit.jupiter.api.Assertions
+                .assertTrue(statements.get(0).toString().contains("$fn$" + body + "$fn$"));
+        assertEquals(2, CCJSqlParserUtil.parseStatements(statements.toString()).size());
+    }
+
+    @Test
+    @Timeout(10)
+    void handlesLongBodiesAndOverlappingDelimiterPrefixes() throws Exception {
+        String body = "$ta$tagX $tagtagX\n".repeat(12000);
+        String sql = "SELECT $tagtag$" + body + "$tagtag$";
+        PlainSelect select = (PlainSelect) CCJSqlParserUtil.parse(new StringReader(sql));
+        assertEquals(body, select.getSelectItem(0).getExpression(StringValue.class).getValue());
+        PlainSelect streamed = (PlainSelect) CCJSqlParserUtil.parse(
+                new java.io.ByteArrayInputStream(sql.getBytes(StandardCharsets.UTF_8)), "UTF-8");
+        assertEquals(body, streamed.getSelectItem(0).getExpression(StringValue.class).getValue());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"SELECT $tag$missing", "SELECT $Tag$wrong$tag$", "SELECT $t$ends$t",
+            "SELECT $a$text$b$", "SELECT $$missing"})
+    void rejectsUnterminatedOrMismatchedTags(String sql) {
+        assertThrows(JSQLParserException.class,
+                () -> CCJSqlParserUtil.parse(sql, parser -> parser.withTimeOut(1000)));
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/expression/TaggedDollarStringTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/TaggedDollarStringTest.java
@@ -15,11 +15,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.AbstractJSqlParser.Dialect;
 import net.sf.jsqlparser.parser.CCJSqlParser;
 import net.sf.jsqlparser.parser.CCJSqlParserConstants;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.parser.StreamProvider;
 import net.sf.jsqlparser.parser.Token;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.statement.Statements;
@@ -46,7 +49,8 @@ class TaggedDollarStringTest {
                 "$1 $other$ こんにちは")) {
             String literal = delimiter + body + delimiter;
             String sql = "SELECT " + literal + " AS value, 2 FROM t";
-            PlainSelect select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(sql);
+            PlainSelect select = (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(sql, true,
+                    parser -> parser.withDialect(Dialect.POSTGRESQL));
             StringValue value =
                     assertInstanceOf(StringValue.class, select.getSelectItem(0).getExpression());
             assertEquals(body, value.getValue());
@@ -55,7 +59,8 @@ class TaggedDollarStringTest {
             assertEquals(literal, value.toString());
             StringBuilder builder = new StringBuilder();
             select.accept(new StatementDeParser(builder), null);
-            PlainSelect again = (PlainSelect) CCJSqlParserUtil.parse(builder.toString());
+            PlainSelect again = (PlainSelect) CCJSqlParserUtil.parse(builder.toString(),
+                    parser -> parser.withDialect(Dialect.POSTGRESQL));
             assertEquals(body, again.getSelectItem(0).getExpression(StringValue.class).getValue());
             assertEquals(select.toString(), builder.toString());
         }
@@ -65,37 +70,61 @@ class TaggedDollarStringTest {
     void keepsDifferentTagsAndDollarSignsInsideBody() throws Exception {
         String body = "$other$ text $Tag$ $$ $1 $t";
         PlainSelect select =
-                (PlainSelect) CCJSqlParserUtil.parse("SELECT $tag$" + body + "$tag$::text, $1");
+                (PlainSelect) CCJSqlParserUtil.parse("SELECT $tag$" + body + "$tag$::text, $1",
+                        parser -> parser.withDialect(Dialect.POSTGRESQL));
         CastExpression cast = select.getSelectItem(0).getExpression(CastExpression.class);
         assertEquals(body, ((StringValue) cast.getLeftExpression()).getValue());
         assertInstanceOf(JdbcParameter.class, select.getSelectItem(1).getExpression());
     }
 
     @Test
-    void retainsIdentifiersAndSupportsOptOut() throws Exception {
+    void retainsIdentifiersWithPostgreSqlDialect() throws Exception {
         PlainSelect select = (PlainSelect) CCJSqlParserUtil
-                .parse("SELECT $parameter, foo$bar, \"$tag$abc$tag$\", $1 FROM t");
+                .parse("SELECT $parameter, foo$bar, \"$tag$abc$tag$\", $1 FROM t",
+                        parser -> parser.withDialect(Dialect.POSTGRESQL));
         for (int i = 0; i < 3; i++) {
             assertInstanceOf(Column.class, select.getSelectItem(i).getExpression());
         }
         assertInstanceOf(JdbcParameter.class, select.getSelectItem(3).getExpression());
+    }
+
+    static Stream<Consumer<CCJSqlParser>> identifierConfigurations() {
+        return Stream.concat(
+                Stream.<Consumer<CCJSqlParser>>of(parser -> {
+                },
+                        parser -> parser.withDialect(Dialect.POSTGRESQL)
+                                .withDollarQuotedStringTags(false)),
+                Stream.of(Dialect.values()).filter(dialect -> dialect != Dialect.POSTGRESQL)
+                        .map(dialect -> parser -> parser.withDialect(dialect)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("identifierConfigurations")
+    void retainsIdentifiersAndUntaggedLiterals(Consumer<CCJSqlParser> configuration)
+            throws Exception {
         for (String identifier : List.of("$tag$abc$tag$", "$tag$identifier")) {
-            PlainSelect legacy = (PlainSelect) CCJSqlParserUtil.parse("SELECT " + identifier,
-                    parser -> parser.withDollarQuotedStringTags(false));
+            PlainSelect select =
+                    (PlainSelect) CCJSqlParserUtil.parse("SELECT " + identifier, configuration);
             assertEquals(identifier,
-                    legacy.getSelectItem(0).getExpression(Column.class).getColumnName());
+                    select.getSelectItem(0).getExpression(Column.class).getColumnName());
         }
         PlainSelect untagged = (PlainSelect) CCJSqlParserUtil.parse("SELECT $$text$$",
-                parser -> parser.withDollarQuotedStringTags(false));
+                configuration);
         assertEquals("text", untagged.getSelectItem(0).getExpression(StringValue.class).getValue());
+    }
+
+    @Test
+    void supportsExplicitOptInWithoutDialect() throws Exception {
+        PlainSelect select = (PlainSelect) CCJSqlParserUtil.parse("SELECT $tag$abc$tag$",
+                parser -> parser.withDollarQuotedStringTags(true));
+        assertEquals("abc", select.getSelectItem(0).getExpression(StringValue.class).getValue());
     }
 
     @Test
     void retainsBodyWithOtherLexerOptions() throws Exception {
         PlainSelect select = (PlainSelect) CCJSqlParserUtil.parse(
                 "SELECT $t$#hash\n\\text't$tag$ \"q\"$t$",
-                parser -> parser
-                        .withDialect(net.sf.jsqlparser.parser.AbstractJSqlParser.Dialect.MYSQL));
+                parser -> parser.withDialect(Dialect.MYSQL).withDollarQuotedStringTags(true));
         assertEquals("#hash\n\\text't$tag$ \"q\"",
                 select.getSelectItem(0).getExpression(StringValue.class).getValue());
     }
@@ -103,7 +132,8 @@ class TaggedDollarStringTest {
     @Test
     void keepsLineColumnAndAbsoluteTokenPositions() {
         String literal = "$tag$a\nb$tag$";
-        CCJSqlParser parser = CCJSqlParserUtil.newParser("SELECT " + literal + ", 2");
+        CCJSqlParser parser = CCJSqlParserUtil.newParser("SELECT " + literal + ", 2")
+                .withDialect(Dialect.POSTGRESQL);
         parser.getNextToken();
         Token value = parser.getNextToken();
         Token comma = parser.getNextToken();
@@ -124,12 +154,14 @@ class TaggedDollarStringTest {
         String body = "SELECT 'a;''b'::text;\n";
         String sql =
                 "CREATE FUNCTION f() RETURNS text AS $fn$" + body + "$fn$ LANGUAGE SQL; SELECT 42;";
-        Statements statements = CCJSqlParserUtil.parseStatements(sql);
+        Statements statements = CCJSqlParserUtil.parseStatements(sql,
+                parser -> parser.withDialect(Dialect.POSTGRESQL));
         assertEquals(2, statements.size());
         assertEquals("SELECT 42", statements.get(1).toString());
         org.junit.jupiter.api.Assertions
                 .assertTrue(statements.get(0).toString().contains("$fn$" + body + "$fn$"));
-        assertEquals(2, CCJSqlParserUtil.parseStatements(statements.toString()).size());
+        assertEquals(2, CCJSqlParserUtil.parseStatements(statements.toString(),
+                parser -> parser.withDialect(Dialect.POSTGRESQL)).size());
     }
 
     @Test
@@ -137,10 +169,13 @@ class TaggedDollarStringTest {
     void handlesLongBodiesAndOverlappingDelimiterPrefixes() throws Exception {
         String body = "$ta$tagX $tagtagX\n".repeat(12000);
         String sql = "SELECT $tagtag$" + body + "$tagtag$";
-        PlainSelect select = (PlainSelect) CCJSqlParserUtil.parse(new StringReader(sql));
+        PlainSelect select =
+                (PlainSelect) new CCJSqlParser(new StreamProvider(new StringReader(sql)))
+                        .withDialect(Dialect.POSTGRESQL).Statement();
         assertEquals(body, select.getSelectItem(0).getExpression(StringValue.class).getValue());
-        PlainSelect streamed = (PlainSelect) CCJSqlParserUtil.parse(
-                new java.io.ByteArrayInputStream(sql.getBytes(StandardCharsets.UTF_8)), "UTF-8");
+        PlainSelect streamed = (PlainSelect) CCJSqlParserUtil.newParser(
+                new java.io.ByteArrayInputStream(sql.getBytes(StandardCharsets.UTF_8)), "UTF-8")
+                .withDialect(Dialect.POSTGRESQL).Statement();
         assertEquals(body, streamed.getSelectItem(0).getExpression(StringValue.class).getValue());
     }
 
@@ -149,6 +184,7 @@ class TaggedDollarStringTest {
             "SELECT $a$text$b$", "SELECT $$missing"})
     void rejectsUnterminatedOrMismatchedTags(String sql) {
         assertThrows(JSQLParserException.class,
-                () -> CCJSqlParserUtil.parse(sql, parser -> parser.withTimeOut(1000)));
+                () -> CCJSqlParserUtil.parse(sql,
+                        parser -> parser.withDialect(Dialect.POSTGRESQL).withTimeOut(1000)));
     }
 }

--- a/src/test/java/net/sf/jsqlparser/statement/select/PostgresTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/PostgresTest.java
@@ -108,8 +108,6 @@ public class PostgresTest {
     }
 
     @Test
-    @Disabled
-    // wip
     void testDollarQuotedText() throws JSQLParserException {
         String sqlStr = "SELECT $tag$This\nis\na\nselect\ntest\n$tag$ from dual where a=b";
         PlainSelect st = (PlainSelect) CCJSqlParserUtil.parse(sqlStr);

--- a/src/test/java/net/sf/jsqlparser/statement/select/PostgresTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/PostgresTest.java
@@ -14,6 +14,7 @@ import net.sf.jsqlparser.expression.Alias;
 import net.sf.jsqlparser.expression.JsonExpression;
 import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.expression.operators.relational.Intersects;
+import net.sf.jsqlparser.parser.AbstractJSqlParser.Dialect;
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
@@ -110,7 +111,8 @@ public class PostgresTest {
     @Test
     void testDollarQuotedText() throws JSQLParserException {
         String sqlStr = "SELECT $tag$This\nis\na\nselect\ntest\n$tag$ from dual where a=b";
-        PlainSelect st = (PlainSelect) CCJSqlParserUtil.parse(sqlStr);
+        PlainSelect st = (PlainSelect) CCJSqlParserUtil.parse(sqlStr,
+                parser -> parser.withDialect(Dialect.POSTGRESQL));
 
         StringValue stringValue = st.getSelectItem(0).getExpression(StringValue.class);
 


### PR DESCRIPTION
Tagged PostgreSQL strings such as `$json$…$json$` currently fail to parse or become column references. Recognize them as `StringValue` while preserving the exact delimiter, whitespace and literal contents:

```sql
SELECT $json$[{"some":"json","with":"properties$"}]$json$::jsonb;
```

Reuse a shared delimiter recognizer in the lexer, `StringValue` and routine-body boundary detection. The lexer reads the original character stream with a linear delimiter matcher, handles longest-match identifier tokens, and updates token end positions. Dollar-quoted values keep doubled apostrophes unchanged in `getNotExcapedValue()`. A tagged routine body remains one token, so a following SQL statement is preserved.

Tagged quoting is disabled by default to preserve identifier parsing. Enable it with `withDialect(Dialect.POSTGRESQL)` or `withDollarQuotedStringTags(true)`; an explicit `withDollarQuotedStringTags(false)` after the PostgreSQL preset disables it again. Ordinary dollar-containing identifiers, positional parameters and untagged `$$` literals remain supported.

Validation:

- Full Gradle `check` and Maven `verify`.
- Re-enabled the existing tagged-string regression test.
- Empty/Unicode tags, whitespace and CRLF preservation, embedded dollar signs and other tags, casts, bind parameters, quoted identifiers, default/non-PostgreSQL identifier parsing, explicit opt-in and PostgreSQL preset overrides.
- Model/deparser round-trips, token positions, long Reader/InputStream inputs with overlapping delimiter prefixes, unterminated tags, and routine bodies followed by another statement.
- Syntax follows the [PostgreSQL dollar-quoting documentation](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-DOLLAR-QUOTING).

Fixes #2233.
