### PR TITLE
Support dialect-specific CREATE INDEX definitions

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
+++ b/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
@@ -46,7 +46,7 @@ public abstract class AbstractJSqlParser<P> {
                                                         AdjacentStringLiterals.WHITESPACE,
                                                         Feature.allowDoubleQuotedStrings,
                                                         Feature.allowBackslashEscapeCharacter), SNOWFLAKE(
-                                                                Feature.allowBackslashEscapeCharacter), INFORMIX;
+                                                                Feature.allowBackslashEscapeCharacter), INFORMIX, SPANNER;
 
         private final Set<Feature> lexerFeatures;
         private final AdjacentStringLiterals adjacentStringLiterals;

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
@@ -334,7 +334,9 @@ public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
 
     @Override
     public <S> T visit(CreateIndex createIndex, S context) {
-
+        TableDefinitionTraversal.visit(createIndex,
+                expression -> expression.accept(expressionVisitor, context),
+                table -> table.accept(fromItemVisitor, context));
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/index/CreateIndex.java
@@ -9,14 +9,12 @@
  */
 package net.sf.jsqlparser.statement.create.index;
 
-import static java.util.stream.Collectors.joining;
-
 import java.util.*;
+import java.util.function.Consumer;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.schema.*;
 import net.sf.jsqlparser.statement.*;
 import net.sf.jsqlparser.statement.create.table.*;
-import net.sf.jsqlparser.statement.select.PlainSelect;
 
 public class CreateIndex implements Statement {
 
@@ -27,6 +25,7 @@ public class CreateIndex implements Statement {
     private boolean usingIfNotExists = false;
     private boolean concurrently;
     private boolean only;
+    private boolean nullFiltered;
     private List<String> includeColumns;
     private Boolean nullsDistinct;
     private List<Index.Option> storageParameters;
@@ -64,6 +63,20 @@ public class CreateIndex implements Statement {
 
     public void setOnly(boolean only) {
         this.only = only;
+    }
+
+    /** Whether this Spanner index omits rows with null key values. */
+    public boolean isNullFiltered() {
+        return nullFiltered;
+    }
+
+    public void setNullFiltered(boolean nullFiltered) {
+        this.nullFiltered = nullFiltered;
+    }
+
+    public CreateIndex withNullFiltered(boolean nullFiltered) {
+        setNullFiltered(nullFiltered);
+        return this;
     }
 
     public List<String> getIncludeColumns() {
@@ -142,10 +155,15 @@ public class CreateIndex implements Statement {
 
     /** Shared rendering for the statement model and CreateIndexDeParser. */
     public StringBuilder appendTo(StringBuilder buffer) {
+        return appendTo(buffer, expression -> buffer.append(expression));
+    }
+
+    /** Shares rendering while allowing visitors to transform key and option expressions. */
+    public StringBuilder appendTo(StringBuilder buffer, Consumer<Expression> expressionPrinter) {
         appendIndexHeader(buffer);
         appendIndexTarget(buffer);
-        appendIndexColumns(buffer);
-        appendPostgreSqlTail(buffer);
+        appendIndexColumns(buffer, expressionPrinter);
+        appendPostgreSqlTail(buffer, expressionPrinter);
         if (tailParameters != null) {
             for (String param : tailParameters) {
                 buffer.append(" ").append(param);
@@ -158,6 +176,12 @@ public class CreateIndex implements Statement {
         buffer.append("CREATE ");
         if (index.getType() != null) {
             buffer.append(index.getType()).append(" ");
+        }
+        if (index.getClustering() != null) {
+            buffer.append(index.getClustering()).append(" ");
+        }
+        if (nullFiltered) {
+            buffer.append("NULL_FILTERED ");
         }
         buffer.append("INDEX ");
         if (concurrently) {
@@ -185,17 +209,22 @@ public class CreateIndex implements Statement {
         }
     }
 
-    private void appendIndexColumns(StringBuilder buffer) {
-        if (index.getColumnsNames() != null) {
+    private void appendIndexColumns(StringBuilder buffer, Consumer<Expression> expressionPrinter) {
+        if (index.getColumns() != null) {
             buffer.append(" (");
-            buffer.append(index.getColumns().stream()
-                    .map(Index.ColumnParams::toString)
-                    .collect(joining(", ")));
+            for (Iterator<Index.ColumnParams> columns = index.getColumns().iterator(); columns
+                    .hasNext();) {
+                columns.next().appendTo(buffer, expressionPrinter);
+                if (columns.hasNext()) {
+                    buffer.append(", ");
+                }
+            }
             buffer.append(")");
         }
     }
 
-    private void appendPostgreSqlTail(StringBuilder buffer) {
+    private void appendPostgreSqlTail(StringBuilder buffer,
+            Consumer<Expression> expressionPrinter) {
         if (includeColumns != null) {
             buffer.append(" INCLUDE (").append(String.join(", ", includeColumns)).append(")");
         }
@@ -203,14 +232,15 @@ public class CreateIndex implements Statement {
             buffer.append(" NULLS ").append(nullsDistinct ? "DISTINCT" : "NOT DISTINCT");
         }
         if (storageParameters != null) {
-            buffer.append(" WITH ")
-                    .append(PlainSelect.getStringList(storageParameters, true, true));
+            buffer.append(" WITH ");
+            Index.Option.appendListTo(buffer, storageParameters, expressionPrinter);
         }
         if (tableSpace != null) {
             buffer.append(" TABLESPACE ").append(tableSpace);
         }
         if (where != null) {
-            buffer.append(" WHERE ").append(where);
+            buffer.append(" WHERE ");
+            expressionPrinter.accept(where);
         }
     }
 

--- a/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
+++ b/src/main/java/net/sf/jsqlparser/statement/create/table/Index.java
@@ -511,7 +511,7 @@ public class Index implements TableElement, Serializable {
             }
             appendParams(builder);
             appendCollation(builder);
-            appendOperatorClass(builder);
+            appendOperatorClass(builder, expressionPrinter);
             appendSortOrder(builder);
             appendNullOrdering(builder);
             if (exclusionOperator != null) {
@@ -531,13 +531,13 @@ public class Index implements TableElement, Serializable {
             }
         }
 
-        private void appendOperatorClass(StringBuilder builder) {
+        private void appendOperatorClass(StringBuilder builder,
+                Consumer<Expression> expressionPrinter) {
             if (operatorClass != null && !hasParam(operatorClass)) {
                 builder.append(" ").append(operatorClass);
                 if (operatorClassParameters != null && !operatorClassParameters.isEmpty()) {
-                    builder.append(" ")
-                            .append(PlainSelect.getStringList(
-                                    operatorClassParameters, true, true));
+                    builder.append(" ");
+                    Option.appendListTo(builder, operatorClassParameters, expressionPrinter);
                 }
             }
         }
@@ -559,7 +559,7 @@ public class Index implements TableElement, Serializable {
         }
     }
 
-    /** A named PostgreSQL index option with an optional value. */
+    /** A named index option with an optional value. */
     public static class Option implements Serializable {
         private String name;
         private Expression value;
@@ -614,7 +614,33 @@ public class Index implements TableElement, Serializable {
 
         @Override
         public String toString() {
-            return value == null ? name : name + (useEquals ? " = " : " ") + value;
+            if (value == null) {
+                return name;
+            }
+            StringBuilder builder = new StringBuilder();
+            return appendTo(builder, expression -> builder.append(expression)).toString();
+        }
+
+        public StringBuilder appendTo(StringBuilder builder,
+                Consumer<Expression> expressionPrinter) {
+            builder.append(name);
+            if (value != null) {
+                builder.append(useEquals ? " = " : " ");
+                expressionPrinter.accept(value);
+            }
+            return builder;
+        }
+
+        public static StringBuilder appendListTo(StringBuilder builder, List<Option> options,
+                Consumer<Expression> expressionPrinter) {
+            builder.append('(');
+            for (int i = 0; i < options.size(); i++) {
+                if (i > 0) {
+                    builder.append(", ");
+                }
+                options.get(i).appendTo(builder, expressionPrinter);
+            }
+            return builder.append(')');
         }
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/TableDefinitionTraversal.java
+++ b/src/main/java/net/sf/jsqlparser/util/TableDefinitionTraversal.java
@@ -15,6 +15,7 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.LikeClause;
 import net.sf.jsqlparser.statement.alter.AlterExpression;
+import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.table.CheckConstraint;
 import net.sf.jsqlparser.statement.create.table.ColumnDefinition;
 import net.sf.jsqlparser.statement.create.table.ColumnOption;
@@ -28,6 +29,16 @@ import net.sf.jsqlparser.statement.create.table.TableElement;
 /** Traverses structured table definitions without interpreting legacy raw column options. */
 public final class TableDefinitionTraversal {
     private TableDefinitionTraversal() {}
+
+    public static void visit(CreateIndex createIndex, Consumer<Expression> expressions,
+            Consumer<Table> tables) {
+        accept(createIndex.getTable(), tables);
+        if (createIndex.getIndex() != null) {
+            visit(createIndex.getIndex(), expressions, tables);
+        }
+        visitOptions(createIndex.getStorageParameters(), expressions);
+        accept(createIndex.getWhere(), expressions);
+    }
 
     public static void visit(CreateTable table, Consumer<Expression> expressions,
             Consumer<Table> tables) {

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -1552,7 +1552,9 @@ public class TablesNamesFinder<Void>
 
     @Override
     public <S> Void visit(CreateIndex createIndex, S context) {
-        throwUnsupported(createIndex);
+        TableDefinitionTraversal.visit(createIndex,
+                expression -> expression.accept(this, context),
+                table -> visit(table, context));
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/CreateIndexDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/CreateIndexDeParser.java
@@ -9,16 +9,28 @@
  */
 package net.sf.jsqlparser.util.deparser;
 
+import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 
 public class CreateIndexDeParser extends AbstractDeParser<CreateIndex> {
+    private final ExpressionVisitor<StringBuilder> expressionVisitor;
 
     public CreateIndexDeParser(StringBuilder buffer) {
+        this(buffer, null);
+    }
+
+    public CreateIndexDeParser(StringBuilder buffer,
+            ExpressionVisitor<StringBuilder> expressionVisitor) {
         super(buffer);
+        this.expressionVisitor = expressionVisitor;
     }
 
     @Override
     public void deParse(CreateIndex createIndex) {
-        createIndex.appendTo(builder);
+        if (expressionVisitor == null) {
+            createIndex.appendTo(builder);
+        } else {
+            createIndex.appendTo(builder, expression -> expression.accept(expressionVisitor, null));
+        }
     }
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -141,7 +141,8 @@ public class StatementDeParser extends AbstractDeParser<Statement>
 
     @Override
     public <S> StringBuilder visit(CreateIndex createIndex, S context) {
-        CreateIndexDeParser createIndexDeParser = new CreateIndexDeParser(builder);
+        CreateIndexDeParser createIndexDeParser =
+                new CreateIndexDeParser(builder, expressionDeParser);
         createIndexDeParser.deParse(createIndex);
         return builder;
     }

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/CreateIndexValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/CreateIndexValidator.java
@@ -14,6 +14,7 @@ import static java.util.stream.Collectors.toList;
 import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.statement.create.index.CreateIndex;
 import net.sf.jsqlparser.statement.create.table.Index;
+import net.sf.jsqlparser.util.TableDefinitionTraversal;
 import net.sf.jsqlparser.util.validation.ValidationCapability;
 import net.sf.jsqlparser.util.validation.metadata.NamedObject;
 
@@ -38,6 +39,9 @@ public class CreateIndexValidator extends AbstractValidator<CreateIndex> {
                         NamedObject.table);
             }
         }
+        TableDefinitionTraversal.visit(createIndex, this::validateOptionalExpression, table -> {
+            // Table and index names are validated above for each capability.
+        });
     }
 
 }

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -11760,37 +11760,50 @@ Index.ColumnParams IndexColumnWithParams(): {
     List<String> parameter = null;
     Expression expression = null;
     String collation = null;
-    Token operatorClass = null;
+    String operatorClass = null;
     List<Index.Option> operatorClassParameters = null;
     Token sortOrder = null;
     Token nullOrdering = null;
     Index.ColumnParams column = null;
+    boolean postgres = Dialect.POSTGRESQL.name().equals(getAsString(Feature.dialect));
+    boolean expressionParenthesized = true;
 }
 {
     (
+        LOOKAHEAD({ Dialect.POSTGRESQL.name().equals(getAsString(Feature.dialect)) && isFunctionAhead() }) expression=Function()
+        { expressionParenthesized = false; }
+        |
         columnName=RelObjectName()
         |
         "(" expression=Expression() ")"
     )
     // MySQL prefix lengths precede all PostgreSQL key attributes.
-    [ LOOKAHEAD("(") parameter=CreateParameter() { columnParams.addAll(parameter); } ]
-    [ LOOKAHEAD(2) <K_COLLATE> collation=RelObjectName()
-        { columnParams.add("COLLATE"); columnParams.add(collation); } ]
-    [ LOOKAHEAD(2) (operatorClass=<S_IDENTIFIER> | operatorClass=<S_QUOTED_IDENTIFIER>)
+    [ LOOKAHEAD("(", { !Dialect.POSTGRESQL.name().equals(getAsString(Feature.dialect)) }) parameter=CreateParameter() { columnParams.addAll(parameter); } ]
+    [ LOOKAHEAD(2) <K_COLLATE> collation=IndexKeyAttributeName()
+        { if (!postgres) { columnParams.add("COLLATE"); columnParams.add(collation); } } ]
+    [ LOOKAHEAD(2, IndexKeyAttributeName(), {
+            getToken(1).kind == S_IDENTIFIER || getToken(1).kind == S_QUOTED_IDENTIFIER
+            || (Dialect.POSTGRESQL.name().equals(getAsString(Feature.dialect))
+                && getToken(1).kind != K_ASC && getToken(1).kind != K_DESC
+                && getToken(1).kind != K_NULLS && getToken(1).kind != K_COLLATE
+                && getToken(1).kind != K_WITH) })
+        operatorClass=IndexKeyAttributeName()
         [ LOOKAHEAD(2) operatorClassParameters=PostgreSqlIndexOptions() ]
         {
-            columnParams.add(operatorClass.image);
-            if (operatorClassParameters != null) {
-                columnParams.add(PlainSelect.getStringList(
-                        operatorClassParameters, true, true));
+            if (!postgres) {
+                columnParams.add(operatorClass);
+                if (operatorClassParameters != null) {
+                    columnParams.add(PlainSelect.getStringList(
+                            operatorClassParameters, true, true));
+                }
             }
         }
     ]
     [ LOOKAHEAD(2) (sortOrder=<K_ASC> | sortOrder=<K_DESC>)
-        { columnParams.add(sortOrder.image); } ]
+        { if (!postgres) { columnParams.add(sortOrder.image); } } ]
     [ LOOKAHEAD(2) <K_NULLS> (nullOrdering=<K_FIRST> | nullOrdering=<K_LAST>)
-        { columnParams.add("NULLS"); columnParams.add(nullOrdering.image); } ]
-    ( LOOKAHEAD(2, { getToken(1).kind != K_WITH }) parameter=CreateParameter() { columnParams.addAll(parameter); } )*
+        { if (!postgres) { columnParams.add("NULLS"); columnParams.add(nullOrdering.image); } } ]
+    ( LOOKAHEAD(2, { !Dialect.POSTGRESQL.name().equals(getAsString(Feature.dialect)) && getToken(1).kind != K_WITH }) parameter=CreateParameter() { columnParams.addAll(parameter); } )*
     {
         column = expression != null
                 ? new Index.ColumnParams(expression,
@@ -11798,8 +11811,9 @@ Index.ColumnParams IndexColumnWithParams(): {
                 : new Index.ColumnParams(columnName,
                         columnParams.isEmpty() ? null : columnParams);
         column.setCollation(collation);
+        column.setExpressionParenthesized(expressionParenthesized);
         if (operatorClass != null) {
-            column.setOperatorClass(operatorClass.image);
+            column.setOperatorClass(operatorClass);
             column.setOperatorClassParameters(operatorClassParameters);
         }
         if (sortOrder != null) {
@@ -11812,6 +11826,20 @@ Index.ColumnParams IndexColumnWithParams(): {
         }
         return column;
     }
+}
+
+/** Keeps qualified PostgreSQL collation and operator-class names out of expression parsing. */
+String IndexKeyAttributeName():
+{
+    String name;
+    String part;
+}
+{
+    name=RelObjectName()
+    ( LOOKAHEAD(".", { Dialect.POSTGRESQL.name().equals(getAsString(Feature.dialect)) })
+        "." part=RelObjectNameExt() { name += "." + part; }
+    )*
+    { return name; }
 }
 
 Index.Option PostgreSqlIndexOption():
@@ -11867,6 +11895,33 @@ Index Index(): {
     name= RelObjectNames() { return new Index().withName(name.getNames()).withType(""); }
 }
 
+/** Parses dialect-specific index modifiers while retaining the legacy single type token. */
+Index CreateIndexModifiers(CreateIndex statement):
+{
+    Index index = new Index();
+    Token token;
+    List<String> parameter;
+    Index.Clustering clustering;
+}
+{
+    (
+        LOOKAHEAD({ Dialect.SQLSERVER.name().equals(getAsString(Feature.dialect))
+                && (getToken(1).kind == K_UNIQUE || isKeywordAhead("CLUSTERED")
+                    || isKeywordAhead("NONCLUSTERED")) })
+        [ token=<K_UNIQUE> { index.setType(token.image); } ]
+        clustering=SqlServerIndexClustering() { index.setClustering(clustering); }
+        |
+        LOOKAHEAD({ Dialect.SPANNER.name().equals(getAsString(Feature.dialect))
+                && (getToken(1).kind == K_UNIQUE || isKeywordAhead("NULL_FILTERED")) })
+        [ token=<K_UNIQUE> { index.setType(token.image); } ]
+        [ LOOKAHEAD({ isKeywordAhead("NULL_FILTERED") }) token=<S_IDENTIFIER>
+            { statement.setNullFiltered(true); } ]
+        |
+        [ parameter=CreateParameter() { index.setType(parameter.get(0)); } ]
+    )
+    { return index; }
+}
+
 CreateIndex CreateIndex():
 {
     CreateIndex createIndex = new CreateIndex();
@@ -11878,26 +11933,20 @@ CreateIndex CreateIndex():
     String tableSpace = null;
     Expression where = null;
     String indexType;
-    Index index = null;
+    Index index;
     List<String> parameter = new ArrayList<String>();
     List<String> tailParameters = new ArrayList<String>();
-    List<String> name;
+    ObjectNames name;
 }
 {
-    [ parameter=CreateParameter() ]
+    index=CreateIndexModifiers(createIndex)
 
     <K_INDEX>
     [ LOOKAHEAD({ getToken(1).kind == K_CONCURRENTLY })
         <K_CONCURRENTLY> { createIndex.setConcurrently(true); } ]
     [ LOOKAHEAD(2) <K_IF> <K_NOT> <K_EXISTS> { createIndex.setUsingIfNotExists(true);} ]
     [ LOOKAHEAD({ getToken(1).kind != K_ON && getToken(1).kind != K_USING })
-        index = Index() ]
-    {
-        if (index == null) {
-            index = new Index();
-        }
-        index.setType(parameter.isEmpty() ? null : parameter.get(0));
-    }
+        name=RelObjectNames() { index.setName(name.getNames()); } ]
     (
         LOOKAHEAD(3)(
             <K_ON> [ <K_ONLY> { createIndex.setOnly(true); } ] table=Table()

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -702,7 +702,7 @@ One grammar covers every supported RDBMS, but a few pieces of syntax mean differ
     * - ``MYSQL``
       - ``withBackslashEscapeCharacter``, ``withHashLineComments``, ``withDoubleQuotedStrings`` (MySQL and MariaDB, the last for the default ``sql_mode``)
     * - ``SQLSERVER``
-      - ``withSquareBracketQuotation`` and ``CLUSTERED`` / ``NONCLUSTERED`` options on table-level primary key and unique constraints
+      - ``withSquareBracketQuotation`` and ``CLUSTERED`` / ``NONCLUSTERED`` options on table-level primary key and unique constraints and ``CREATE INDEX``
     * - ``POSTGRESQL``, ``ANSI_SQL``
       - the newline rule for adjacent string literals
     * - ``BIGQUERY``
@@ -713,6 +713,8 @@ One grammar covers every supported RDBMS, but a few pieces of syntax mean differ
       - ``withBackslashEscapeCharacter`` only, double quotes stay quoted identifiers
     * - ``INFORMIX``
       - Informix ``ALTER TABLE ... ADD CONSTRAINT`` definitions with optional trailing constraint names
+    * - ``SPANNER``
+      - GoogleSQL ``CREATE [UNIQUE] NULL_FILTERED INDEX`` with a separate null-filtering flag
 
 Features set explicitly *after* the preset win over it.
 
@@ -720,6 +722,29 @@ With ``Dialect.SQLSERVER``, ``PRIMARY KEY NONCLUSTERED (id)`` and
 ``UNIQUE CLUSTERED (id)`` store their clustering option in ``Index.getClustering()``
 for both ``CREATE TABLE`` and ``ALTER TABLE``. Without that dialect, these words
 retain their existing interpretation as optional index names.
+
+``CREATE UNIQUE NONCLUSTERED INDEX ix ON t (id)`` also requires
+``Dialect.SQLSERVER``. Uniqueness remains in ``Index.getType()`` and clustering
+is stored separately in ``Index.getClustering()``. With ``Dialect.SPANNER``,
+``CREATE UNIQUE NULL_FILTERED INDEX ix ON t (id)`` stores null filtering in
+``CreateIndex.isNullFiltered()``. An omitted clustering or null-filtering option
+is not supplied from database defaults. The Spanner preset currently selects
+this index syntax; it does not configure GoogleSQL string-literal rules.
+
+With ``Dialect.POSTGRESQL``, index keys accept schema-qualified collation and
+operator-class names, for example ``name COLLATE pg_catalog."C"
+pg_catalog.text_ops ASC NULLS LAST``. Function keys such as ``lower(name)`` are
+stored as expressions. Key attributes are available through ``getCollation()``,
+``getOperatorClass()``, ``getOperatorClassParameters()``, ``getSortOrder()`` and
+``getNullOrdering()`` on ``Index.ColumnParams``. Under this dialect these
+attributes are not duplicated in the legacy ``getParams()`` list, so changing
+or removing them is reflected when rendering SQL. Other dialects retain the
+legacy parameter representation, including MySQL prefix lengths.
+
+``CreateIndexDeParser`` and ``StatementDeParser`` pass key expressions,
+structured option values and the partial-index predicate to their expression
+visitor. ``StatementVisitorAdapter``, ``TablesNamesFinder`` and index validation
+traverse the same structured expressions.
 
 Informix's constraint form requires an explicit dialect selection:
 

--- a/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTraversalTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/CreateIndexTraversalTest.java
@@ -1,0 +1,72 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.expression.LongValue;
+import net.sf.jsqlparser.parser.AbstractJSqlParser.Dialect;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.StatementVisitorAdapter;
+import net.sf.jsqlparser.statement.create.index.CreateIndex;
+import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
+import org.junit.jupiter.api.Test;
+
+class CreateIndexTraversalTest {
+    private static final String SQL = "CREATE INDEX ix ON public.t "
+            + "((id + 1) public.test_ops (option = 2)) WITH (fillfactor = 80) WHERE id > 3";
+
+    @Test
+    void visitsKeyOptionStorageAndPredicateExpressionsOnceWithContext() throws Exception {
+        CreateIndex statement = (CreateIndex) CCJSqlParserUtil.parse(SQL,
+                parser -> parser.withDialect(Dialect.POSTGRESQL));
+        List<Long> values = new ArrayList<>();
+        ExpressionVisitorAdapter<Void> expressions = new ExpressionVisitorAdapter<Void>() {
+            @Override
+            public <S> Void visit(LongValue value, S context) {
+                assertEquals("context", context);
+                values.add(value.getValue());
+                return null;
+            }
+        };
+        statement.accept(new StatementVisitorAdapter<>(new SelectVisitorAdapter<>(expressions)),
+                "context");
+        assertEquals(List.of(1L, 2L, 80L, 3L), values);
+        assertEquals(Set.of("public.t"), new TablesNamesFinder().getTables(statement));
+    }
+
+    @Test
+    void deparsesAllExpressionsThroughTheCustomVisitor() throws Exception {
+        CreateIndex statement = (CreateIndex) CCJSqlParserUtil.parse(SQL,
+                parser -> parser.withDialect(Dialect.POSTGRESQL));
+        StringBuilder output = new StringBuilder();
+        ExpressionDeParser expressions = new ExpressionDeParser() {
+            @Override
+            public <S> StringBuilder visit(LongValue value, S context) {
+                return getBuilder().append(value.getValue() + 10);
+            }
+        };
+        statement.accept(new StatementDeParser(expressions, new SelectDeParser(), output));
+        assertEquals("CREATE INDEX ix ON public.t "
+                + "((id + 11) public.test_ops (option = 12)) WITH (fillfactor = 90) WHERE id > 13",
+                output.toString());
+        assertEquals(SQL, statement.toString());
+        assertEquals(output.toString(), CCJSqlParserUtil.parse(output.toString(),
+                parser -> parser.withDialect(Dialect.POSTGRESQL)).toString());
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/statement/create/DialectIndexDefinitionTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/DialectIndexDefinitionTest.java
@@ -1,0 +1,214 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create;
+
+import static net.sf.jsqlparser.test.TestUtils.assertDeparse;
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.AbstractJSqlParser.Dialect;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statements;
+import net.sf.jsqlparser.statement.create.index.CreateIndex;
+import net.sf.jsqlparser.statement.create.table.Index;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DialectIndexDefinitionTest {
+    private static CreateIndex parse(String sql, Dialect dialect) throws JSQLParserException {
+        return (CreateIndex) CCJSqlParserUtil.parse(sql, parser -> parser.withDialect(dialect));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "UNIQUE ", "CLUSTERED ", "NONCLUSTERED ",
+            "UNIQUE CLUSTERED ", "UNIQUE NONCLUSTERED "})
+    void parsesSqlServerIndexModifiers(String modifiers) throws Exception {
+        String sql = "CREATE " + modifiers
+                + "INDEX [index name] ON [dbo].[store] ([manager_staff_id] DESC, [id] ASC)";
+        CreateIndex statement = (CreateIndex) assertSqlCanBeParsedAndDeparsed(sql, true,
+                parser -> parser.withDialect(Dialect.SQLSERVER));
+        Index index = statement.getIndex();
+        assertEquals(modifiers.contains("UNIQUE") ? "UNIQUE" : null, index.getType());
+        assertEquals(modifiers.contains("NONCLUSTERED") ? Index.Clustering.NONCLUSTERED
+                : modifiers.contains("CLUSTERED") ? Index.Clustering.CLUSTERED : null,
+                index.getClustering());
+        assertFalse(statement.isNullFiltered());
+        assertEquals(index.getClustering(), parse(statement.toString(), Dialect.SQLSERVER)
+                .getIndex().getClustering());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "UNIQUE ", "NULL_FILTERED ", "UNIQUE NULL_FILTERED "})
+    void parsesSpannerIndexModifiersIssue652(String modifiers) throws Exception {
+        String sql = "CREATE " + modifiers
+                + "INDEX IF NOT EXISTS `index name` ON `Users` (`name` DESC, `id` ASC)";
+        CreateIndex statement = (CreateIndex) assertSqlCanBeParsedAndDeparsed(sql, true,
+                parser -> parser.withDialect(Dialect.SPANNER));
+        assertEquals(modifiers.contains("UNIQUE") ? "UNIQUE" : null,
+                statement.getIndex().getType());
+        assertEquals(modifiers.contains("NULL_FILTERED"), statement.isNullFiltered());
+        assertNull(statement.getIndex().getClustering());
+        assertEquals(statement.isNullFiltered(),
+                parse(statement.toString(), Dialect.SPANNER).isNullFiltered());
+    }
+
+    @Test
+    void requiresDialectForCombinedModifiersAndPreservesLegacySingleTypes() throws Exception {
+        for (String type : List.of("CLUSTERED", "NONCLUSTERED", "NULL_FILTERED", "mytype")) {
+            String sql = "CREATE " + type + " INDEX ix ON t (id)";
+            CreateIndex legacy = (CreateIndex) assertSqlCanBeParsedAndDeparsed(sql);
+            assertEquals(type, legacy.getIndex().getType());
+            assertNull(legacy.getIndex().getClustering());
+            assertFalse(legacy.isNullFiltered());
+        }
+        for (Dialect target : List.of(Dialect.SQLSERVER, Dialect.SPANNER)) {
+            String sql = "CREATE UNIQUE "
+                    + (target == Dialect.SQLSERVER ? "NONCLUSTERED" : "NULL_FILTERED")
+                    + " INDEX ix ON t (id)";
+            assertThrows(JSQLParserException.class, () -> CCJSqlParserUtil.parse(sql));
+            for (Dialect dialect : Dialect.values()) {
+                if (dialect != target) {
+                    assertThrows(JSQLParserException.class, () -> parse(sql, dialect),
+                            dialect.name());
+                }
+            }
+        }
+    }
+
+    @Test
+    void rejectsDuplicateOrReversedModifiers() {
+        for (String modifiers : List.of("UNIQUE CLUSTERED NONCLUSTERED", "NONCLUSTERED UNIQUE",
+                "UNIQUE UNIQUE", "UNIQUE NULL_FILTERED")) {
+            assertThrows(JSQLParserException.class,
+                    () -> parse("CREATE " + modifiers + " INDEX ix ON t (id)", Dialect.SQLSERVER));
+        }
+        for (String modifiers : List.of("NULL_FILTERED UNIQUE",
+                "UNIQUE NULL_FILTERED NULL_FILTERED",
+                "UNIQUE UNIQUE", "UNIQUE NONCLUSTERED")) {
+            assertThrows(JSQLParserException.class,
+                    () -> parse("CREATE " + modifiers + " INDEX ix ON t (id)", Dialect.SPANNER));
+        }
+    }
+
+    @Test
+    void rendersModifiedClusteringAndNullFiltering() throws Exception {
+        CreateIndex sqlServer = parse("CREATE UNIQUE NONCLUSTERED INDEX ix ON t (id)",
+                Dialect.SQLSERVER);
+        sqlServer.getIndex().setClustering(Index.Clustering.CLUSTERED);
+        assertDeparse(sqlServer, "CREATE UNIQUE CLUSTERED INDEX ix ON t (id)");
+        sqlServer.getIndex().setClustering(null);
+        assertDeparse(sqlServer, "CREATE UNIQUE INDEX ix ON t (id)");
+
+        CreateIndex spanner = parse("CREATE UNIQUE NULL_FILTERED INDEX ix ON t (id)",
+                Dialect.SPANNER);
+        spanner.setNullFiltered(false);
+        assertDeparse(spanner, "CREATE UNIQUE INDEX ix ON t (id)");
+        assertDeparse(spanner.withNullFiltered(true),
+                "CREATE UNIQUE NULL_FILTERED INDEX ix ON t (id)");
+    }
+
+    @Test
+    void parsesSakilaIndexAndFollowingStatementsIssue1563() throws Exception {
+        String sql =
+                "CREATE UNIQUE NONCLUSTERED INDEX idx_fk_address_id ON store(manager_staff_id);";
+        Statements statements = CCJSqlParserUtil.parseStatements(sql + "\nGO\nSELECT 1;",
+                parser -> parser.withDialect(Dialect.SQLSERVER));
+        assertEquals(2, statements.size());
+        assertEquals(Index.Clustering.NONCLUSTERED,
+                ((CreateIndex) statements.get(0)).getIndex().getClustering());
+        assertEquals("SELECT 1", statements.get(1).toString());
+    }
+
+    @Test
+    void parsesQualifiedPostgreSqlAttributesIssue1994() throws Exception {
+        String sql = "CREATE INDEX \"index_keyword\" ON \"inter\".\"inter_ti_rec\" USING btree "
+                + "(\"keyword\" COLLATE \"pg_catalog\".\"default\" \"pg_catalog\".\"text_ops\" ASC NULLS LAST)";
+        CreateIndex statement = (CreateIndex) assertSqlCanBeParsedAndDeparsed(sql, true,
+                parser -> parser.withDialect(Dialect.POSTGRESQL));
+        Index.ColumnParams key = statement.getIndex().getColumns().get(0);
+        assertEquals("\"pg_catalog\".\"default\"", key.getCollation());
+        assertEquals("\"pg_catalog\".\"text_ops\"", key.getOperatorClass());
+        assertEquals(Index.ColumnParams.SortOrder.ASC, key.getSortOrder());
+        assertEquals(Index.ColumnParams.NullOrdering.LAST, key.getNullOrdering());
+        assertNull(key.getParams());
+
+        key.setCollation("public.\"C\"");
+        key.setOperatorClass("public.text_pattern_ops");
+        key.setSortOrder(Index.ColumnParams.SortOrder.DESC);
+        key.setNullOrdering(Index.ColumnParams.NullOrdering.FIRST);
+        assertDeparse(statement,
+                "CREATE INDEX \"index_keyword\" ON \"inter\".\"inter_ti_rec\" USING btree "
+                        + "(\"keyword\" COLLATE public.\"C\" public.text_pattern_ops DESC NULLS FIRST)");
+        assertEquals(key.getOperatorClass(), parse(statement.toString(), Dialect.POSTGRESQL)
+                .getIndex().getColumns().get(0).getOperatorClass());
+        key.setCollation(null);
+        key.setOperatorClass(null);
+        key.setSortOrder(null);
+        key.setNullOrdering(null);
+        assertDeparse(statement,
+                "CREATE INDEX \"index_keyword\" ON \"inter\".\"inter_ti_rec\" USING btree (\"keyword\")");
+    }
+
+    @Test
+    void preservesQuotedNamePartsAndBareFunctionKeys() throws Exception {
+        String sql = "CREATE INDEX ix ON t (lower(name) COLLATE \"schema.with.dot\".\"C\" "
+                + "\"schema\".\"op\"\"class\" DESC NULLS FIRST)";
+        CreateIndex statement = (CreateIndex) assertSqlCanBeParsedAndDeparsed(sql, true,
+                parser -> parser.withDialect(Dialect.POSTGRESQL));
+        Index.ColumnParams key = statement.getIndex().getColumns().get(0);
+        assertTrue(key.isExpression());
+        assertFalse(key.isExpressionParenthesized());
+        assertEquals("\"schema.with.dot\".\"C\"", key.getCollation());
+        assertEquals("\"schema\".\"op\"\"class\"", key.getOperatorClass());
+        assertNull(key.getParams());
+    }
+
+    @Test
+    void keepsPostgreSqlFunctionAndFollowingIndexSeparateIssue1994() throws Exception {
+        String sql = "DROP FUNCTION IF EXISTS fin.restore_fund_data(in_fund_id int8); "
+                + "CREATE OR REPLACE FUNCTION fin.restore_fund_data(in_fund_id int8) "
+                + "RETURNS pg_catalog.varchar AS $BODY$ BEGIN RETURN 'success'; END $BODY$ "
+                + "LANGUAGE plpgsql VOLATILE COST 100; "
+                + "CREATE INDEX ix ON inter.inter_ti_rec "
+                + "(keyword COLLATE pg_catalog.\"default\" pg_catalog.text_ops ASC NULLS LAST); "
+                + "SELECT 1;";
+        Statements statements = CCJSqlParserUtil.parseStatements(sql,
+                parser -> parser.withDialect(Dialect.POSTGRESQL));
+        assertEquals(4, statements.size());
+        assertEquals("pg_catalog.text_ops", ((CreateIndex) statements.get(2))
+                .getIndex().getColumns().get(0).getOperatorClass());
+        assertEquals("SELECT 1", statements.get(3).toString());
+    }
+
+    @Test
+    void gatesQualifiedAttributesAndRejectsRepeatedPostgreSqlAttributes() {
+        for (String key : List.of("name COLLATE public.\"C\"", "name public.text_ops")) {
+            String sql = "CREATE INDEX ix ON t (" + key + ")";
+            assertThrows(JSQLParserException.class, () -> CCJSqlParserUtil.parse(sql));
+            for (Dialect dialect : Dialect.values()) {
+                if (dialect != Dialect.POSTGRESQL) {
+                    assertThrows(JSQLParserException.class, () -> parse(sql, dialect));
+                }
+            }
+        }
+        for (String key : List.of("name ASC DESC", "name NULLS FIRST NULLS LAST",
+                "name COLLATE public.\"C\" COLLATE public.\"C\"")) {
+            assertThrows(JSQLParserException.class,
+                    () -> parse("CREATE INDEX ix ON t (" + key + ")", Dialect.POSTGRESQL));
+        }
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/util/validation/validator/CreateIndexValidatorTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/validation/validator/CreateIndexValidatorTest.java
@@ -16,6 +16,8 @@ import net.sf.jsqlparser.util.validation.ValidationTestAsserts;
 import net.sf.jsqlparser.util.validation.feature.DatabaseType;
 import net.sf.jsqlparser.util.validation.feature.FeaturesAllowed;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class CreateIndexValidatorTest extends ValidationTestAsserts {
 
@@ -34,6 +36,18 @@ public class CreateIndexValidatorTest extends ValidationTestAsserts {
                 "CREATE INDEX idx_american_football_action_plays_1 ON american_football_action_plays USING btree (play_type)")) {
             validateNotAllowed(sql, 1, 1, FeaturesAllowed.DML, Feature.createIndex);
         }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "CREATE INDEX ix ON t ((lower(name)))",
+            "CREATE INDEX ix ON t (name text_ops (option = lower('value')))",
+            "CREATE INDEX ix ON t (name) WITH (option = lower('value'))",
+            "CREATE INDEX ix ON t (name) WHERE lower(name) = 'value'"})
+    void validatesExpressionsInAllIndexClauses(String sql) {
+        FeaturesAllowed allowed = new FeaturesAllowed(Feature.values());
+        validateNoErrors(sql, 1, allowed);
+        validateNotAllowed(sql, 1, 1, allowed.remove(Feature.function), Feature.function);
     }
 
 }


### PR DESCRIPTION
`CREATE INDEX` rejects Spanner's `UNIQUE NULL_FILTERED` combination, SQL Server's `UNIQUE NONCLUSTERED` combination, and the schema-qualified PostgreSQL collation/operator-class example in #1994. This change parses and preserves these definitions with an explicit dialect:

- `SPANNER`: keep uniqueness in `Index.getType()` and null filtering in `CreateIndex.isNullFiltered()`.
- `SQLSERVER`: reuse `Index.getClustering()` independently of uniqueness.
- `POSTGRESQL`: accept qualified collation/operator-class names and bare function keys. Store key attributes once in their structured fields so AST edits are reflected in SQL output.

Share key/option expression rendering between the AST and deparser, and route `CREATE INDEX` through the common definition traversal used by visitors, table discovery and validation. Preserve the default parser's single-type and raw key-parameter behavior, including MySQL prefix lengths.

Fixes #652. Addresses the index example in #1994 and the `CREATE UNIQUE NONCLUSTERED INDEX` failure in #1563. This does not resolve all failures in the Sakila scripts linked from #1563. A regression test also covers a PostgreSQL function followed by an index and another statement.

Validation:
- Gradle `check`: 6,272 tests, no failures, 25 skipped; formatting and static checks passed. The local formatter ratchet uses the upstream base commit because the fork's `origin/master` is behind upstream.
- Maven `verify` passed.
- Coverage includes dialect isolation, modifier combinations, AST edits, expression visitors/deparsers, validation and statement boundaries.

Syntax references: [Spanner](https://docs.cloud.google.com/spanner/docs/reference/standard-sql/data-definition-language#_create_index), [SQL Server](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-index-transact-sql?view=sql-server-ver17), [PostgreSQL](https://www.postgresql.org/docs/18/sql-createindex.html).
