### PR TITLE
Support SQL Server XML methods on subquery results

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
+++ b/src/main/java/net/sf/jsqlparser/expression/ExpressionVisitor.java
@@ -569,6 +569,15 @@ public interface ExpressionVisitor<T> {
 
     <S> T visit(RowGetExpression rowGetExpression, S context);
 
+    default <S> T visit(MethodCallExpression methodCall, S context) {
+        methodCall.getExpression().accept(this, context);
+        return methodCall.getMethod().accept(this, context);
+    }
+
+    default void visit(MethodCallExpression methodCall) {
+        this.visit(methodCall, null);
+    }
+
     default void visit(RowGetExpression rowGetExpression) {
         this.visit(rowGetExpression, null);
     }

--- a/src/main/java/net/sf/jsqlparser/expression/MethodCallExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/MethodCallExpression.java
@@ -1,0 +1,58 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression;
+
+import java.util.function.Consumer;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
+/** A method applied to an expression, such as a SQL Server XML subquery result. */
+public class MethodCallExpression extends ASTNodeAccessImpl implements Expression {
+    private Expression expression;
+    private Function method;
+
+    public MethodCallExpression(Expression expression, Function method) {
+        this.expression = expression;
+        this.method = method;
+    }
+
+    public Expression getExpression() {
+        return expression;
+    }
+
+    public void setExpression(Expression expression) {
+        this.expression = expression;
+    }
+
+    public Function getMethod() {
+        return method;
+    }
+
+    public void setMethod(Function method) {
+        this.method = method;
+    }
+
+    public StringBuilder appendTo(StringBuilder builder, Consumer<Expression> printer) {
+        printer.accept(expression);
+        builder.append('.');
+        printer.accept(method);
+        return builder;
+    }
+
+    @Override
+    public <T, S> T accept(ExpressionVisitor<T> visitor, S context) {
+        return visitor.visit(this, context);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        return appendTo(builder, value -> builder.append(value)).toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -1775,6 +1775,11 @@ public class TablesNamesFinder<Void>
     }
 
     @Override
+    public <S> Void visit(MethodCallExpression methodCall, S context) {
+        return ExpressionVisitor.super.visit(methodCall, context);
+    }
+
+    @Override
     public <S> Void visit(HexValue hexValue, S context) {
         return null;
     }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -64,6 +64,7 @@ import net.sf.jsqlparser.expression.PostgresNamedFunctionParameter;
 import net.sf.jsqlparser.expression.RangeExpression;
 import net.sf.jsqlparser.expression.RowConstructor;
 import net.sf.jsqlparser.expression.RowGetExpression;
+import net.sf.jsqlparser.expression.MethodCallExpression;
 import net.sf.jsqlparser.expression.SignedExpression;
 import net.sf.jsqlparser.expression.StringValue;
 import net.sf.jsqlparser.expression.StructType;
@@ -1469,6 +1470,11 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
         rowGetExpression.getExpression().accept(this, context);
         builder.append(".").append(rowGetExpression.getColumnName());
         return null;
+    }
+
+    @Override
+    public <S> StringBuilder visit(MethodCallExpression methodCall, S context) {
+        return methodCall.appendTo(builder, expression -> expression.accept(this, context));
     }
 
     @Override

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -9180,10 +9180,17 @@ Expression NavigationStep(Expression base):
 {
     Expression step = null;
     String nm = null;
+    Function method;
 }
 {
     (
-        "." nm=RelObjectNameExt() { step = new RowGetExpression(base, nm); }
+        "."
+        (
+            LOOKAHEAD({ Dialect.SQLSERVER.name().equals(getAsString(Feature.dialect)) && isFunctionAhead() })
+            method=Function() { step = new MethodCallExpression(base, method); }
+            |
+            nm=RelObjectNameExt() { step = new RowGetExpression(base, nm); }
+        )
         |
         step = ArrayExpression(base)
     )
@@ -9201,7 +9208,6 @@ Expression PrimaryExpression() #PrimaryExpression:
     Token token = null;
     Token sign = null;
     Token adjacentToken = null;
-    String tmp = "";
     ColDataType type = null;
     boolean not = false;
     boolean exclamationMarkNot = false;
@@ -9354,8 +9360,8 @@ Expression PrimaryExpression() #PrimaryExpression:
                 "." "*"
                 { retval = new FunctionAllColumns(unwrapParenthesedFunction(retval)); } ]
 
-            // RowGet Expressions
-            ( LOOKAHEAD(2) "." tmp=RelObjectName() { retval = new RowGetExpression(retval, tmp); } )*
+            // Share field and method navigation with the other primary expressions.
+            ( LOOKAHEAD(".") nxt=NavigationStep(retval) { retval = nxt; } )*
         )
     )
 

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -766,6 +766,13 @@ uses the existing ``Update`` model's ``fromItem`` and ``joins`` properties.
 Table discovery and metadata validation recognize a target alias declared in
 that FROM clause. Other dialects retain the existing FROM-after-SET syntax.
 
+``Dialect.SQLSERVER`` supports methods on expression results, including
+``(SELECT ... FOR XML PATH(''), TYPE).value('.', 'varchar(max)')``.
+``MethodCallExpression`` exposes the receiver expression and a ``Function``
+containing the method name and arguments. Field access and method calls share
+the navigation grammar; expression visitors and deparsers traverse both the
+receiver and method arguments. XQuery strings remain string literals.
+
 With ``Dialect.SQLSERVER``, ``PRIMARY KEY NONCLUSTERED (id)`` and
 ``UNIQUE CLUSTERED (id)`` store their clustering option in ``Index.getClustering()``
 for both ``CREATE TABLE`` and ``ALTER TABLE``. Without that dialect, these words

--- a/src/test/java/net/sf/jsqlparser/statement/select/SqlServerXmlMethodTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/select/SqlServerXmlMethodTest.java
@@ -1,0 +1,139 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.select;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.expression.Function;
+import net.sf.jsqlparser.expression.MethodCallExpression;
+import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.parser.AbstractJSqlParser.Dialect;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.parser.feature.Feature;
+import net.sf.jsqlparser.parser.feature.FeatureConfiguration;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.StatementVisitorAdapter;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
+import net.sf.jsqlparser.util.validation.Validation;
+import net.sf.jsqlparser.util.validation.feature.FeaturesAllowed;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class SqlServerXmlMethodTest {
+    private static final String SIMPLE =
+            "SELECT (SELECT body FROM docs FOR XML PATH (''), TYPE).value('.', 'varchar(max)')";
+
+    private static PlainSelect parse(String sql) throws Exception {
+        return (PlainSelect) CCJSqlParserUtil.parse(sql, p -> p.withDialect(Dialect.SQLSERVER));
+    }
+
+    @Test
+    void parsesOriginalStuffQueryIssue386() throws Exception {
+        String sql = "SELECT (STUFF((SELECT '|' + person_name FROM person "
+                + "JOIN person_group ON person.person_id = person_group.person_id "
+                + "WHERE person_group.group_id = 1 FOR XML PATH(''), TYPE)"
+                + ".value('.', 'varchar(max)'), 1, 1, '')) AS person_name";
+        Statement statement = assertSqlCanBeParsedAndDeparsed(sql, true,
+                p -> p.withDialect(Dialect.SQLSERVER));
+        assertEquals(Set.of("person", "person_group"),
+                new TablesNamesFinder().getTables(statement));
+        assertEquals(statement.toString(), parse(statement.toString()).toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"value('.', 'varchar(max)')", "query('/root')", "exist('/root')",
+            "query('/root').value('.', 'int')"})
+    void preservesMethodsAndChains(String method) throws Exception {
+        String sql = "SELECT (SELECT body FROM docs FOR XML PATH(''), TYPE)." + method;
+        PlainSelect select = (PlainSelect) assertSqlCanBeParsedAndDeparsed(sql, true,
+                p -> p.withDialect(Dialect.SQLSERVER));
+        MethodCallExpression call = (MethodCallExpression) select.getSelectItem(0).getExpression();
+        assertInstanceOf(ParenthesedSelect.class, call.getExpression());
+        assertEquals(method.substring(0, method.indexOf('(')), call.getMethod().getName());
+        assertEquals(select.toString(), parse(select.toString()).toString());
+        assertEquals(Set.of("docs"), new TablesNamesFinder().getTables((Statement) select));
+    }
+
+    @Test
+    void visitsReceiverAndMethodArgumentsWithContext() throws Exception {
+        List<String> values = new ArrayList<>();
+        ExpressionVisitorAdapter<Void> expressions = new ExpressionVisitorAdapter<Void>() {
+            @Override
+            public <S> Void visit(StringValue value, S context) {
+                assertEquals("context", context);
+                values.add(value.getValue());
+                return null;
+            }
+        };
+        SelectVisitorAdapter<Void> selects = new SelectVisitorAdapter<>(expressions);
+        expressions.setSelectVisitor(selects);
+        parse(SIMPLE).accept(new StatementVisitorAdapter<>(selects), "context");
+        assertTrue(values.contains("."));
+        assertTrue(values.contains("varchar(max)"));
+        assertEquals(1, values.stream().filter("."::equals).count());
+    }
+
+    @Test
+    void editsAndDeparsesMethodArguments() throws Exception {
+        PlainSelect select = parse(SIMPLE);
+        MethodCallExpression call = (MethodCallExpression) select.getSelectItem(0).getExpression();
+        call.setMethod(new Function("query", new StringValue("'/root'")));
+        StringBuilder output = new StringBuilder();
+        ExpressionDeParser expressions = new ExpressionDeParser() {
+            @Override
+            public <S> StringBuilder visit(StringValue value, S context) {
+                return getBuilder().append("'changed'");
+            }
+        };
+        select.accept(new StatementDeParser(expressions, new SelectDeParser(), output));
+        assertTrue(output.toString().endsWith(".query('changed')"));
+        assertTrue(select.toString().endsWith(".query('/root')"));
+        assertEquals(output.toString(), parse(output.toString()).toString());
+    }
+
+    @Test
+    void gatesDialectAndRetainsRowNavigation() throws Exception {
+        assertThrows(JSQLParserException.class, () -> CCJSqlParserUtil.parse(SIMPLE));
+        for (Dialect dialect : Dialect.values()) {
+            if (dialect != Dialect.SQLSERVER) {
+                assertThrows(JSQLParserException.class,
+                        () -> CCJSqlParserUtil.parse(SIMPLE, p -> p.withDialect(dialect)));
+            }
+        }
+        assertSqlCanBeParsedAndDeparsed("SELECT (row_value).field FROM t");
+        assertSqlCanBeParsedAndDeparsed("SELECT (row_value).field COLLATE en_US FROM t");
+        assertThrows(JSQLParserException.class,
+                () -> parse(SIMPLE.substring(0, SIMPLE.length() - 1)));
+        assertEquals(2, CCJSqlParserUtil.parseStatements(SIMPLE + "; SELECT 1;",
+                p -> p.withDialect(Dialect.SQLSERVER)).size());
+    }
+
+    @Test
+    void validatesMethodAsFunction() {
+        String sql = "SELECT 1 WHERE " + SIMPLE.substring("SELECT ".length()) + " = 'value'";
+        FeatureConfiguration config = new FeatureConfiguration().setValue(Feature.dialect,
+                Dialect.SQLSERVER.name());
+        assertTrue(new Validation(config, List.of(new FeaturesAllowed(Feature.values())), sql)
+                .validate().isEmpty());
+        assertFalse(new Validation(config,
+                List.of(new FeaturesAllowed(Feature.values()).remove(Feature.function)), sql)
+                .validate().isEmpty());
+    }
+}


### PR DESCRIPTION
Fixes #386.

With `Dialect.SQLSERVER`, XML results from parenthesized `SELECT ... FOR XML ... TYPE` queries now support `.value()`, `.query()` and chained method calls, including the reported `STUFF` query. `MethodCallExpression` exposes the receiver and existing `Function` arguments, and shared navigation parsing and rendering keep row navigation, visitors, table discovery and custom deparsing consistent. XQuery strings remain literals.

Validation: full Gradle `check` (including formatting and static analysis) and Maven `verify` passed. Regression coverage includes the issue query, AST mutation, visitor context, capability validation, dialect isolation and existing field navigation.

Reference: [Microsoft FOR XML TYPE examples](https://learn.microsoft.com/en-us/sql/relational-databases/xml/type-directive-in-for-xml-queries?view=sql-server-ver17).
