### PR TITLE
feat: preserve ALTER COLUMN default expressions in the AST

### DIFF
--- a/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
+++ b/src/main/java/net/sf/jsqlparser/statement/alter/AlterExpression.java
@@ -18,6 +18,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.statement.ReferentialAction;
@@ -883,6 +884,16 @@ public class AlterExpression implements Serializable {
     }
 
     protected void toStringAlterColumn(StringBuilder b) {
+        appendAlterColumn(b, b::append);
+    }
+
+    /** Renders ALTER COLUMN default/visibility actions with their common tail. */
+    public void appendColumnActionTo(StringBuilder b, Consumer<Expression> expressionPrinter) {
+        appendAlterColumn(b, expressionPrinter);
+        appendCommonTail(b);
+    }
+
+    private void appendAlterColumn(StringBuilder b, Consumer<Expression> expressionPrinter) {
         b.append("ALTER ");
         if (hasColumn) {
             b.append("COLUMN ");
@@ -890,7 +901,12 @@ public class AlterExpression implements Serializable {
         if (columnDropDefaultList != null && !columnDropDefaultList.isEmpty()) {
             b.append(PlainSelect.getStringList(columnDropDefaultList));
         } else if (columnSetDefaultList != null && !columnSetDefaultList.isEmpty()) {
-            b.append(PlainSelect.getStringList(columnSetDefaultList));
+            for (int i = 0; i < columnSetDefaultList.size(); i++) {
+                if (i > 0) {
+                    b.append(", ");
+                }
+                columnSetDefaultList.get(i).appendTo(b, expressionPrinter);
+            }
         } else {
             b.append(PlainSelect.getStringList(columnSetVisibilityList));
         }
@@ -1575,7 +1591,8 @@ public class AlterExpression implements Serializable {
 
     public static final class ColumnSetDefault implements Serializable {
         private final String columnName;
-        private final String defaultValue;
+        private String defaultValue;
+        private Expression defaultExpression;
 
         public ColumnSetDefault(String columnName, String defaultValue) {
             this.columnName = columnName;
@@ -1586,13 +1603,40 @@ public class AlterExpression implements Serializable {
             return columnName;
         }
 
+        /** Constructs a structured default without overloading the legacy nullable String API. */
+        public static ColumnSetDefault fromExpression(String columnName, Expression expression) {
+            ColumnSetDefault result = new ColumnSetDefault(columnName, null);
+            result.setDefaultExpression(expression);
+            return result;
+        }
+
+        public Expression getDefaultExpression() {
+            return defaultExpression;
+        }
+
+        public void setDefaultExpression(Expression defaultExpression) {
+            this.defaultExpression = defaultExpression;
+            this.defaultValue = null;
+        }
+
         public String getDefaultValue() {
-            return defaultValue;
+            return defaultExpression == null ? defaultValue : defaultExpression.toString();
+        }
+
+        public void appendTo(StringBuilder sql, Consumer<Expression> expressionPrinter) {
+            sql.append(columnName).append(" SET DEFAULT ");
+            if (defaultExpression == null) {
+                sql.append(defaultValue);
+            } else {
+                expressionPrinter.accept(defaultExpression);
+            }
         }
 
         @Override
         public String toString() {
-            return columnName + " SET DEFAULT " + defaultValue;
+            StringBuilder sql = new StringBuilder();
+            appendTo(sql, sql::append);
+            return sql.toString();
         }
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/TableDefinitionTraversal.java
+++ b/src/main/java/net/sf/jsqlparser/util/TableDefinitionTraversal.java
@@ -44,6 +44,10 @@ public final class TableDefinitionTraversal {
     /** Visits the structured definitions and expressions belonging to a single ALTER action. */
     public static void visit(AlterExpression action, Consumer<Expression> expressions,
             Consumer<Table> tables) {
+        if (action.getColumnSetDefaultList() != null) {
+            action.getColumnSetDefaultList()
+                    .forEach(column -> accept(column.getDefaultExpression(), expressions));
+        }
         if (action.getColDataTypeList() != null) {
             action.getColDataTypeList().forEach(column -> visit(column, expressions, tables));
         }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/AlterDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/AlterDeParser.java
@@ -12,7 +12,6 @@ package net.sf.jsqlparser.util.deparser;
 import net.sf.jsqlparser.statement.alter.Alter;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.statement.alter.AlterExpression;
-import net.sf.jsqlparser.statement.alter.AlterOperation;
 import net.sf.jsqlparser.statement.alter.AlterExpressionPrimaryKey;
 import net.sf.jsqlparser.statement.create.table.DefaultConstraint;
 import net.sf.jsqlparser.statement.select.PlainSelect;
@@ -50,13 +49,6 @@ public class AlterDeParser extends AbstractDeParser<Alter> {
     }
 
     private void deParseAction(AlterExpression action) {
-        if (action.getOperation() == AlterOperation.ALTER
-                && action.getColumnSetDefaultList() != null
-                && !action.getColumnSetDefaultList().isEmpty()) {
-            action.appendColumnActionTo(builder,
-                    expression -> expression.accept(expressionVisitor, null));
-            return;
-        }
         if (action instanceof AlterExpressionPrimaryKey) {
             ((AlterExpressionPrimaryKey) action).appendTo(builder,
                     expression -> expression.accept(expressionVisitor, null));
@@ -66,6 +58,13 @@ public class AlterDeParser extends AbstractDeParser<Alter> {
             builder.append(action.getOperation()).append(' ');
             new TableElementDeParser(builder, expressionVisitor).deParse(action.getIndex());
             deParseTail(action);
+            return;
+        }
+        if (action.getOperation() == net.sf.jsqlparser.statement.alter.AlterOperation.ALTER
+                && action.getColumnSetDefaultList() != null
+                && !action.getColumnSetDefaultList().isEmpty()) {
+            action.appendColumnActionTo(builder,
+                    expression -> expression.accept(expressionVisitor, null));
             return;
         }
         if (action.getColDataTypeList() == null || action.getColDataTypeList().size() != 1

--- a/src/main/java/net/sf/jsqlparser/util/deparser/AlterDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/AlterDeParser.java
@@ -12,6 +12,7 @@ package net.sf.jsqlparser.util.deparser;
 import net.sf.jsqlparser.statement.alter.Alter;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.statement.alter.AlterExpression;
+import net.sf.jsqlparser.statement.alter.AlterOperation;
 import net.sf.jsqlparser.statement.alter.AlterExpressionPrimaryKey;
 import net.sf.jsqlparser.statement.create.table.DefaultConstraint;
 import net.sf.jsqlparser.statement.select.PlainSelect;
@@ -49,6 +50,13 @@ public class AlterDeParser extends AbstractDeParser<Alter> {
     }
 
     private void deParseAction(AlterExpression action) {
+        if (action.getOperation() == AlterOperation.ALTER
+                && action.getColumnSetDefaultList() != null
+                && !action.getColumnSetDefaultList().isEmpty()) {
+            action.appendColumnActionTo(builder,
+                    expression -> expression.accept(expressionVisitor, null));
+            return;
+        }
         if (action instanceof AlterExpressionPrimaryKey) {
             ((AlterExpressionPrimaryKey) action).appendTo(builder,
                     expression -> expression.accept(expressionVisitor, null));

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/AlterValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/AlterValidator.java
@@ -40,14 +40,8 @@ public class AlterValidator extends AbstractValidator<Alter> {
     }
 
     public void validate(Alter alter, AlterExpression e) {
-        if (e.getColDataTypeList() != null) {
-            e.getColDataTypeList().forEach(column -> TableDefinitionTraversal.visit(column,
-                    this::validateOptionalExpression, this::validateOptionalFromItem));
-        }
-        if (e.getIndex() != null) {
-            TableDefinitionTraversal.visit(e.getIndex(), this::validateOptionalExpression,
-                    this::validateOptionalFromItem);
-        }
+        TableDefinitionTraversal.visit(e, this::validateOptionalExpression,
+                this::validateOptionalFromItem);
         for (ValidationCapability c : getCapabilities()) {
 
             validateOptionalColumnName(c, e.getColumnOldName());

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -14552,7 +14552,7 @@ AlterExpression.ColumnSetDefault AlterExpressionColumnSetDefault():
 {
     columnName = RelObjectName() <K_SET> <K_DEFAULT> defaultValue = Expression()
     {
-        return new AlterExpression.ColumnSetDefault(columnName, defaultValue.toString());
+        return AlterExpression.ColumnSetDefault.fromExpression(columnName, defaultValue);
     }
 }
 

--- a/src/test/java/net/sf/jsqlparser/statement/alter/AlterColumnDefaultExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/alter/AlterColumnDefaultExpressionTest.java
@@ -1,0 +1,101 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.alter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.expression.LongValue;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.StatementVisitorAdapter;
+import net.sf.jsqlparser.statement.alter.AlterExpression.ColumnSetDefault;
+import net.sf.jsqlparser.statement.select.SelectVisitorAdapter;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AlterColumnDefaultExpressionTest {
+    @ParameterizedTest
+    @ValueSource(strings = {"(1 + 2)", "NULL", "CURRENT_TIMESTAMP",
+            "nextval('app.counter'::regclass)", "'value'::text", "-1"})
+    void parsedDefaultRetainsExpressionAndLegacyText(String value) throws JSQLParserException {
+        Alter alter = parse(value);
+        ColumnSetDefault column =
+                alter.getAlterExpressions().get(0).getColumnSetDefaultList().get(0);
+        assertNotNull(column.getDefaultExpression());
+        assertEquals(column.getDefaultExpression().toString(), column.getDefaultValue());
+        StringBuilder buffer = new StringBuilder();
+        alter.accept(new StatementDeParser(buffer), null);
+        assertEquals(alter.toString(), buffer.toString());
+        assertEquals(alter.toString(), CCJSqlParserUtil.parse(buffer.toString()).toString());
+    }
+
+    @Test
+    void visitorReachesDefaultsInEachAlterActionWithContext() throws JSQLParserException {
+        List<Long> values = new ArrayList<>();
+        ExpressionVisitorAdapter<Void> expressions = new ExpressionVisitorAdapter<Void>() {
+            @Override
+            public <S> Void visit(LongValue value, S context) {
+                assertEquals("context", context);
+                values.add(value.getValue());
+                return null;
+            }
+        };
+        CCJSqlParserUtil.parse("ALTER TABLE t ALTER COLUMN a SET DEFAULT (1 + 2), "
+                + "ALTER COLUMN b SET DEFAULT 3")
+                .accept(new StatementVisitorAdapter<>(new SelectVisitorAdapter<>(expressions)),
+                        "context");
+        assertThat(values).containsExactly(1L, 2L, 3L);
+    }
+
+    @Test
+    void customDeparserAndAstEditsUseTheStructuredDefault() throws JSQLParserException {
+        Alter alter = parse("(1 + 2)");
+        StringBuilder output = new StringBuilder();
+        ExpressionDeParser expressions = new ExpressionDeParser() {
+            @Override
+            public <S> StringBuilder visit(LongValue value, S context) {
+                return getBuilder().append(value.getValue() + 100);
+            }
+        };
+        alter.accept(new StatementDeParser(expressions, new SelectDeParser(), output), null);
+        assertEquals("ALTER TABLE t ALTER COLUMN a SET DEFAULT (101 + 102)", output.toString());
+        ColumnSetDefault column =
+                alter.getAlterExpressions().get(0).getColumnSetDefaultList().get(0);
+        column.setDefaultExpression(new LongValue(42));
+        assertEquals("42", column.getDefaultValue());
+        assertEquals("ALTER TABLE t ALTER COLUMN a SET DEFAULT 42", alter.toString());
+    }
+
+    @Test
+    void legacyStringConstructorRemainsOpaqueAndAcceptsNull() {
+        ColumnSetDefault column = new ColumnSetDefault("a", "vendor_default()");
+        assertNull(column.getDefaultExpression());
+        assertEquals("a SET DEFAULT vendor_default()", column.toString());
+        assertEquals("a SET DEFAULT null", new ColumnSetDefault("a", null).toString());
+        column.setDefaultExpression(new LongValue(1));
+        assertEquals("1", column.getDefaultValue());
+        column.setDefaultExpression(null);
+        assertNull(column.getDefaultValue());
+    }
+
+    private static Alter parse(String value) throws JSQLParserException {
+        return (Alter) CCJSqlParserUtil.parse("ALTER TABLE t ALTER COLUMN a SET DEFAULT " + value);
+    }
+}


### PR DESCRIPTION
ALTER COLUMN SET DEFAULT currently converts the parsed expression into a String, preventing expression traversal and custom deparsing. Retain the Expression, expose it for AST edits, and derive the existing getDefaultValue() text from it. The legacy String constructor remains available and opaque, including nullable calls.

Share ALTER COLUMN action rendering and route ALTER validation through the existing table-definition traversal. Regression tests cover arithmetic, casts, functions, NULL, multiple actions, visitor context, custom deparsing and AST edits.

This change covers ALTER COLUMN SET DEFAULT; CREATE TABLE column defaults retain their existing representation.

Validation: Java 17 `./gradlew check` passed, including the full test suite, grammar ambiguity check and static analysis.
