### PR TITLE
Visit pipe expressions through shared deparser paths

### DIFF
--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -79,7 +79,6 @@ import net.sf.jsqlparser.statement.select.Top;
 import net.sf.jsqlparser.statement.select.UnPivot;
 import net.sf.jsqlparser.statement.select.Values;
 import net.sf.jsqlparser.statement.select.WithItem;
-import net.sf.jsqlparser.statement.update.UpdateSet;
 
 @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
 public class SelectDeParser extends AbstractDeParser<PlainSelect>
@@ -1159,9 +1158,11 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
 
     @Override
     public StringBuilder visit(LimitPipeOperator limit, Void context) {
-        builder.append("|> ").append("LIMIT ").append(limit.getLimitExpression());
+        builder.append("|> LIMIT ");
+        limit.getLimitExpression().accept(expressionVisitor, context);
         if (limit.getOffsetExpression() != null) {
-            builder.append(" OFFSET ").append(limit.getOffsetExpression());
+            builder.append(" OFFSET ");
+            limit.getOffsetExpression().accept(expressionVisitor, context);
         }
         return builder;
     }
@@ -1206,7 +1207,8 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
 
         int i = 0;
         for (SelectItem<?> selectItem : select.getSelectItems()) {
-            builder.append(i++ > 0 ? ", " : " ").append(selectItem);
+            builder.append(i++ > 0 ? ", " : " ");
+            selectItem.accept(this, context);
         }
         builder.append("\n");
         return builder;
@@ -1214,10 +1216,10 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
 
     @Override
     public StringBuilder visit(SetPipeOperator set, Void context) {
-        builder.append("|> ").append("SET");
-        int i = 0;
-        for (UpdateSet updateSet : set.getUpdateSets()) {
-            builder.append(i++ > 0 ? ", " : " ").append(updateSet);
+        builder.append("|> SET");
+        if (!set.getUpdateSets().isEmpty()) {
+            builder.append(' ');
+            deparseUpdateSets(set.getUpdateSets(), builder, expressionVisitor);
         }
         builder.append("\n");
         return builder;

--- a/src/test/java/net/sf/jsqlparser/statement/piped/PipeExpressionDeParserTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/piped/PipeExpressionDeParserTest.java
@@ -1,0 +1,73 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2025 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement.piped;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import net.sf.jsqlparser.expression.LongValue;
+import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PipeExpressionDeParserTest {
+    @Test
+    void customPrinterVisitsEveryValueOnceAcrossThePipeline() throws Exception {
+        String sql = "FROM t |> SELECT 1 AS a, 'secret' AS b |> EXTEND a + 2 AS c "
+                + "|> SET a = 3, b = 'hidden' |> LIMIT 4 OFFSET 5";
+        var statement = CCJSqlParserUtil.parse(sql);
+        String original = statement.toString();
+        List<Long> visited = new ArrayList<>();
+        List<String> strings = new ArrayList<>();
+        StringBuilder output = new StringBuilder();
+        ExpressionDeParser expressions = new ExpressionDeParser() {
+            @Override
+            public <S> StringBuilder visit(LongValue value, S context) {
+                visited.add(value.getValue());
+                return getBuilder().append(value.getValue() + 100);
+            }
+
+            @Override
+            public <S> StringBuilder visit(StringValue value, S context) {
+                strings.add(value.getValue());
+                return getBuilder().append("'masked'");
+            }
+        };
+        statement.accept(new StatementDeParser(expressions, new SelectDeParser(), output), null);
+        assertEquals(Arrays.asList(1L, 2L, 3L, 4L, 5L), visited);
+        assertEquals(Arrays.asList("secret", "hidden"), strings);
+        assertEquals("FROM t\n|> SELECT 101 AS a, 'masked' AS b\n"
+                + "|> EXTEND a + 102 AS c\n|> SET a = 103, b = 'masked'\n"
+                + "|> LIMIT 104 OFFSET 105", output.toString());
+        assertEquals(original, statement.toString());
+        assertEquals(output.toString(), CCJSqlParserUtil.parse(output.toString()).toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"FROM t |> SELECT DISTINCT a + 1 AS b, a * 2 AS c",
+            "FROM t |> EXTEND COALESCE(a, 1) AS b",
+            "FROM t |> SET a = 1, b = (SELECT 2)",
+            "FROM t |> SET (a, b) = (1, 2)",
+            "FROM t |> LIMIT 1", "FROM t |> LIMIT 1 OFFSET 2"})
+    void defaultPrinterPreservesAliasesSubqueriesAndAssignmentBrackets(String sql)
+            throws Exception {
+        var statement = CCJSqlParserUtil.parse(sql);
+        StringBuilder output = new StringBuilder();
+        statement.accept(new StatementDeParser(output), null);
+        assertEquals(statement.toString(), output.toString());
+        assertEquals(statement.toString(), CCJSqlParserUtil.parse(output.toString()).toString());
+    }
+}


### PR DESCRIPTION
A custom `ExpressionDeParser` can rewrite `SELECT 7` while leaving `FROM t |> SELECT 7`, `|> SET a = 7` and `|> LIMIT 7` unchanged. These pipe operators append nested AST nodes directly, bypassing the supplied expression visitor. This makes transformations inconsistent across equivalent ordinary and pipe SQL.

Route SELECT and EXTEND items through the existing select-item visitor, reuse the ordinary UPDATE assignment deparser for SET, and visit LIMIT/OFFSET expressions explicitly. This removes duplicate assignment rendering while preserving aliases, tuple brackets and default SQL output.

The downstream investigation found [Confluent JDBC's custom deparser overrides](https://github.com/confluentinc/kafka-connect-jdbc/blob/44b12393de1201c309fda4ae4c17c4b093439630/src/main/java/io/confluent/connect/jdbc/util/SqlParser.java#L455) explaining why nested expressions must remain reachable through visitors. The pipe cases here are independent upstream reproductions; they are not a claim about Confluent using pipe syntax.

Tests exercise one custom printer across a pipeline, check that each literal is visited once, preserve aliases and the original AST, and round-trip DISTINCT, EXTEND, subqueries, tuple assignments and LIMIT/OFFSET.

Validation: Java 17 `./gradlew --console=plain --max-workers=2 check`, including all tests and static analysis.
