### PR TITLE
Support PostgreSQL DO wrappers with preserved routine body literals

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
+++ b/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
@@ -457,7 +457,7 @@ public enum Feature {
      */
     oracleBlock,
 
-    execute, executeExec, executeCall, executeExecute,
+    execute, executeExec, executeCall, executeExecute, doStatement,
 
     /**
      * SQL "EXECUTE" statement is allowed

--- a/src/main/java/net/sf/jsqlparser/statement/DoStatement.java
+++ b/src/main/java/net/sf/jsqlparser/statement/DoStatement.java
@@ -1,0 +1,78 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement;
+
+import java.util.function.Consumer;
+import net.sf.jsqlparser.expression.StringValue;
+
+/** A PostgreSQL anonymous routine. The language-specific body remains a string literal. */
+public class DoStatement implements Statement {
+    private StringValue code;
+    private String language;
+    private boolean languageBeforeCode;
+
+    public StringValue getCode() {
+        return code;
+    }
+
+    public void setCode(StringValue code) {
+        this.code = code;
+    }
+
+    public DoStatement withCode(StringValue code) {
+        setCode(code);
+        return this;
+    }
+
+    /** Returns the explicit language, or null when omitted. */
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public DoStatement withLanguage(String language) {
+        setLanguage(language);
+        return this;
+    }
+
+    public boolean isLanguageBeforeCode() {
+        return languageBeforeCode;
+    }
+
+    public void setLanguageBeforeCode(boolean languageBeforeCode) {
+        this.languageBeforeCode = languageBeforeCode;
+    }
+
+    public StringBuilder appendTo(StringBuilder builder, Consumer<StringValue> codePrinter) {
+        builder.append("DO ");
+        if (languageBeforeCode && language != null) {
+            builder.append("LANGUAGE ").append(language).append(' ');
+        }
+        codePrinter.accept(code);
+        if (!languageBeforeCode && language != null) {
+            builder.append(" LANGUAGE ").append(language);
+        }
+        return builder;
+    }
+
+    @Override
+    public <T, S> T accept(StatementVisitor<T> visitor, S context) {
+        return visitor.visit(this, context);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        return appendTo(builder, value -> builder.append(value)).toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/StatementFeatureVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementFeatureVisitor.java
@@ -599,6 +599,13 @@ public class StatementFeatureVisitor extends StatementVisitorAdapter<Void> {
     }
 
     @Override
+    public <S> Void visit(DoStatement statement, S context) {
+        analysis.claimTopLevel();
+        analysis.opaque("DO");
+        return null;
+    }
+
+    @Override
     public <S> Void visit(CreateFunctionalStatement createFunctionalStatement, S context) {
         analysis.claimTopLevel();
         analysis.certain(StmtFeature.MODIFIES_SCHEMA);

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitor.java
@@ -210,6 +210,14 @@ public interface StatementVisitor<T> {
 
     <S> T visit(Execute execute, S context);
 
+    default <S> T visit(DoStatement statement, S context) {
+        return null;
+    }
+
+    default void visit(DoStatement statement) {
+        this.visit(statement, null);
+    }
+
     default void visit(Execute execute) {
         this.visit(execute, null);
     }

--- a/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
+++ b/src/main/java/net/sf/jsqlparser/statement/StatementVisitorAdapter.java
@@ -424,6 +424,12 @@ public class StatementVisitorAdapter<T> implements StatementVisitor<T> {
     }
 
     @Override
+    public <S> T visit(DoStatement statement, S context) {
+        expressionVisitor.visitExpression(statement.getCode(), context);
+        return null;
+    }
+
+    @Override
     public <S> T visit(LockStatement lock, S context) {
 
         return null;

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -91,6 +91,7 @@ import net.sf.jsqlparser.statement.Commit;
 import net.sf.jsqlparser.statement.CreateFunctionalStatement;
 import net.sf.jsqlparser.statement.DeclareStatement;
 import net.sf.jsqlparser.statement.DescribeStatement;
+import net.sf.jsqlparser.statement.DoStatement;
 import net.sf.jsqlparser.statement.ExplainStatement;
 import net.sf.jsqlparser.statement.IfElseStatement;
 import net.sf.jsqlparser.statement.OutputClause;
@@ -1561,6 +1562,12 @@ public class TablesNamesFinder<Void>
         TableDefinitionTraversal.visit(createIndex,
                 expression -> expression.accept(this, context),
                 table -> visit(table, context));
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(DoStatement statement, S context) {
+        throwUnsupported(statement);
         return null;
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -38,6 +38,7 @@ import net.sf.jsqlparser.statement.Commit;
 import net.sf.jsqlparser.statement.CreateFunctionalStatement;
 import net.sf.jsqlparser.statement.DeclareStatement;
 import net.sf.jsqlparser.statement.DescribeStatement;
+import net.sf.jsqlparser.statement.DoStatement;
 import net.sf.jsqlparser.statement.ExplainStatement;
 import net.sf.jsqlparser.statement.IfElseStatement;
 import net.sf.jsqlparser.statement.PurgeStatement;
@@ -149,6 +150,11 @@ public class StatementDeParser extends AbstractDeParser<Statement>
                 new CreateIndexDeParser(builder, expressionDeParser);
         createIndexDeParser.deParse(createIndex);
         return builder;
+    }
+
+    @Override
+    public <S> StringBuilder visit(DoStatement statement, S context) {
+        return statement.appendTo(builder, code -> code.accept(expressionDeParser, context));
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/PostgresqlVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/PostgresqlVersion.java
@@ -27,6 +27,7 @@ public enum PostgresqlVersion implements Version {
             EnumSet.of(// supported if used with jdbc
                     Feature.jdbcParameter,
                     Feature.jdbcNamedParameter, // expressions
+                    Feature.doStatement,
                     Feature.exprLike,
                     Feature.exprSimilarTo, // https://www.postgresql.org/docs/current/sql-select.html
                     Feature.select,

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/StatementValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/StatementValidator.java
@@ -35,6 +35,7 @@ import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.statement.Block;
 import net.sf.jsqlparser.statement.Commit;
 import net.sf.jsqlparser.statement.CreateFunctionalStatement;
+import net.sf.jsqlparser.statement.DoStatement;
 import net.sf.jsqlparser.statement.DeclareStatement;
 import net.sf.jsqlparser.statement.DescribeStatement;
 import net.sf.jsqlparser.statement.ExplainStatement;
@@ -229,6 +230,12 @@ public class StatementValidator extends AbstractValidator<Statement>
     @Override
     public <S> Void visit(Execute execute, S context) {
         getValidator(ExecuteValidator.class).validate(execute);
+        return null;
+    }
+
+    @Override
+    public <S> Void visit(DoStatement statement, S context) {
+        validateFeature(Feature.doStatement);
         return null;
     }
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2764,6 +2764,9 @@ Statement SingleStatement() :
             |
             stm = Execute()
             |
+            LOOKAHEAD({ getToken(1).kind == K_DO && Dialect.POSTGRESQL.name().equals(getAsString(Feature.dialect)) })
+            stm = DoStatement()
+            |
             stm = Set()
             |
             stm = Reset()
@@ -2881,6 +2884,26 @@ OracleBlock.ExceptionHandler OracleExceptionHandler():
     <K_WHEN> name=TypeDdlName() { handler.getExceptions().add(name); }
     ( <K_OR> name=TypeDdlName() { handler.getExceptions().add(name); } )*
     <K_THEN> body=OracleBlockStatements() { handler.setStatements(body); return handler; }
+}
+
+DoStatement DoStatement():
+{
+    DoStatement statement = new DoStatement();
+    String language;
+    Token code;
+}
+{
+    <K_DO>
+    (
+        LOOKAHEAD({ isKeywordAhead("LANGUAGE") })
+        AccessKeyword("LANGUAGE") language=RelObjectName() code=<S_CHAR_LITERAL>
+        { statement.setLanguage(language); statement.setLanguageBeforeCode(true); }
+        |
+        code=<S_CHAR_LITERAL>
+        [ LOOKAHEAD({ isKeywordAhead("LANGUAGE") }) AccessKeyword("LANGUAGE")
+            language=RelObjectName() { statement.setLanguage(language); } ]
+    )
+    { statement.setCode(new StringValue(code.image)); return statement; }
 }
 
 Block Block() #Block : {

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -766,6 +766,17 @@ uses the existing ``Update`` model's ``fromItem`` and ``joins`` properties.
 Table discovery and metadata validation recognize a target alias declared in
 that FROM clause. Other dialects retain the existing FROM-after-SET syntax.
 
+``Dialect.POSTGRESQL`` enables ``DO [LANGUAGE name] code [LANGUAGE name]``,
+with the language clause allowed once, before or after the body.
+``DoStatement.getCode()`` is a ``StringValue`` that preserves the literal's
+quotes, dollar tag and body text. The optional language and its position have
+separate properties; an omitted language remains unspecified in the AST.
+The body is language-specific source, not a parsed PL/pgSQL statement tree.
+Expression visitors can inspect or replace the body literal. Feature analysis
+reports ``OPAQUE``; table discovery rejects this statement because the body's
+table accesses are unknown. Validation checks the ``doStatement`` capability,
+without validating the procedural language inside the literal.
+
 With ``Dialect.SQLSERVER``, ``PRIMARY KEY NONCLUSTERED (id)`` and
 ``UNIQUE CLUSTERED (id)`` store their clustering option in ``Index.getClustering()``
 for both ``CREATE TABLE`` and ``ALTER TABLE``. Without that dialect, these words

--- a/src/test/java/net/sf/jsqlparser/statement/DoStatementTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/DoStatementTest.java
@@ -1,0 +1,127 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.parser.AbstractJSqlParser.Dialect;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.parser.feature.Feature;
+import net.sf.jsqlparser.parser.feature.FeatureConfiguration;
+import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
+import net.sf.jsqlparser.util.validation.Validation;
+import net.sf.jsqlparser.util.validation.feature.FeaturesAllowed;
+import net.sf.jsqlparser.util.validation.feature.PostgresqlVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DoStatementTest {
+    @ParameterizedTest
+    @ValueSource(strings = {"DO $$BEGIN NULL; END$$", "DO LANGUAGE plpgsql $$BEGIN NULL; END$$",
+            "DO $body$BEGIN NULL; END$body$ LANGUAGE plpgsql", "DO 'BEGIN NULL; END'",
+            "DO LANGUAGE plpython3u 'print(1)'"})
+    void roundTripsBodyAndLanguagePosition(String sql) throws Exception {
+        DoStatement statement = (DoStatement) assertSqlCanBeParsedAndDeparsed(sql, false,
+                p -> p.withDialect(Dialect.POSTGRESQL));
+        assertEquals(sql, CCJSqlParserUtil.parse(statement.toString(),
+                p -> p.withDialect(Dialect.POSTGRESQL)).toString());
+        assertEquals(sql.startsWith("DO LANGUAGE"), statement.isLanguageBeforeCode());
+        assertEquals(
+                sql.contains("LANGUAGE") ? sql.contains("plpython") ? "plpython3u" : "plpgsql"
+                        : null,
+                statement.getLanguage());
+        assertTrue(statement.getFeatures().isOpaque());
+        assertTrue(statement.getFeatures().mayModifyData());
+        assertThrows(UnsupportedOperationException.class,
+                () -> new TablesNamesFinder().getTables(statement));
+    }
+
+    @Test
+    void preservesProceduralBodyAndFollowingStatementsIssue1946() throws Exception {
+        String body = "$$\nBEGIN\n IF NOT EXISTS (SELECT 1 FROM comm.permission_operation) THEN\n"
+                + " INSERT INTO comm.permission_operation (permission_operation_id) VALUES (1) "
+                + "ON CONFLICT (permission_operation_id) DO NOTHING;\n END IF;\nEND $$";
+        Statements statements = CCJSqlParserUtil.parseStatements("DO " + body + "; SELECT 1;",
+                p -> p.withDialect(Dialect.POSTGRESQL));
+        assertEquals(2, statements.size());
+        assertEquals(body, ((DoStatement) statements.get(0)).getCode().toString());
+        assertEquals("SELECT 1", statements.get(1).toString());
+    }
+
+    @Test
+    void supportsBodyVisitorsAndAstEdits() throws Exception {
+        DoStatement statement = (DoStatement) CCJSqlParserUtil.parse("DO $$BEGIN NULL; END$$",
+                p -> p.withDialect(Dialect.POSTGRESQL));
+        List<String> bodies = new ArrayList<>();
+        statement.accept(new StatementVisitorAdapter<>(new SelectVisitorAdapter<>(
+                new ExpressionVisitorAdapter<Void>() {
+                    @Override
+                    public <S> Void visit(StringValue value, S context) {
+                        assertEquals("context", context);
+                        bodies.add(value.toString());
+                        return null;
+                    }
+                })), "context");
+        assertEquals(List.of("$$BEGIN NULL; END$$"), bodies);
+        statement.withCode(new StringValue("$new$BEGIN PERFORM 1; END$new$"))
+                .withLanguage("plpgsql");
+        statement.setLanguageBeforeCode(true);
+        assertEquals("DO LANGUAGE plpgsql $new$BEGIN PERFORM 1; END$new$", statement.toString());
+        StringBuilder output = new StringBuilder();
+        ExpressionDeParser expressions = new ExpressionDeParser() {
+            @Override
+            public <S> StringBuilder visit(StringValue value, S context) {
+                return getBuilder().append("$$BEGIN NULL; END$$");
+            }
+        };
+        statement.accept(new StatementDeParser(expressions, new SelectDeParser(), output));
+        assertEquals("DO LANGUAGE plpgsql $$BEGIN NULL; END$$", output.toString());
+    }
+
+    @Test
+    void gatesDialectAndRejectsMalformedWrappers() throws Exception {
+        String sql = "DO $$BEGIN NULL; END$$";
+        assertThrows(JSQLParserException.class, () -> CCJSqlParserUtil.parse(sql));
+        for (Dialect dialect : Dialect.values()) {
+            if (dialect != Dialect.POSTGRESQL) {
+                assertThrows(JSQLParserException.class,
+                        () -> CCJSqlParserUtil.parse(sql, p -> p.withDialect(dialect)));
+            }
+        }
+        for (String malformed : List.of("DO", "DO LANGUAGE plpgsql", "DO 123",
+                "DO LANGUAGE plpgsql $$x$$ LANGUAGE plpgsql", "DO $tag$unterminated")) {
+            assertThrows(JSQLParserException.class,
+                    () -> CCJSqlParserUtil.parse(malformed,
+                            p -> p.withDialect(Dialect.POSTGRESQL)));
+        }
+    }
+
+    @Test
+    void validatesWrapperCapabilityWithoutClaimingBodyValidation() {
+        FeatureConfiguration config = new FeatureConfiguration()
+                .setValue(Feature.dialect, Dialect.POSTGRESQL.name());
+        assertTrue(new Validation(config, List.of(PostgresqlVersion.V10),
+                "DO $$arbitrary language body$$")
+                .validate().isEmpty());
+        assertFalse(new Validation(config, List.of(new FeaturesAllowed(Feature.select)),
+                "DO $$arbitrary language body$$").validate().isEmpty());
+    }
+}


### PR DESCRIPTION
With `Dialect.POSTGRESQL`, `DO` now parses into a dedicated `DoStatement` that preserves its body literal, dollar-quote tag, optional language and language-clause position. The wrapper uses shared rendering for the model and deparser; visitors can inspect or replace the body literal, and validation exposes a PostgreSQL `doStatement` capability.

This is the wrapper/body-preservation stage of #1946. It does not parse the procedural language inside the string into an INSERT/IF/loop AST. Feature analysis reports the statement as opaque, and table discovery explicitly reports unsupported analysis rather than claiming an empty set of tables.

Tests cover both LANGUAGE positions, tagged/untagged dollar and single-quoted bodies, a representative issue block followed by another statement, AST edits, visitor/deparser customization, dialect isolation, capability validation and malformed wrappers. Full Gradle check and Maven verify passed (local formatter ratchet: upstream base `eddb1fb5`).

Refs #1946.

Syntax: [PostgreSQL DO](https://www.postgresql.org/docs/18/sql-do.html).
