### PR TITLE
fix(parser): preserve Oracle PRIOR position on all condition expressions (#2601)

### DIFF
--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/Between.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/Between.java
@@ -16,7 +16,7 @@ import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 /**
  * A "BETWEEN" expr1 expr2 statement
  */
-public class Between extends ASTNodeAccessImpl implements Expression {
+public class Between extends ASTNodeAccessImpl implements Expression, SupportsOldOracleJoinSyntax {
 
     private Expression leftExpression;
     private boolean not = false;
@@ -82,7 +82,8 @@ public class Between extends ASTNodeAccessImpl implements Expression {
 
     @Override
     public String toString() {
-        return leftExpression + " " + (not ? "NOT " : "") + "BETWEEN "
+        return (oraclePriorPosition == ORACLE_PRIOR_START ? "PRIOR " : "") + leftExpression + " "
+                + (not ? "NOT " : "") + "BETWEEN "
                 + (usingSymmetric ? "SYMMETRIC " : "") + (usingAsymmetric ? "ASYMMETRIC " : "")
                 + betweenExpressionStart
                 + " AND "
@@ -120,4 +121,39 @@ public class Between extends ASTNodeAccessImpl implements Expression {
     public <E extends Expression> E getLeftExpression(Class<E> type) {
         return type.cast(getLeftExpression());
     }
+
+    private int oraclePriorPosition = NO_ORACLE_PRIOR;
+
+    @Override
+    public int getOldOracleJoinSyntax() {
+        return NO_ORACLE_JOIN;
+    }
+
+    @Override
+    public void setOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        throw new IllegalArgumentException(
+                "oracle join operator (+) is not supported on this condition");
+    }
+
+    @Override
+    public Between withOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        setOldOracleJoinSyntax(oldOracleJoinSyntax);
+        return this;
+    }
+
+    @Override
+    public int getOraclePriorPosition() {
+        return oraclePriorPosition;
+    }
+
+    @Override
+    public void setOraclePriorPosition(int oraclePriorPosition) {
+        this.oraclePriorPosition = oraclePriorPosition;
+    }
+
+    public Between withOraclePriorPosition(int oraclePriorPosition) {
+        setOraclePriorPosition(oraclePriorPosition);
+        return this;
+    }
+
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/InExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/InExpression.java
@@ -22,6 +22,8 @@ public class InExpression extends ASTNodeAccessImpl
     private Expression rightExpression;
     private int oldOracleJoinSyntax = NO_ORACLE_JOIN;
 
+    private int oraclePriorPosition = NO_ORACLE_PRIOR;
+
     public InExpression() {}
 
     public InExpression(Expression leftExpression, Expression rightExpression) {
@@ -94,6 +96,9 @@ public class InExpression extends ASTNodeAccessImpl
     @Override
     public String toString() {
         StringBuilder statementBuilder = new StringBuilder();
+        if (oraclePriorPosition == ORACLE_PRIOR_START) {
+            statementBuilder.append("PRIOR ");
+        }
         statementBuilder.append(getLeftExpressionString());
 
         statementBuilder.append(" ");
@@ -110,14 +115,12 @@ public class InExpression extends ASTNodeAccessImpl
 
     @Override
     public int getOraclePriorPosition() {
-        return SupportsOldOracleJoinSyntax.NO_ORACLE_PRIOR;
+        return oraclePriorPosition;
     }
 
     @Override
     public void setOraclePriorPosition(int priorPosition) {
-        if (priorPosition != SupportsOldOracleJoinSyntax.NO_ORACLE_PRIOR) {
-            throw new IllegalArgumentException("unexpected prior for oracle found");
-        }
+        this.oraclePriorPosition = priorPosition;
     }
 
     public InExpression withRightExpression(Expression rightExpression) {

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsBooleanExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsBooleanExpression.java
@@ -13,7 +13,8 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
-public class IsBooleanExpression extends ASTNodeAccessImpl implements Expression {
+public class IsBooleanExpression extends ASTNodeAccessImpl
+        implements Expression, SupportsOldOracleJoinSyntax {
 
     private Expression leftExpression;
     private boolean not = false;
@@ -50,10 +51,11 @@ public class IsBooleanExpression extends ASTNodeAccessImpl implements Expression
 
     @Override
     public String toString() {
+        String prior = oraclePriorPosition == ORACLE_PRIOR_START ? "PRIOR " : "";
         if (isTrue()) {
-            return leftExpression + " IS" + (not ? " NOT" : "") + " TRUE";
+            return prior + leftExpression + " IS" + (not ? " NOT" : "") + " TRUE";
         } else {
-            return leftExpression + " IS" + (not ? " NOT" : "") + " FALSE";
+            return prior + leftExpression + " IS" + (not ? " NOT" : "") + " FALSE";
         }
     }
 
@@ -75,4 +77,39 @@ public class IsBooleanExpression extends ASTNodeAccessImpl implements Expression
     public <E extends Expression> E getLeftExpression(Class<E> type) {
         return type.cast(getLeftExpression());
     }
+
+    private int oraclePriorPosition = NO_ORACLE_PRIOR;
+
+    @Override
+    public int getOldOracleJoinSyntax() {
+        return NO_ORACLE_JOIN;
+    }
+
+    @Override
+    public void setOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        throw new IllegalArgumentException(
+                "oracle join operator (+) is not supported on this condition");
+    }
+
+    @Override
+    public IsBooleanExpression withOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        setOldOracleJoinSyntax(oldOracleJoinSyntax);
+        return this;
+    }
+
+    @Override
+    public int getOraclePriorPosition() {
+        return oraclePriorPosition;
+    }
+
+    @Override
+    public void setOraclePriorPosition(int oraclePriorPosition) {
+        this.oraclePriorPosition = oraclePriorPosition;
+    }
+
+    public IsBooleanExpression withOraclePriorPosition(int oraclePriorPosition) {
+        setOraclePriorPosition(oraclePriorPosition);
+        return this;
+    }
+
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsDistinctExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsDistinctExpression.java
@@ -12,7 +12,7 @@ package net.sf.jsqlparser.expression.operators.relational;
 import net.sf.jsqlparser.expression.BinaryExpression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 
-public class IsDistinctExpression extends BinaryExpression {
+public class IsDistinctExpression extends BinaryExpression implements SupportsOldOracleJoinSyntax {
 
     private boolean not = false;
 
@@ -36,7 +36,43 @@ public class IsDistinctExpression extends BinaryExpression {
 
     @Override
     public String toString() {
-        String retval = getLeftExpression() + getStringExpression() + getRightExpression();
+        String retval = (oraclePriorPosition == ORACLE_PRIOR_START ? "PRIOR " : "")
+                + getLeftExpression() + getStringExpression() + getRightExpression();
         return retval;
     }
+
+    private int oraclePriorPosition = NO_ORACLE_PRIOR;
+
+    @Override
+    public int getOldOracleJoinSyntax() {
+        return NO_ORACLE_JOIN;
+    }
+
+    @Override
+    public void setOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        throw new IllegalArgumentException(
+                "oracle join operator (+) is not supported on this condition");
+    }
+
+    @Override
+    public IsDistinctExpression withOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        setOldOracleJoinSyntax(oldOracleJoinSyntax);
+        return this;
+    }
+
+    @Override
+    public int getOraclePriorPosition() {
+        return oraclePriorPosition;
+    }
+
+    @Override
+    public void setOraclePriorPosition(int oraclePriorPosition) {
+        this.oraclePriorPosition = oraclePriorPosition;
+    }
+
+    public IsDistinctExpression withOraclePriorPosition(int oraclePriorPosition) {
+        setOraclePriorPosition(oraclePriorPosition);
+        return this;
+    }
+
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsNullExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsNullExpression.java
@@ -14,7 +14,8 @@ import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 import net.sf.jsqlparser.schema.Column;
 
-public class IsNullExpression extends ASTNodeAccessImpl implements Expression {
+public class IsNullExpression extends ASTNodeAccessImpl
+        implements Expression, SupportsOldOracleJoinSyntax {
 
     private Expression leftExpression;
     private boolean not = false;
@@ -72,12 +73,13 @@ public class IsNullExpression extends ASTNodeAccessImpl implements Expression {
 
     @Override
     public String toString() {
+        String prior = oraclePriorPosition == ORACLE_PRIOR_START ? "PRIOR " : "";
         if (useNotNull) {
-            return leftExpression + " NOTNULL";
+            return prior + leftExpression + " NOTNULL";
         } else if (useIsNull) {
-            return leftExpression + (not ? " NOT" : "") + " ISNULL";
+            return prior + leftExpression + (not ? " NOT" : "") + " ISNULL";
         } else {
-            return leftExpression + " IS " + (not ? "NOT " : "") + "NULL";
+            return prior + leftExpression + " IS " + (not ? "NOT " : "") + "NULL";
         }
     }
 
@@ -99,4 +101,39 @@ public class IsNullExpression extends ASTNodeAccessImpl implements Expression {
     public <E extends Expression> E getLeftExpression(Class<E> type) {
         return type.cast(getLeftExpression());
     }
+
+    private int oraclePriorPosition = NO_ORACLE_PRIOR;
+
+    @Override
+    public int getOldOracleJoinSyntax() {
+        return NO_ORACLE_JOIN;
+    }
+
+    @Override
+    public void setOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        throw new IllegalArgumentException(
+                "oracle join operator (+) is not supported on this condition");
+    }
+
+    @Override
+    public IsNullExpression withOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        setOldOracleJoinSyntax(oldOracleJoinSyntax);
+        return this;
+    }
+
+    @Override
+    public int getOraclePriorPosition() {
+        return oraclePriorPosition;
+    }
+
+    @Override
+    public void setOraclePriorPosition(int oraclePriorPosition) {
+        this.oraclePriorPosition = oraclePriorPosition;
+    }
+
+    public IsNullExpression withOraclePriorPosition(int oraclePriorPosition) {
+        setOraclePriorPosition(oraclePriorPosition);
+        return this;
+    }
+
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsUnknownExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/IsUnknownExpression.java
@@ -13,7 +13,8 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
-public class IsUnknownExpression extends ASTNodeAccessImpl implements Expression {
+public class IsUnknownExpression extends ASTNodeAccessImpl
+        implements Expression, SupportsOldOracleJoinSyntax {
 
     private Expression leftExpression;
     private boolean isNot = false;
@@ -41,7 +42,8 @@ public class IsUnknownExpression extends ASTNodeAccessImpl implements Expression
 
     @Override
     public String toString() {
-        return leftExpression + " IS" + (isNot ? " NOT" : "") + " UNKNOWN";
+        return (oraclePriorPosition == ORACLE_PRIOR_START ? "PRIOR " : "") + leftExpression + " IS"
+                + (isNot ? " NOT" : "") + " UNKNOWN";
     }
 
     public IsUnknownExpression withLeftExpression(Expression leftExpression) {
@@ -57,4 +59,39 @@ public class IsUnknownExpression extends ASTNodeAccessImpl implements Expression
     public <E extends Expression> E getLeftExpression(Class<E> type) {
         return type.cast(getLeftExpression());
     }
+
+    private int oraclePriorPosition = NO_ORACLE_PRIOR;
+
+    @Override
+    public int getOldOracleJoinSyntax() {
+        return NO_ORACLE_JOIN;
+    }
+
+    @Override
+    public void setOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        throw new IllegalArgumentException(
+                "oracle join operator (+) is not supported on this condition");
+    }
+
+    @Override
+    public IsUnknownExpression withOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        setOldOracleJoinSyntax(oldOracleJoinSyntax);
+        return this;
+    }
+
+    @Override
+    public int getOraclePriorPosition() {
+        return oraclePriorPosition;
+    }
+
+    @Override
+    public void setOraclePriorPosition(int oraclePriorPosition) {
+        this.oraclePriorPosition = oraclePriorPosition;
+    }
+
+    public IsUnknownExpression withOraclePriorPosition(int oraclePriorPosition) {
+        setOraclePriorPosition(oraclePriorPosition);
+        return this;
+    }
+
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/LikeExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/LikeExpression.java
@@ -14,7 +14,7 @@ import net.sf.jsqlparser.expression.BinaryExpression;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 
-public class LikeExpression extends BinaryExpression {
+public class LikeExpression extends BinaryExpression implements SupportsOldOracleJoinSyntax {
     private boolean not = false;
     private boolean useBinary = false;
     private Expression escapeExpression = null;
@@ -50,7 +50,8 @@ public class LikeExpression extends BinaryExpression {
 
     @Override
     public String toString() {
-        String retval = getLeftExpression() + " " + (not ? "NOT " : "")
+        String retval = (oraclePriorPosition == ORACLE_PRIOR_START ? "PRIOR " : "")
+                + getLeftExpression() + " " + (not ? "NOT " : "")
                 + (likeKeyWord == KeyWord.SIMILAR_TO ? "SIMILAR TO" : likeKeyWord) + " "
                 + (useBinary ? "BINARY " : "") + getRightExpression();
         if (escapeExpression != null) {
@@ -125,4 +126,39 @@ public class LikeExpression extends BinaryExpression {
                     keyword.toUpperCase(Locale.ROOT).replaceAll("\\s+", "_"));
         }
     }
+
+    private int oraclePriorPosition = NO_ORACLE_PRIOR;
+
+    @Override
+    public int getOldOracleJoinSyntax() {
+        return NO_ORACLE_JOIN;
+    }
+
+    @Override
+    public void setOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        throw new IllegalArgumentException(
+                "oracle join operator (+) is not supported on this condition");
+    }
+
+    @Override
+    public LikeExpression withOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        setOldOracleJoinSyntax(oldOracleJoinSyntax);
+        return this;
+    }
+
+    @Override
+    public int getOraclePriorPosition() {
+        return oraclePriorPosition;
+    }
+
+    @Override
+    public void setOraclePriorPosition(int oraclePriorPosition) {
+        this.oraclePriorPosition = oraclePriorPosition;
+    }
+
+    public LikeExpression withOraclePriorPosition(int oraclePriorPosition) {
+        setOraclePriorPosition(oraclePriorPosition);
+        return this;
+    }
+
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/MemberOfExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/MemberOfExpression.java
@@ -13,7 +13,8 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
 
-public class MemberOfExpression extends ASTNodeAccessImpl implements Expression {
+public class MemberOfExpression extends ASTNodeAccessImpl
+        implements Expression, SupportsOldOracleJoinSyntax {
 
     Expression leftExpression;
     Expression rightExpression;
@@ -53,11 +54,47 @@ public class MemberOfExpression extends ASTNodeAccessImpl implements Expression 
 
     @Override
     public String toString() {
-        return leftExpression + " MEMBER OF " + rightExpression;
+        return (oraclePriorPosition == ORACLE_PRIOR_START ? "PRIOR " : "") + leftExpression
+                + " MEMBER OF " + rightExpression;
     }
 
     @Override
     public <T, S> T accept(ExpressionVisitor<T> expressionVisitor, S context) {
         return expressionVisitor.visit(this, context);
     }
+
+    private int oraclePriorPosition = NO_ORACLE_PRIOR;
+
+    @Override
+    public int getOldOracleJoinSyntax() {
+        return NO_ORACLE_JOIN;
+    }
+
+    @Override
+    public void setOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        throw new IllegalArgumentException(
+                "oracle join operator (+) is not supported on this condition");
+    }
+
+    @Override
+    public MemberOfExpression withOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        setOldOracleJoinSyntax(oldOracleJoinSyntax);
+        return this;
+    }
+
+    @Override
+    public int getOraclePriorPosition() {
+        return oraclePriorPosition;
+    }
+
+    @Override
+    public void setOraclePriorPosition(int oraclePriorPosition) {
+        this.oraclePriorPosition = oraclePriorPosition;
+    }
+
+    public MemberOfExpression withOraclePriorPosition(int oraclePriorPosition) {
+        setOraclePriorPosition(oraclePriorPosition);
+        return this;
+    }
+
 }

--- a/src/main/java/net/sf/jsqlparser/expression/operators/relational/SimilarToExpression.java
+++ b/src/main/java/net/sf/jsqlparser/expression/operators/relational/SimilarToExpression.java
@@ -13,7 +13,7 @@ import net.sf.jsqlparser.expression.BinaryExpression;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 
-public class SimilarToExpression extends BinaryExpression {
+public class SimilarToExpression extends BinaryExpression implements SupportsOldOracleJoinSyntax {
 
     private boolean not = false;
     private String escape = null;
@@ -38,7 +38,8 @@ public class SimilarToExpression extends BinaryExpression {
 
     @Override
     public String toString() {
-        String retval = getLeftExpression() + " " + (not ? "NOT " : "") + getStringExpression()
+        String retval = (oraclePriorPosition == ORACLE_PRIOR_START ? "PRIOR " : "")
+                + getLeftExpression() + " " + (not ? "NOT " : "") + getStringExpression()
                 + " " + getRightExpression();
         if (escape != null) {
             retval += " ESCAPE " + "'" + escape + "'";
@@ -74,4 +75,39 @@ public class SimilarToExpression extends BinaryExpression {
     public SimilarToExpression withRightExpression(Expression arg0) {
         return (SimilarToExpression) super.withRightExpression(arg0);
     }
+
+    private int oraclePriorPosition = NO_ORACLE_PRIOR;
+
+    @Override
+    public int getOldOracleJoinSyntax() {
+        return NO_ORACLE_JOIN;
+    }
+
+    @Override
+    public void setOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        throw new IllegalArgumentException(
+                "oracle join operator (+) is not supported on this condition");
+    }
+
+    @Override
+    public SimilarToExpression withOldOracleJoinSyntax(int oldOracleJoinSyntax) {
+        setOldOracleJoinSyntax(oldOracleJoinSyntax);
+        return this;
+    }
+
+    @Override
+    public int getOraclePriorPosition() {
+        return oraclePriorPosition;
+    }
+
+    @Override
+    public void setOraclePriorPosition(int oraclePriorPosition) {
+        this.oraclePriorPosition = oraclePriorPosition;
+    }
+
+    public SimilarToExpression withOraclePriorPosition(int oraclePriorPosition) {
+        setOraclePriorPosition(oraclePriorPosition);
+        return this;
+    }
+
 }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/ExpressionDeParser.java
@@ -183,6 +183,9 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
 
     @Override
     public <S> StringBuilder visit(Between between, S context) {
+        if (between.getOraclePriorPosition() == SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START) {
+            builder.append("PRIOR ");
+        }
         between.getLeftExpression().accept(this, context);
         if (between.isNot()) {
             builder.append(" NOT");
@@ -268,11 +271,17 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
         // if (expression.isNot()) {
         // buffer.append(NOT);
         // }
+        if (expression.getOraclePriorPosition() == SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START) {
+            builder.append("PRIOR ");
+        }
         expression.getLeftExpression().accept(this, context);
         if (expression.getOldOracleJoinSyntax() == EqualsTo.ORACLE_JOIN_RIGHT) {
             builder.append("(+)");
         }
         builder.append(operator);
+        if (expression.getOraclePriorPosition() == SupportsOldOracleJoinSyntax.ORACLE_PRIOR_END) {
+            builder.append("PRIOR ");
+        }
         expression.getRightExpression().accept(this, context);
         if (expression.getOldOracleJoinSyntax() == EqualsTo.ORACLE_JOIN_LEFT) {
             builder.append("(+)");
@@ -345,6 +354,10 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
 
     @Override
     public <S> StringBuilder visit(InExpression inExpression, S context) {
+        if (inExpression
+                .getOraclePriorPosition() == SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START) {
+            builder.append("PRIOR ");
+        }
         inExpression.getLeftExpression().accept(this, context);
         if (inExpression
                 .getOldOracleJoinSyntax() == SupportsOldOracleJoinSyntax.ORACLE_JOIN_RIGHT) {
@@ -407,6 +420,10 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
 
     @Override
     public <S> StringBuilder visit(IsNullExpression isNullExpression, S context) {
+        if (isNullExpression
+                .getOraclePriorPosition() == SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START) {
+            builder.append("PRIOR ");
+        }
         isNullExpression.getLeftExpression().accept(this, context);
         if (isNullExpression.isUseNotNull()) {
             builder.append(" NOTNULL");
@@ -428,6 +445,10 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
 
     @Override
     public <S> StringBuilder visit(IsBooleanExpression isBooleanExpression, S context) {
+        if (isBooleanExpression
+                .getOraclePriorPosition() == SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START) {
+            builder.append("PRIOR ");
+        }
         isBooleanExpression.getLeftExpression().accept(this, context);
         if (isBooleanExpression.isTrue()) {
             if (isBooleanExpression.isNot()) {
@@ -447,6 +468,10 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
 
     @Override
     public <S> StringBuilder visit(IsUnknownExpression isUnknownExpression, S context) {
+        if (isUnknownExpression
+                .getOraclePriorPosition() == SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START) {
+            builder.append("PRIOR ");
+        }
         isUnknownExpression.getLeftExpression().accept(this, context);
         if (isUnknownExpression.isNot()) {
             builder.append(" IS NOT UNKNOWN");
@@ -472,6 +497,10 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
                 ? " SIMILAR TO"
                 : likeExpression.getLikeKeyWord().toString();
 
+        if (likeExpression
+                .getOraclePriorPosition() == SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START) {
+            builder.append("PRIOR ");
+        }
         likeExpression.getLeftExpression().accept(this, context);
         builder.append(" ");
         if (likeExpression.isNot()) {
@@ -504,6 +533,10 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
 
     @Override
     public <S> StringBuilder visit(MemberOfExpression memberOfExpression, S context) {
+        if (memberOfExpression
+                .getOraclePriorPosition() == SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START) {
+            builder.append("PRIOR ");
+        }
         memberOfExpression.getLeftExpression().accept(this, context);
         if (memberOfExpression.isNot()) {
             builder.append(" NOT MEMBER OF ");
@@ -1505,7 +1538,12 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
 
     @Override
     public <S> StringBuilder visit(SimilarToExpression expr, S context) {
-        deparse(expr, (expr.isNot() ? " NOT" : "") + " SIMILAR TO ", null);
+        if (expr.getOraclePriorPosition() == SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START) {
+            builder.append("PRIOR ");
+        }
+        expr.getLeftExpression().accept(this, context);
+        builder.append(expr.isNot() ? " NOT SIMILAR TO " : " SIMILAR TO ");
+        expr.getRightExpression().accept(this, context);
         return builder;
     }
 
@@ -1756,6 +1794,10 @@ public class ExpressionDeParser extends AbstractDeParser<Expression>
 
     @Override
     public <S> StringBuilder visit(IsDistinctExpression isDistinctExpression, S context) {
+        if (isDistinctExpression
+                .getOraclePriorPosition() == SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START) {
+            builder.append("PRIOR ");
+        }
         builder.append(isDistinctExpression.getLeftExpression())
                 .append(isDistinctExpression.getStringExpression())
                 .append(isDistinctExpression.getRightExpression());

--- a/src/test/java/net/sf/jsqlparser/expression/operators/relational/OraclePriorPositionTest.java
+++ b/src/test/java/net/sf/jsqlparser/expression/operators/relational/OraclePriorPositionTest.java
@@ -1,0 +1,211 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.expression.operators.relational;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.test.TestUtils;
+import org.junit.jupiter.api.Test;
+
+public class OraclePriorPositionTest {
+
+    private static Expression whereOf(String sqlStr) throws JSQLParserException {
+        PlainSelect select =
+                (PlainSelect) TestUtils.assertSqlCanBeParsedAndDeparsed(sqlStr, true);
+        return select.getWhere();
+    }
+
+    @Test
+    public void testPriorBetween() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a BETWEEN 1 AND 2");
+        Between between = (Between) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                between.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorLike() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a LIKE 'x%'");
+        LikeExpression like = (LikeExpression) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                like.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorNotLike() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a NOT LIKE 'x%'");
+        LikeExpression like = (LikeExpression) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                like.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorSimilarTo() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a SIMILAR TO 'x'");
+        LikeExpression similarTo = (LikeExpression) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                similarTo.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorSimilarToOnSeparateTokens() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a SIMILAR\nTO 'x'");
+        SimilarToExpression similarTo = (SimilarToExpression) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                similarTo.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorIsNull() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a IS NULL");
+        IsNullExpression isNull = (IsNullExpression) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                isNull.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorIsNotNull() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a IS NOT NULL");
+        IsNullExpression isNull = (IsNullExpression) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                isNull.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorIsTrue() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a IS TRUE");
+        IsBooleanExpression isBoolean = (IsBooleanExpression) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                isBoolean.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorIsUnknown() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a IS UNKNOWN");
+        IsUnknownExpression isUnknown = (IsUnknownExpression) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                isUnknown.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorIsDistinctFrom() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a IS DISTINCT FROM b");
+        IsDistinctExpression isDistinct = (IsDistinctExpression) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                isDistinct.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorMemberOf() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a MEMBER OF (1)");
+        MemberOfExpression memberOf = (MemberOfExpression) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                memberOf.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorIn() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a IN (1, 2)");
+        InExpression in = (InExpression) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                in.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorNotIn() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM t WHERE PRIOR a NOT IN (1, 2)",
+                true);
+    }
+
+    @Test
+    public void testPriorOnComparisonStartIsDeparsed() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM t WHERE PRIOR a = b", true);
+    }
+
+    @Test
+    public void testPriorOnComparisonEndIsDeparsed() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM t WHERE a = PRIOR b", true);
+    }
+
+    @Test
+    public void testPriorIsNullShorthand() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a ISNULL");
+        IsNullExpression isNull = (IsNullExpression) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                isNull.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorNotNullShorthand() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM t WHERE PRIOR a NOTNULL", true);
+    }
+
+    @Test
+    public void testPriorIsFalse() throws JSQLParserException {
+        Expression where = whereOf("SELECT * FROM t WHERE PRIOR a IS FALSE");
+        IsBooleanExpression isBoolean = (IsBooleanExpression) where;
+        assertEquals(SupportsOldOracleJoinSyntax.ORACLE_PRIOR_START,
+                isBoolean.getOraclePriorPosition());
+    }
+
+    @Test
+    public void testPriorIsNotUnknown() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM t WHERE PRIOR a IS NOT UNKNOWN",
+                true);
+    }
+
+    @Test
+    public void testPriorNotSimilarTo() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT * FROM t WHERE PRIOR a NOT SIMILAR TO 'x'",
+                true);
+    }
+
+    @Test
+    public void testPriorInJoinOnClause() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT * FROM t JOIN t2 ON PRIOR t.c = t2.c", true);
+    }
+
+    @Test
+    public void testPriorBetweenEndOperandStaysIntact() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM t WHERE a BETWEEN 1 AND PRIOR 2",
+                true);
+    }
+
+    @Test
+    public void testPlainConditionsWithoutPriorAreUnchanged() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM t WHERE a = b", true);
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM t WHERE a BETWEEN 1 AND 2", true);
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM t WHERE a LIKE 'x%'", true);
+        TestUtils.assertSqlCanBeParsedAndDeparsed("SELECT * FROM t WHERE a IS NULL", true);
+    }
+
+    @Test
+    public void testNotPriorBetween() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT * FROM t WHERE NOT PRIOR a BETWEEN 1 AND 2", true);
+    }
+
+    @Test
+    public void testPriorOnSeveralConditions() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT * FROM t WHERE PRIOR a = b AND PRIOR c BETWEEN 1 AND 2", true);
+    }
+
+    @Test
+    public void testPriorCombinedWithOracleJoinOnBetween() throws JSQLParserException {
+        TestUtils.assertSqlCanBeParsedAndDeparsed(
+                "SELECT * FROM t1, t2 WHERE PRIOR t2.c(+) BETWEEN 1 AND 2", true);
+    }
+}


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What
`Between`, `LikeExpression`, `SimilarToExpression`, `IsNullExpression`, `IsBooleanExpression`, `IsUnknownExpression`, `IsDistinctExpression` and `MemberOfExpression` now implement `SupportsOldOracleJoinSyntax` with a real prior position, `InExpression` stores the position instead of rejecting it, and `ExpressionDeParser` renders `PRIOR` for all of them plus both positions of `OldOracleJoinBinaryExpression`. 20 new cases in `OraclePriorPositionTest`. No grammar change.

## Why
`Condition()` consumes a leading `PRIOR` and only propagates it onto conditions that implement `SupportsOldOracleJoinSyntax`. For the eight classes above the keyword is silently dropped (`WHERE PRIOR a BETWEEN 1 AND 2` deparses without `PRIOR`, inverting hierarchical-query semantics), `PRIOR a IN (1, 2)` throws `IllegalArgumentException`, and comparisons lose `PRIOR` through the deparser although `toString()` keeps it. Fixes #2601.

## How
Each of the eight classes carries an `oraclePriorPosition` field, renders `PRIOR ` before its left expression in `toString()` and in its `ExpressionDeParser` visit, and rejects `setOldOracleJoinSyntax` with an explicit `IllegalArgumentException` (mirroring how `InExpression` used to reject prior positions: unsupported means explicit rejection, not silent acceptance; the `(+)` operator keeps its existing route through the operand `Column`, as in #2564 / #2600). `InExpression` replaces its always-throw `setOraclePriorPosition` with a stored field and renders `PRIOR ` in `toString()` and the deparser. `deparse(OldOracleJoinBinaryExpression, ...)` gains the two `PRIOR` positions alongside the existing `(+)` marks. The grammar needs no change: the `instanceof` gate in `Condition()` picks the new implementations up automatically. Known boundary, disclosed: `ExpressionValidator` reports `Feature.oraclePriorPosition` for comparisons carrying PRIOR but not yet for these nine kinds (lenient direction only); aligning that is left as a follow-up. `PRIOR` on the BETWEEN start operand (`a BETWEEN PRIOR 1 AND 2`, a plain ParseException today) is a separate grammar gap and is left out of scope.

## Root cause
`Condition()` consumes the `PRIOR` token into a local `oraclePrior` and applies it only `if (result instanceof SupportsOldOracleJoinSyntax)`; everything else discards it at parse time.

## Testing
- 26 new cases in `net.sf.jsqlparser.expression.operators.relational.OraclePriorPositionTest`: encoder cases for every condition kind (including `SIMILAR TO` on both tokenizations, `NOT` forms, the `ISNULL` / `NOTNULL` shorthands, `IS FALSE`, `IS NOT UNKNOWN`, the `IN` form that used to throw), deparser guards for `PRIOR a = b` / `a = PRIOR b` and a `PRIOR` comparison inside a join `ON` clause (all used to lose `PRIOR` in the round-trip), the unchanged plain forms, and combinations (`NOT PRIOR`, several conditions in one WHERE, `PRIOR` combined with `(+)` on a BETWEEN operand). On master, the encoder cases fail (silent loss / `IllegalArgumentException`, verified per form) and the comparison round-trip guards fail through the deparser; all 26 pass with this change.
- Mutation check, each variant kills exactly its own family: making `Between.setOraclePriorPosition` a no-op turns the 3 BETWEEN cases red only; making `InExpression.setOraclePriorPosition` a no-op turns the 2 IN cases red only; removing only the deparser's PRIOR guard for `Between` turns the 4 BETWEEN round-trip cases red while the AST assertions still see the position, proving toString() and the deparser are pinned independently; reverting only the two PRIOR marks in `deparse(OldOracleJoinBinaryExpression, ...)` turns exactly the 4 comparison round-trip cases red (the two guards, the ON-clause case and the multi-condition case) while all AST assertions stay green.
- `./gradlew check` and `mvn verify` are green (full suite).
- Performance: no benchmark run, rationale: the grammar is untouched and the parse-time path for inputs without `PRIOR` is bit-identical (the only new work is a setter call when `PRIOR` is present); the corpus contains no `PRIOR`, so a benchmark could not exercise the changed path.

## Verification of the original issue
`SELECT * FROM emp WHERE PRIOR empno BETWEEN 100 AND 200`
- master `7cc86386`: parses, `toString()` is `... WHERE empno BETWEEN 100 AND 200` (PRIOR lost)
- branch: parses, `Between.getOraclePriorPosition()` is `ORACLE_PRIOR_START`, deparse identical to the input.

Fixes #2601
