### PR TITLE
Resolve shadowed contextual keyword and data-type token warnings

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -2339,6 +2339,8 @@ TOKEN : /* Date/Time with time zones */
 
 TOKEN : /* Data Types */
 {
+    // Dedicated keyword tokens (e.g. K_BINARY/K_CHAR) are consumed by DataType().
+    // Repeating them here cannot match DATA_TYPE and causes unreachable-token warnings.
     <DATA_TYPE: ( <TYPE_BIT> | <TYPE_BLOB> | <TYPE_BOOLEAN> |  <TYPE_ENUM>
                      | <TYPE_REAL> | <TYPE_DOUBLE> | <TYPE_UUID> | <TYPE_MAP>| <TYPE_TINYINT> | <TYPE_SMALLINT>
                      | <TYPE_INTEGER> | <TYPE_BIGINT> | <TYPE_HUGEINT> | <TYPE_UTINYINT> | <TYPE_USMALLINT>
@@ -2347,15 +2349,15 @@ TOKEN : /* Data Types */
               ) >
 
     | <#TYPE_BIT:  "BISTRING">
-    | <#TYPE_BLOB: "BLOB" | "BYTEA" | <K_BINARY> | "VARBINARY" | <K_BYTES> >
-    | <#TYPE_BOOLEAN: <K_BOOLEAN> | "BOOL" >
+    | <#TYPE_BLOB: "BLOB" | "BYTEA" | "VARBINARY" >
+    | <#TYPE_BOOLEAN: "BOOL" >
     | <#TYPE_CLOB: "CLOB">
     | <#TYPE_ENUM: "ENUM" >
     | <#TYPE_MAP: "MAP" >
     | <#TYPE_DECIMAL: "DECIMAL" | "NUMBER" | "NUMERIC" >
     | <#TYPE_TINYINT: "TINYINT" | "INT1" >
     | <#TYPE_SMALLINT: "SMALLINT" | "INT2" | "SHORT" >
-    | <#TYPE_INTEGER: ( "INTEGER" | "INT" | "INT4" | <K_SIGNED> | <K_UNSIGNED> ) >
+    | <#TYPE_INTEGER: ( "INTEGER" | "INT" | "INT4" ) >
     | <#TYPE_BIGINT: "BIGINT" | "INT8" | "LONG" >
     | <#TYPE_HUGEINT: "HUGEINT" >
     | <#TYPE_UTINYINT: "UTINYINT" >
@@ -2365,7 +2367,7 @@ TOKEN : /* Data Types */
     | <#TYPE_UHUGEINT: "UHUGEINT" >
     | <#TYPE_REAL: "REAL" | "FLOAT4" | "FLOAT">
     | <#TYPE_DOUBLE: "DOUBLE" | "PRECISION"  | "FLOAT8" | "FLOAT64">
-    | <#TYPE_VARCHAR: "NVARCHAR" | "VARCHAR" | "NCHAR" | <K_CHAR> | "BPCHAR" | "TEXT" | "STRING" | <K_CHARACTER> | "VARYING">
+    | <#TYPE_VARCHAR: "NVARCHAR" | "VARCHAR" | "NCHAR" | "BPCHAR" | "TEXT" | "STRING" | "VARYING">
     | <#TYPE_TIME: "TIMETZ" >
     | <#TYPE_TIMESTAMP: "TIMESTAMP_NS" | "TIMESTAMP_MS" | "TIMESTAMP_S"  >
 
@@ -5756,7 +5758,8 @@ String SetOperationModifier():
              [ ( tk=<K_ALL> | tk="DISTINCT")  { modifier+=tk.image; } ]
             <K_BY> <K_NAME> { modifier+= " BY NAME"; }
             [
-                "MATCHING" { modifier+= " MATCHING"; }
+                LOOKAHEAD({ isKeywordAhead("MATCHING") })
+                ContextualKeyword("MATCHING") { modifier+= " MATCHING"; }
                 "("
                 identifier = RelObjectName() { modifier+="(" + identifier; }
                 ("," identifier = RelObjectName()  { modifier+=", " + identifier; })*
@@ -15526,14 +15529,14 @@ AlterSystemStatement AlterSystemStatement():
         |
         (
             <K_ENABLE>  (
-                            "DISTRIBUTED" "RECOVERY" { operation = AlterSystemOperation.ENABLE_DISTRIBUTED_RECOVERY; }
+                            ContextualKeyword("DISTRIBUTED") ContextualKeyword("RECOVERY") { operation = AlterSystemOperation.ENABLE_DISTRIBUTED_RECOVERY; }
                             | <K_RESTRICTED> <K_SESSION> { operation = AlterSystemOperation.ENABLE_DISTRIBUTED_RECOVERY; }
                         )
         )
         |
         (
             <K_DISABLE> (
-                            "DISTRIBUTED" "RECOVERY" { operation = AlterSystemOperation.DISABLE_DISTRIBUTED_RECOVERY; }
+                            ContextualKeyword("DISTRIBUTED") ContextualKeyword("RECOVERY") { operation = AlterSystemOperation.DISABLE_DISTRIBUTED_RECOVERY; }
                             | <K_RESTRICTED> <K_SESSION> { operation = AlterSystemOperation.DISABLE_RESTRICTED_SESSION; }
                         )
         )
@@ -15686,6 +15689,17 @@ Comment Comment():
     )
     {
         return result;
+    }
+}
+
+/** Consumes a keyword that remains an ordinary identifier outside this grammar context. */
+void ContextualKeyword(String expected):
+{ Token keyword; }
+{
+    keyword=<S_IDENTIFIER> {
+        if (!expected.equalsIgnoreCase(keyword.image)) {
+            throw new ParseException("Expected " + expected + " but found " + keyword.image);
+        }
     }
 }
 

--- a/src/test/java/net/sf/jsqlparser/parser/ContextualTokenTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/ContextualTokenTest.java
@@ -1,0 +1,78 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.parser;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.statement.alter.AlterSystemStatement;
+import net.sf.jsqlparser.statement.alter.AlterSystemOperation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static net.sf.jsqlparser.test.TestUtils.assertSqlCanBeParsedAndDeparsed;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ContextualTokenTest {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "SELECT a FROM t UNION ALL BY NAME MATCHING (a) SELECT a FROM u",
+            "SELECT a FROM t UNION DISTINCT BY NAME MATCHING (a, b) SELECT a FROM u",
+            "ALTER SYSTEM ENABLE DISTRIBUTED RECOVERY",
+            "ALTER SYSTEM DISABLE DISTRIBUTED RECOVERY"
+    })
+    void parsesPreviouslyShadowedContextualKeywords(String sql) throws Exception {
+        for (boolean complex : new boolean[] {false, true}) {
+            String parsed = assertSqlCanBeParsedAndDeparsed(sql, true,
+                    parser -> parser.withAllowComplexParsing(complex)).toString();
+            assertEquals(parsed, CCJSqlParserUtil.parse(parsed).toString());
+        }
+    }
+
+    @Test
+    void preservesAlterSystemOperation() throws Exception {
+        assertEquals(AlterSystemOperation.ENABLE_DISTRIBUTED_RECOVERY,
+                ((AlterSystemStatement) CCJSqlParserUtil.parse(
+                        "alter system enable distributed recovery")).getOperation());
+        assertEquals(AlterSystemOperation.DISABLE_DISTRIBUTED_RECOVERY,
+                ((AlterSystemStatement) CCJSqlParserUtil.parse(
+                        "alter system disable distributed recovery")).getOperation());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"MATCHING", "DISTRIBUTED", "RECOVERY"})
+    void keepsContextualWordsUsableAsIdentifiers(String word) throws Exception {
+        assertEquals(CCJSqlParserConstants.S_IDENTIFIER,
+                CCJSqlParserUtil.newParser(word).getNextToken().kind);
+        assertSqlCanBeParsedAndDeparsed("SELECT " + word + ", " + word
+                + "(a) FROM " + word + " AS x", true);
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {"BYTES", "BINARY", "BOOLEAN", "UNSIGNED", "SIGNED", "CHARACTER", "CHAR"})
+    void retainsDedicatedTypeTokensAndTypeParsing(String type) throws Exception {
+        assertNotEquals(CCJSqlParserConstants.DATA_TYPE,
+                CCJSqlParserUtil.newParser(type).getNextToken().kind);
+        assertSqlCanBeParsedAndDeparsed("CREATE TABLE t (c " + type + ")", true);
+        assertSqlCanBeParsedAndDeparsed("SELECT CAST(c AS " + type + ") FROM t", true);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "ALTER SYSTEM ENABLE other RECOVERY",
+            "ALTER SYSTEM DISABLE DISTRIBUTED other",
+            "ALTER SYSTEM ENABLE DISTRIBUTED",
+            "SELECT a FROM t UNION ALL BY NAME other (a) SELECT a FROM u",
+            "SELECT a FROM t UNION ALL BY NAME MATCHING () SELECT a FROM u"
+    })
+    void rejectsWrongContextualKeywords(String sql) {
+        assertThrows(JSQLParserException.class, () -> CCJSqlParserUtil.parse(sql));
+    }
+}


### PR DESCRIPTION
JavaCC reports ten remaining shadowed/unreachable token warnings from #2403. Three also hide real parsing failures: `MATCHING` in `UNION ... BY NAME MATCHING (...)` and `DISTRIBUTED RECOVERY` in `ALTER SYSTEM` are lexed as identifiers but the grammar expects unreachable literal tokens.

Consume these words with a shared contextual-keyword production, retaining their use as ordinary identifiers elsewhere. Remove seven unreachable dedicated-keyword alternatives from `DATA_TYPE`; `DataType()` already handles those token kinds directly. This keeps the change separate from a broader token redesign.

Validation: the three affected statement examples failed on master and pass with this change. Full Gradle `check` and Maven `clean verify`, plus regressions for contextual words as identifiers, dedicated data-type tokens/casts, operation identity, round trips, and invalid contextual keywords. All ten warnings reported by this issue that remained on master are removed; the pre-existing `WITH` lookahead warning remains.

Integration validation: all twelve existing PRs plus these three independent fixes pass full Gradle `check` together (6,495 tests; 0 failures/errors; 25 skipped). Existing dialect-enum, shared-index-helper and documentation conflicts were resolved only in the local validation branch.

Fixes #2403.
