### PR TITLE
Accept SQL Server CREATE TABLE trailing commas with shared element parsing

### DIFF
--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -13044,15 +13044,12 @@ CreateTable CreateTable(boolean isUsingOrReplace):
 {
     CreateTable createTable = new CreateTable();
     Table table = null;
-    List<ColumnDefinition> columnDefinitions = new ArrayList<ColumnDefinition>();
     List<TableElement> tableElements = new ArrayList<TableElement>();
+    TableElement element;
     List<String> tableOptions = new ArrayList<String>();
     List<TableOption> typedTableOptions = new ArrayList<TableOption>();
     List<String> createOptions = new ArrayList<String>();
     Token tk = null;
-    ColumnDefinition coldef = null;
-    List<Index> indexes = new ArrayList<Index>();
-    Index index = null;
     List<String> parameter = new ArrayList<String>();
     TableOption tableOption = null;
     SpannerInterleaveIn interleaveIn = null;
@@ -13065,7 +13062,6 @@ CreateTable CreateTable(boolean isUsingOrReplace):
     Table partitionOfTable = null;
     PartitionBound partitionBound = null;
     ColDataType ofType = null;
-    LikeClause likeClause = null;
 }
 {
     { createTable.setOrReplace(isUsingOrReplace);}
@@ -13088,33 +13084,12 @@ CreateTable CreateTable(boolean isUsingOrReplace):
         )
         |
             (
-                "("
-                (
-                    LOOKAHEAD(<K_LIKE>) likeClause=LikeClause() { tableElements.add(likeClause); }
-                    |
-                    LOOKAHEAD(3) index = CreateTableConstraint()
-                        { indexes.add(index); tableElements.add(index); }
-                    |
-                    coldef = CreateTableColumnDefinition(ofType != null)
-                        { columnDefinitions.add(coldef); tableElements.add(coldef); }
-                )
-
-                (
-                    ","
-                    (
-                        LOOKAHEAD(<K_LIKE>) likeClause=LikeClause() { tableElements.add(likeClause); }
-                        |
-                        LOOKAHEAD(3) (
-                            index = CreateTableConstraint()
-                            { indexes.add(index); tableElements.add(index); }
-                        )
-                        |
-                        (
-                            coldef = CreateTableColumnDefinition(ofType != null)
-                            { columnDefinitions.add(coldef); tableElements.add(coldef); }
-                        )
-                    )
+                "(" element=CreateTableElement(ofType != null) { tableElements.add(element); }
+                ( LOOKAHEAD(2) "," element=CreateTableElement(ofType != null)
+                    { tableElements.add(element); }
                 )*
+                [ LOOKAHEAD({ Dialect.SQLSERVER.name().equals(getAsString(Feature.dialect))
+                        && getToken(1).kind == K_COMMA && getToken(2).kind == CLOSING_BRACKET }) "," ]
 
                 ")"
             )
@@ -13161,6 +13136,17 @@ CreateTable CreateTable(boolean isUsingOrReplace):
             createTable.setColumns(columns);
         return createTable;
     }
+}
+
+TableElement CreateTableElement(boolean typed):
+{ TableElement element; }
+{
+    (
+        LOOKAHEAD(<K_LIKE>) element=LikeClause()
+        | LOOKAHEAD(3) element=CreateTableConstraint()
+        | element=CreateTableColumnDefinition(typed)
+    )
+    { return element; }
 }
 
 ColumnDefinition CreateTableColumnDefinition(boolean typed):

--- a/src/site/sphinx/usage.rst
+++ b/src/site/sphinx/usage.rst
@@ -770,6 +770,8 @@ With ``Dialect.SQLSERVER``, ``PRIMARY KEY NONCLUSTERED (id)`` and
 ``UNIQUE CLUSTERED (id)`` store their clustering option in ``Index.getClustering()``
 for both ``CREATE TABLE`` and ``ALTER TABLE``. Without that dialect, these words
 retain their existing interpretation as optional index names.
+SQL Server ``CREATE TABLE`` also accepts a trailing comma after the final column
+or table constraint. SQL output normalizes the definition by omitting that comma.
 
 ``CREATE UNIQUE NONCLUSTERED INDEX ix ON t (id)`` also requires
 ``Dialect.SQLSERVER``. Uniqueness remains in ``Index.getType()`` and clustering

--- a/src/test/java/net/sf/jsqlparser/statement/create/SqlServerCreateTableSeparatorTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/create/SqlServerCreateTableSeparatorTest.java
@@ -1,0 +1,89 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.create;
+
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.parser.AbstractJSqlParser.Dialect;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.create.table.ColumnDefinition;
+import net.sf.jsqlparser.statement.create.table.CreateTable;
+import net.sf.jsqlparser.statement.create.table.Index;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SqlServerCreateTableSeparatorTest {
+    private CreateTable parse(String sql) throws JSQLParserException {
+        return (CreateTable) CCJSqlParserUtil.parse(sql,
+                p -> p.withDialect(Dialect.SQLSERVER).withUnsupportedStatements(false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"CREATE TABLE t (id int,)",
+            "CREATE TABLE t (id int, name varchar(20),)",
+            "CREATE TABLE t (id int, PRIMARY KEY (id),)",
+            "CREATE TABLE t (id int, CHECK (id > 0),)",
+            "CREATE TABLE t (id int, /* last element */ )"})
+    void acceptsOneTrailingSeparatorAndNormalizesBothRenderers(String sql) throws Exception {
+        CreateTable table = parse(sql);
+        String normalized = table.toString();
+        assertFalse(normalized.contains(",)"));
+        assertEquals(normalized, parse(normalized).toString());
+        StringBuilder buffer = new StringBuilder();
+        table.accept(new StatementDeParser(buffer), null);
+        assertEquals(normalized, buffer.toString());
+        assertEquals(table.getTableElements().size(),
+                parse(buffer.toString()).getTableElements().size());
+    }
+
+    @Test
+    void preservesSakilaColumnsAndNonclusteredPrimaryKey() throws Exception {
+        CreateTable table = parse("CREATE TABLE film_text (film_id INT NOT NULL, "
+                + "title VARCHAR(255) NOT NULL, description TEXT, PRIMARY KEY NONCLUSTERED (film_id),)");
+        assertEquals(4, table.getTableElements().size());
+        assertInstanceOf(ColumnDefinition.class, table.getTableElements().get(0));
+        Index primaryKey = assertInstanceOf(Index.class, table.getTableElements().get(3));
+        assertEquals("PRIMARY KEY", primaryKey.getType());
+        assertEquals(Index.Clustering.NONCLUSTERED, primaryKey.getClustering());
+        assertEquals(3, table.getColumnDefinitions().size());
+        table.getColumnDefinitions().get(0).setColumnName("renamed_id");
+        assertTrue(table.toString().contains("renamed_id INT"));
+        assertEquals(2, CCJSqlParserUtil.parseStatements(table + "; SELECT 1;",
+                p -> p.withDialect(Dialect.SQLSERVER)).size());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"CREATE TABLE t (,)",
+            "CREATE TABLE t (, id int)", "CREATE TABLE t (id int,,)",
+            "CREATE TABLE t (id int,, name int)", "CREATE TABLE t (id int, PRIMARY KEY,)",
+            "CREATE TABLE t (id int, PRIMARY KEY (id,))",
+            "CREATE FUNCTION f() RETURNS @r TABLE (id int,) AS BEGIN RETURN; END"})
+    void rejectsMissingElementsAndDoesNotWidenOtherDefinitionLists(String sql) {
+        assertThrows(JSQLParserException.class, () -> parse(sql));
+    }
+
+    @Test
+    void retainsOtherDialectsAndCreateTableForms() throws Exception {
+        String trailing = "CREATE TABLE t (id int,)";
+        assertThrows(JSQLParserException.class, () -> CCJSqlParserUtil.parse(trailing));
+        for (Dialect dialect : new Dialect[] {Dialect.POSTGRESQL, Dialect.MYSQL, Dialect.ORACLE}) {
+            assertThrows(JSQLParserException.class,
+                    () -> CCJSqlParserUtil.parse(trailing, p -> p.withDialect(dialect)));
+        }
+        for (String sql : new String[] {"CREATE TABLE t (id int, PRIMARY KEY (id))",
+                "CREATE TABLE t (id) AS SELECT 1", "CREATE TABLE t AS SELECT 1",
+                "CREATE TABLE t ()"}) {
+            assertEquals(CCJSqlParserUtil.parse(sql).toString(), parse(sql).toString());
+        }
+    }
+}


### PR DESCRIPTION
SQL Server `CREATE TABLE film_text (..., PRIMARY KEY NONCLUSTERED (film_id),)` fails on its final comma. Accept one trailing separator with `Dialect.SQLSERVER`, preserving the ordered table elements and normalizing the comma away when rendering SQL.

Extract the repeated column/constraint/LIKE choice into one table-element production and remove unused intermediate lists. Other dialects and function return-table definitions retain their existing separator rules.

Validation: full Gradle `check`, focused dialect/malformed-input/AST/round-trip regressions, and the updated usage-page Sphinx build passed. The original Sakila schema now parses and round-trips as 70 statements.

Refs #1563; this covers the schema separator gap.

Syntax: [Microsoft ScriptDom CREATE TABLE grammar](https://github.com/microsoft/SqlScriptDOM/blob/c122a7f9e69e9e98b0abbe7b69693ce23aaca829/SqlScriptDom/Parser/TSql/TSql160.g#L26628).
