### PR TITLE
Structure FOR PORTION intervals in UPDATE and DELETE

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
+++ b/src/main/java/net/sf/jsqlparser/parser/feature/Feature.java
@@ -337,6 +337,9 @@ public enum Feature {
      * @see Update
      */
     update,
+
+    /** Application-time FOR PORTION OF in UPDATE and DELETE. */
+    forPortion,
     /**
      * "UPDATE table1 SET ... FROM table2
      */

--- a/src/main/java/net/sf/jsqlparser/statement/ForPortionClause.java
+++ b/src/main/java/net/sf/jsqlparser/statement/ForPortionClause.java
@@ -1,0 +1,72 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement;
+
+import java.util.function.Consumer;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.parser.ASTNodeAccessImpl;
+
+/** The application-time interval affected by an UPDATE or DELETE statement. */
+public class ForPortionClause extends ASTNodeAccessImpl {
+    private String periodName;
+    private Expression fromExpression;
+    private Expression toExpression;
+
+    public ForPortionClause(String periodName, Expression fromExpression, Expression toExpression) {
+        this.periodName = periodName;
+        this.fromExpression = fromExpression;
+        this.toExpression = toExpression;
+    }
+
+    public String getPeriodName() {
+        return periodName;
+    }
+
+    public void setPeriodName(String periodName) {
+        this.periodName = periodName;
+    }
+
+    public Expression getFromExpression() {
+        return fromExpression;
+    }
+
+    public void setFromExpression(Expression fromExpression) {
+        this.fromExpression = fromExpression;
+    }
+
+    public Expression getToExpression() {
+        return toExpression;
+    }
+
+    public void setToExpression(Expression toExpression) {
+        this.toExpression = toExpression;
+    }
+
+    /** Visits both interval bounds, preserving the caller's context. */
+    public <S> void accept(ExpressionVisitor<?> visitor, S context) {
+        fromExpression.accept(visitor, context);
+        toExpression.accept(visitor, context);
+    }
+
+    public StringBuilder appendTo(StringBuilder builder, Consumer<Expression> expressionPrinter) {
+        builder.append("FOR PORTION OF ").append(periodName).append(" FROM ");
+        expressionPrinter.accept(fromExpression);
+        builder.append(" TO ");
+        expressionPrinter.accept(toExpression);
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        return appendTo(builder, builder::append).toString();
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
+++ b/src/main/java/net/sf/jsqlparser/statement/delete/Delete.java
@@ -13,6 +13,7 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.expression.PreferringClause;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.ForPortionClause;
 import net.sf.jsqlparser.statement.OutputClause;
 import net.sf.jsqlparser.statement.ReturningClause;
 import net.sf.jsqlparser.statement.Statement;
@@ -39,6 +40,7 @@ public class Delete implements Statement {
 
     private List<WithItem<?>> withItemsList;
     private Table table;
+    private ForPortionClause forPortionClause;
     private OracleHint oracleHint = null;
     private List<Table> tables;
     private List<FromItem> usingFromItemList;
@@ -111,6 +113,19 @@ public class Delete implements Statement {
     @Override
     public <T, S> T accept(StatementVisitor<T> statementVisitor, S context) {
         return statementVisitor.visit(this, context);
+    }
+
+    public ForPortionClause getForPortionClause() {
+        return forPortionClause;
+    }
+
+    public void setForPortionClause(ForPortionClause forPortionClause) {
+        this.forPortionClause = forPortionClause;
+    }
+
+    public Delete withForPortionClause(ForPortionClause forPortionClause) {
+        setForPortionClause(forPortionClause);
+        return this;
     }
 
     public Table getTable() {
@@ -261,6 +276,9 @@ public class Delete implements Statement {
             b.append(" FROM");
         }
         b.append(" ").append(table);
+        if (forPortionClause != null) {
+            b.append(' ').append(forPortionClause);
+        }
 
         if (usingFromItemList != null && !usingFromItemList.isEmpty()) {
             b.append(" USING ");

--- a/src/main/java/net/sf/jsqlparser/statement/update/Update.java
+++ b/src/main/java/net/sf/jsqlparser/statement/update/Update.java
@@ -14,6 +14,7 @@ import net.sf.jsqlparser.expression.OracleHint;
 import net.sf.jsqlparser.expression.PreferringClause;
 import net.sf.jsqlparser.schema.Column;
 import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.statement.ForPortionClause;
 import net.sf.jsqlparser.statement.OutputClause;
 import net.sf.jsqlparser.statement.ReturningClause;
 import net.sf.jsqlparser.statement.Statement;
@@ -40,6 +41,7 @@ public class Update implements Statement {
 
     private List<WithItem<?>> withItemsList;
     private Table table;
+    private ForPortionClause forPortionClause;
     private Expression where;
     private PreferringClause preferringClause;
     private List<UpdateSet> updateSets;
@@ -112,6 +114,19 @@ public class Update implements Statement {
                 Optional.ofNullable(getWithItemsList()).orElseGet(ArrayList::new);
         collection.addAll(withItemsList);
         return this.withWithItemsList(collection);
+    }
+
+    public ForPortionClause getForPortionClause() {
+        return forPortionClause;
+    }
+
+    public void setForPortionClause(ForPortionClause forPortionClause) {
+        this.forPortionClause = forPortionClause;
+    }
+
+    public Update withForPortionClause(ForPortionClause forPortionClause) {
+        setForPortionClause(forPortionClause);
+        return this;
     }
 
     public Table getTable() {
@@ -372,6 +387,9 @@ public class Update implements Statement {
             b.append("IGNORE ");
         }
         b.append(table);
+        if (forPortionClause != null) {
+            b.append(' ').append(forPortionClause);
+        }
         if (startJoins != null) {
             for (Join join : startJoins) {
                 if (join.isSimple()) {

--- a/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
+++ b/src/main/java/net/sf/jsqlparser/util/TablesNamesFinder.java
@@ -1356,6 +1356,9 @@ public class TablesNamesFinder<Void>
 
         visitJoins(delete.getJoins(), context);
 
+        if (delete.getForPortionClause() != null) {
+            delete.getForPortionClause().accept(this, context);
+        }
         if (delete.getWhere() != null) {
             delete.getWhere().accept(this, context);
         }
@@ -1419,6 +1422,9 @@ public class TablesNamesFinder<Void>
             }
         }
 
+        if (update.getForPortionClause() != null) {
+            update.getForPortionClause().accept(this, context);
+        }
         if (update.getWhere() != null) {
             update.getWhere().accept(this, context);
         }

--- a/src/main/java/net/sf/jsqlparser/util/deparser/AbstractDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/AbstractDeParser.java
@@ -11,6 +11,7 @@ package net.sf.jsqlparser.util.deparser;
 
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.statement.update.UpdateSet;
+import net.sf.jsqlparser.statement.ForPortionClause;
 
 import java.util.List;
 
@@ -40,6 +41,14 @@ abstract class AbstractDeParser<S> {
                 buffer.append(" = ");
                 expressionListDeParser.deParse(updateSet.getValues());
             }
+        }
+    }
+
+    protected void deparseForPortionClause(ForPortionClause clause,
+            ExpressionVisitor<StringBuilder> visitor) {
+        if (clause != null) {
+            builder.append(' ');
+            clause.appendTo(builder, expression -> expression.accept(visitor, null));
         }
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
@@ -77,6 +77,7 @@ public class DeleteDeParser extends AbstractDeParser<Delete> {
             builder.append(" FROM");
         }
         builder.append(" ").append(delete.getTable().toString());
+        deparseForPortionClause(delete.getForPortionClause(), expressionVisitor);
 
         if (delete.getUsingFromItemList() != null && !delete.getUsingFromItemList().isEmpty()) {
             builder.append(" USING").append(

--- a/src/main/java/net/sf/jsqlparser/util/deparser/UpdateDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/UpdateDeParser.java
@@ -61,6 +61,7 @@ public class UpdateDeParser extends AbstractDeParser<Update>
             builder.append("IGNORE ");
         }
         builder.append(update.getTable());
+        deparseForPortionClause(update.getForPortionClause(), expressionVisitor);
         if (update.getStartJoins() != null) {
             for (Join join : update.getStartJoins()) {
                 if (join.isSimple()) {

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/FeaturesAllowed.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/FeaturesAllowed.java
@@ -137,6 +137,7 @@ public class FeaturesAllowed implements FeatureSetValidation, ModifyableFeatureS
      * all {@link Feature}' for SQL UPDATE including {@link #SELECT}
      */
     public static final FeaturesAllowed UPDATE = new FeaturesAllowed("UPDATE", Feature.update,
+            Feature.forPortion,
             Feature.updateJoins,
             Feature.updateFrom, Feature.updateLimit, Feature.updateOrderBy, Feature.updateReturning,
             Feature.updateUseSelect)
@@ -145,7 +146,7 @@ public class FeaturesAllowed implements FeatureSetValidation, ModifyableFeatureS
      * all {@link Feature}' for SQL UPDATE including {@link #SELECT}
      */
     public static final FeaturesAllowed DELETE =
-            new FeaturesAllowed("DELETE", Feature.delete, Feature.deleteJoin,
+            new FeaturesAllowed("DELETE", Feature.delete, Feature.forPortion, Feature.deleteJoin,
                     Feature.deleteLimit, Feature.deleteOrderBy, Feature.deleteTables,
                     Feature.deleteReturningExpressionList,
                     Feature.truncate)

--- a/src/main/java/net/sf/jsqlparser/util/validation/feature/MariaDbVersion.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/feature/MariaDbVersion.java
@@ -26,10 +26,8 @@ public enum MariaDbVersion implements Version {
     V10_5_4("10.5.4",
             EnumSet.of(// supported if used with jdbc
                     Feature.jdbcParameter,
-                    Feature.jdbcNamedParameter,
-                    // expressions
-                    Feature.exprLike,
-                    // https://mariadb.com/kb/en/select/
+                    Feature.jdbcNamedParameter, // expressions
+                    Feature.exprLike, // https://mariadb.com/kb/en/select/
                     Feature.select,
                     Feature.selectGroupBy, Feature.function,
                     Feature.selectHaving,
@@ -49,12 +47,9 @@ public enum MariaDbVersion implements Version {
                     // https://mariadb.com/kb/en/select/#distinct
                     Feature.distinct,
 
-                    Feature.setOperation,
-                    // https://mariadb.com/kb/en/union/
-                    Feature.setOperationUnion,
-                    // https://mariadb.com/kb/en/intersect/
-                    Feature.setOperationIntersect,
-                    // https://mariadb.com/kb/en/except/
+                    Feature.setOperation, // https://mariadb.com/kb/en/union/
+                    Feature.setOperationUnion, // https://mariadb.com/kb/en/intersect/
+                    Feature.setOperationIntersect, // https://mariadb.com/kb/en/except/
                     Feature.setOperationExcept,
 
                     // https://mariadb.com/kb/en/common-table-expressions/
@@ -71,7 +66,8 @@ public enum MariaDbVersion implements Version {
                     Feature.insertReturningExpressionList,
 
                     // https://mariadb.com/kb/en/update/
-                    Feature.update,
+                    Feature.update, // https://mariadb.com/kb/en/application-time-periods/
+                    Feature.forPortion,
                     Feature.updateJoins,
                     Feature.updateOrderBy, Feature.updateLimit,
 
@@ -87,17 +83,12 @@ public enum MariaDbVersion implements Version {
                     Feature.execute, Feature.executeCall,
 
                     // https://mariadb.com/kb/en/drop/
-                    Feature.drop,
-                    // https://mariadb.com/kb/en/drop-index/
-                    Feature.dropIndex,
-                    // https://mariadb.com/kb/en/drop-table/
-                    Feature.dropTable,
-                    // https://mariadb.com/kb/en/drop-database/
+                    Feature.drop, // https://mariadb.com/kb/en/drop-index/
+                    Feature.dropIndex, // https://mariadb.com/kb/en/drop-table/
+                    Feature.dropTable, // https://mariadb.com/kb/en/drop-database/
                     // SCHEMA = DATABASE
-                    Feature.dropSchema,
-                    // https://mariadb.com/kb/en/drop-view/
-                    Feature.dropView,
-                    // https://mariadb.com/kb/en/drop-sequence/
+                    Feature.dropSchema, // https://mariadb.com/kb/en/drop-view/
+                    Feature.dropView, // https://mariadb.com/kb/en/drop-sequence/
                     Feature.dropSequence, Feature.dropTableIfExists, Feature.dropIndexIfExists,
                     Feature.dropViewIfExists, Feature.dropSchemaIfExists,
                     Feature.dropSequenceIfExists,
@@ -106,12 +97,9 @@ public enum MariaDbVersion implements Version {
                     Feature.upsert,
 
                     // https://mariadb.com/kb/en/alter/
-                    Feature.alterTable,
-                    // https://mariadb.com/kb/en/alter-sequence/
-                    Feature.alterSequence,
-                    // https://mariadb.com/kb/en/alter-view/
-                    Feature.alterView,
-                    // https://mariadb.com/kb/en/create-view/
+                    Feature.alterTable, // https://mariadb.com/kb/en/alter-sequence/
+                    Feature.alterSequence, // https://mariadb.com/kb/en/alter-view/
+                    Feature.alterView, // https://mariadb.com/kb/en/create-view/
                     Feature.createView,
                     Feature.createOrReplaceView,
                     Feature.createViewWithComment,
@@ -119,35 +107,22 @@ public enum MariaDbVersion implements Version {
                     // https://mariadb.com/kb/en/create-table/
                     Feature.createTable, Feature.createTableCreateOptionStrings,
                     Feature.createTableTableOptionStrings,
-                    Feature.createTableFromSelect, Feature.createTableIfNotExists,
-                    // https://mariadb.com/kb/en/create-index/
-                    Feature.createIndex,
-                    // https://mariadb.com/kb/en/create-sequence/
-                    Feature.createSequence,
-                    // https://mariadb.com/kb/en/create-database/
-                    Feature.createSchema,
-                    // https://mariadb.com/kb/en/create-trigger/
+                    Feature.createTableFromSelect, Feature.createTableIfNotExists, // https://mariadb.com/kb/en/create-index/
+                    Feature.createIndex, // https://mariadb.com/kb/en/create-sequence/
+                    Feature.createSequence, // https://mariadb.com/kb/en/create-database/
+                    Feature.createSchema, // https://mariadb.com/kb/en/create-trigger/
                     Feature.createTrigger,
 
                     // https://mariadb.com/kb/en/describe/
-                    Feature.describe,
-                    // https://mariadb.com/kb/en/explain/
-                    Feature.explain,
-                    // https://mariadb.com/kb/en/show/
-                    Feature.show,
-                    // https://mariadb.com/kb/en/show-tables/
-                    Feature.showTables,
-                    // https://mariadb.com/kb/en/show-columns/
-                    Feature.showColumns,
-                    // https://mariadb.com/kb/en/show-index/
-                    Feature.showIndex,
-                    // https://mariadb.com/kb/en/use/
-                    Feature.use,
-                    // https://mariadb.com/kb/en/grant/
-                    Feature.grant,
-                    // https://mariadb.com/kb/en/commit/
-                    Feature.commit,
-                    // https://mariadb.com/kb/en/optimizer-hints/
+                    Feature.describe, // https://mariadb.com/kb/en/explain/
+                    Feature.explain, // https://mariadb.com/kb/en/show/
+                    Feature.show, // https://mariadb.com/kb/en/show-tables/
+                    Feature.showTables, // https://mariadb.com/kb/en/show-columns/
+                    Feature.showColumns, // https://mariadb.com/kb/en/show-index/
+                    Feature.showIndex, // https://mariadb.com/kb/en/use/
+                    Feature.use, // https://mariadb.com/kb/en/grant/
+                    Feature.grant, // https://mariadb.com/kb/en/commit/
+                    Feature.commit, // https://mariadb.com/kb/en/optimizer-hints/
                     Feature.mySqlHintStraightJoin,
                     Feature.mysqlCalcFoundRows,
                     Feature.mysqlSqlCacheFlag)),

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/AbstractValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/AbstractValidator.java
@@ -9,6 +9,7 @@
  */
 package net.sf.jsqlparser.util.validation.validator;
 
+import net.sf.jsqlparser.statement.ForPortionClause;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.statement.select.FromItem;
@@ -126,6 +127,15 @@ public abstract class AbstractValidator<S> implements Validator<S> {
         if (isNotEmpty(elementList)) {
             V validator = validatorSupplier.get();
             elementList.forEach(e -> elementConsumer.accept(e, validator));
+        }
+    }
+
+    protected void validateOptionalForPortionClause(ForPortionClause clause) {
+        if (clause != null) {
+            for (ValidationCapability capability : getCapabilities()) {
+                validateFeature(capability, Feature.forPortion);
+            }
+            clause.accept(getValidator(ExpressionValidator.class), null);
         }
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/DeleteValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/DeleteValidator.java
@@ -40,6 +40,7 @@ public class DeleteValidator extends AbstractValidator<Delete> {
             delete.getTables().forEach(t -> t.accept(v, null));
         }
 
+        validateOptionalForPortionClause(delete.getForPortionClause());
         validateOptionalExpression(delete.getWhere());
         validateOptionalOrderByElements(delete.getOrderByElements());
 

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/UpdateValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/UpdateValidator.java
@@ -56,6 +56,7 @@ public class UpdateValidator extends AbstractValidator<Update> {
                     j -> getValidator(SelectValidator.class).validateOptionalJoins(j));
         }
 
+        validateOptionalForPortionClause(update.getForPortionClause());
         validateOptionalExpression(update.getWhere());
         validateOptionalOrderByElements(update.getOrderByElements());
 

--- a/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
+++ b/src/main/jjtree/net/sf/jsqlparser/parser/JSqlParserCC.jjt
@@ -4731,6 +4731,7 @@ Update Update():
 {
     Update update = new Update();
     Table table = null;
+    ForPortionClause forPortionClause;
     List<Join> startJoins = null;
     List<WithItem<?>> with = null;
     List<UpdateSet> updateSets;
@@ -4751,7 +4752,9 @@ Update Update():
    <K_UPDATE> { update.setOracleHint(getOracleHint()); }
     [ LOOKAHEAD(2) <K_LOW_PRIORITY> { modifierPriority = UpdateModifierPriority.LOW_PRIORITY; }]
     [ LOOKAHEAD(2) <K_IGNORE> { modifierIgnore = true; }]
-    table=TableWithAliasAndMysqlIndexHint() [ startJoins=JoinsList() ]
+    table=TableWithAliasAndMysqlIndexHint()
+    [ forPortionClause=ForPortionClause() { update.setForPortionClause(forPortionClause); } ]
+    [ startJoins=JoinsList() ]
     [ LOOKAHEAD(<K_FROM>, { Dialect.TERADATA.name().equals(getAsString(Feature.dialect)) })
         UpdateFromClause(update) { update.setFromBeforeSet(true); } ]
     <K_SET> updateSets = UpdateSets() { update.setUpdateSets(updateSets); }
@@ -4775,6 +4778,24 @@ Update Update():
               .withStartJoins(startJoins)
               .withModifierPriority(modifierPriority)
               .withModifierIgnore(modifierIgnore);
+    }
+}
+
+/** Shared structured interval for application-time UPDATE and DELETE. */
+ForPortionClause ForPortionClause() #ForPortionClause:
+{
+    String periodName;
+    Expression fromExpression;
+    Expression toExpression;
+    ForPortionClause clause;
+}
+{
+    <K_FOR> AccessKeyword("PORTION") <K_OF> periodName=RelObjectName()
+    <K_FROM> fromExpression=Expression() <K_TO> toExpression=Expression()
+    {
+        clause = new ForPortionClause(periodName, fromExpression, toExpression);
+        linkAST(clause, jjtThis);
+        return clause;
     }
 }
 
@@ -5361,6 +5382,7 @@ Delete Delete():
 {
     Delete delete = new Delete();
     Table table = null;
+    ForPortionClause forPortionClause;
     List<Table> tables = new ArrayList<Table>();
     List<WithItem<?>> with = null;
     FromItem usingFromItem = null;
@@ -5390,7 +5412,9 @@ Delete Delete():
     [ outputClause = OutputClause() {delete.setOutputClause(outputClause); } ]
     <K_FROM> | <K_FROM>) { hasFrom = true; }]
 
-    [ LOOKAHEAD(3) table=TableWithAlias() [ LOOKAHEAD(2)  joins=JoinsList() ] ]
+    [ LOOKAHEAD(3) table=TableWithAlias()
+        [ forPortionClause=ForPortionClause() { delete.setForPortionClause(forPortionClause); } ]
+        [ LOOKAHEAD(2) joins=JoinsList() ] ]
     [ <K_USING> usingFromItem=FromItem() { usingFromItemList.add(usingFromItem); }
           ("," usingFromItem=FromItem() { usingFromItemList.add(usingFromItem); } )*]
     [where=WhereClause() { delete.setWhere(where); } ]

--- a/src/test/java/net/sf/jsqlparser/statement/ForPortionClauseTest.java
+++ b/src/test/java/net/sf/jsqlparser/statement/ForPortionClauseTest.java
@@ -1,0 +1,171 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.statement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import net.sf.jsqlparser.JSQLParserException;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.expression.JdbcParameter;
+import net.sf.jsqlparser.expression.LongValue;
+import net.sf.jsqlparser.expression.StringValue;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.parser.feature.Feature;
+import net.sf.jsqlparser.statement.delete.Delete;
+import net.sf.jsqlparser.statement.update.Update;
+import net.sf.jsqlparser.test.TestUtils;
+import net.sf.jsqlparser.util.TablesNamesFinder;
+import net.sf.jsqlparser.util.deparser.ExpressionDeParser;
+import net.sf.jsqlparser.util.deparser.SelectDeParser;
+import net.sf.jsqlparser.util.deparser.StatementDeParser;
+import net.sf.jsqlparser.util.validation.ValidationTestAsserts;
+import net.sf.jsqlparser.util.validation.feature.FeaturesAllowed;
+import net.sf.jsqlparser.util.validation.feature.MariaDbVersion;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ForPortionClauseTest extends ValidationTestAsserts {
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "UPDATE prices FOR PORTION OF VALID_TIME FROM '2020-01-01' TO '2021-01-01' SET price = 10 WHERE id = 1",
+            "DELETE FROM prices FOR PORTION OF VALID_TIME FROM '2020-01-01' TO '2021-01-01' WHERE id = 1",
+            "UPDATE prices p FOR PORTION OF valid_time FROM ? TO ? SET price = ? WHERE id = ?",
+            "DELETE FROM prices AS p FOR PORTION OF \"valid time\" FROM :start_date TO :end_date WHERE id = :id",
+            "UPDATE prices FOR PORTION OF p FROM DATE '2020-01-01' TO DATE '2021-01-01' SET price = 10",
+            "DELETE FROM prices FOR PORTION OF p FROM CAST(? AS DATE) TO CAST(? AS DATE) ORDER BY id LIMIT 1",
+            "UPDATE prices FOR PORTION OF p FROM (1 + 2) TO COALESCE(3, 4) SET price = 10 RETURNING id",
+            "DELETE FROM prices FOR PORTION OF p FROM 1 TO 2 RETURNING id",
+            "WITH ids AS (SELECT id FROM selected) UPDATE prices FOR PORTION OF p FROM 1 TO 2 SET price = 10 WHERE id IN (SELECT id FROM ids)"})
+    void preservesTheIntervalThroughBothStatementRenderers(String sql) throws Exception {
+        Statement statement = TestUtils.assertSqlCanBeParsedAndDeparsed(sql);
+        ForPortionClause clause = portion(statement);
+        assertEquals(clause.toString(),
+                portion(CCJSqlParserUtil.parse(statement.toString())).toString());
+    }
+
+    @Test
+    void exposesTypedBoundsAndPreservesGlobalParameterOrder() throws Exception {
+        Update update = (Update) CCJSqlParserUtil.parse(
+                "UPDATE prices FOR PORTION OF p FROM ? TO ? SET price = ? WHERE id = ?");
+        ForPortionClause clause = update.getForPortionClause();
+        assertEquals("p", clause.getPeriodName());
+        assertEquals(1, ((JdbcParameter) clause.getFromExpression()).getIndex());
+        assertEquals(2, ((JdbcParameter) clause.getToExpression()).getIndex());
+        assertEquals(3,
+                ((JdbcParameter) update.getUpdateSets().get(0).getValues().get(0)).getIndex());
+        clause.setPeriodName("valid_time");
+        clause.setFromExpression(new StringValue("2020-01-01"));
+        clause.setToExpression(new StringValue("2021-01-01"));
+        assertInstanceOf(StringValue.class, clause.getFromExpression());
+        assertEquals(
+                "UPDATE prices FOR PORTION OF valid_time FROM '2020-01-01' TO '2021-01-01' SET price = ? WHERE id = ?",
+                update.toString());
+        Delete delete = (Delete) CCJSqlParserUtil.parse("DELETE FROM prices");
+        assertNull(delete.getForPortionClause());
+        assertSame(delete, delete.withForPortionClause(clause));
+        assertEquals("DELETE FROM prices " + clause, delete.toString());
+        update.setForPortionClause(null);
+        assertEquals("UPDATE prices SET price = ? WHERE id = ?", update.toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"UPDATE prices FOR PORTION OF p FROM 1 TO 2 SET price = 3 WHERE id = 4",
+            "DELETE FROM prices FOR PORTION OF p FROM 1 TO 2 WHERE id = 4"})
+    void customVisitorsSeeEachBoundExactlyOnce(String sql) throws Exception {
+        Statement statement = CCJSqlParserUtil.parse(sql);
+        Object context = new Object();
+        List<Long> bounds = new ArrayList<>();
+        portion(statement).accept(new ExpressionVisitorAdapter<Void>() {
+            @Override
+            public <S> Void visit(LongValue value, S actualContext) {
+                assertSame(context, actualContext);
+                bounds.add(value.getValue());
+                return null;
+            }
+        }, context);
+        assertEquals(List.of(1L, 2L), bounds);
+        List<Long> rendered = new ArrayList<>();
+        StringBuilder output = new StringBuilder();
+        ExpressionDeParser expressions = new ExpressionDeParser() {
+            @Override
+            public <S> StringBuilder visit(LongValue value, S actualContext) {
+                rendered.add(value.getValue());
+                return getBuilder().append(value.getValue() + 100);
+            }
+        };
+        statement.accept(new StatementDeParser(expressions, new SelectDeParser(), output), null);
+        assertEquals(statement instanceof Update ? List.of(1L, 2L, 3L, 4L) : List.of(1L, 2L, 4L),
+                rendered);
+        String expected = sql.replace("FROM 1 TO 2", "FROM 101 TO 102")
+                .replace("price = 3", "price = 103").replace("id = 4", "id = 104");
+        assertEquals(expected, output.toString());
+        assertEquals(sql, statement.toString());
+        TestUtils.assertSqlCanBeParsedAndDeparsed(output.toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "UPDATE prices FOR PORTION OF p FROM (SELECT MIN(ts) FROM starts) TO (SELECT MAX(ts) FROM ends) SET price = 10",
+            "DELETE FROM prices FOR PORTION OF p FROM (SELECT MIN(ts) FROM starts) TO (SELECT MAX(ts) FROM ends)"})
+    void tableDiscoveryTraversesBothBoundExpressions(String sql) throws Exception {
+        assertEquals(Set.of("prices", "starts", "ends"), TablesNamesFinder.findTables(sql));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"UPDATE prices FOR PORTION OF p FROM ? TO ? SET price = 10",
+            "DELETE FROM prices FOR PORTION OF p FROM ? TO ?",
+            "UPDATE prices FOR PORTION OF p FROM ? TO 2 SET price = 10",
+            "UPDATE prices FOR PORTION OF p FROM 1 TO ? SET price = 10",
+            "DELETE FROM prices FOR PORTION OF p FROM ? TO 2",
+            "DELETE FROM prices FOR PORTION OF p FROM 1 TO ?"})
+    void validatesTheClauseFeatureAndBothBoundExpressions(String sql) throws Exception {
+        validateNoErrors(sql, 1,
+                new FeaturesAllowed().add(FeaturesAllowed.DML).add(Feature.jdbcParameter));
+        validateNoErrors(sql, 1, MariaDbVersion.V10_5_4);
+        validateNotAllowed(sql, 1, 1,
+                new FeaturesAllowed().add(FeaturesAllowed.DML).add(Feature.jdbcParameter)
+                        .remove(Feature.forPortion),
+                Feature.forPortion);
+        validateNotAllowed(sql, 1, 1,
+                new FeaturesAllowed().add(FeaturesAllowed.DML).remove(Feature.jdbcParameter),
+                Feature.jdbcParameter);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"UPDATE prices FOR PORTION p FROM 1 TO 2 SET price = 10",
+            "DELETE FROM prices FOR PORTION OF p FROM 1",
+            "DELETE FROM prices FOR PORTION OF p FROM 1 TO",
+            "DELETE FROM prices FOR PORTION OF p TO 2",
+            "UPDATE prices FOR PORTION OF p FROM 1 TO 2",
+            "DELETE FROM prices FOR PORTION OF p FROM 1 TO 2 garbage"})
+    void rejectsIncompleteClausesAndTrailingInput(String sql) {
+        assertThrows(JSQLParserException.class, () -> CCJSqlParserUtil.parse(sql));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"UPDATE portion SET valid_time = 1",
+            "DELETE FROM portion WHERE valid_time = 1",
+            "SELECT portion, valid_time FROM prices FOR UPDATE"})
+    void preservesOrdinaryIdentifiersAndForUpdate(String sql) throws Exception {
+        TestUtils.assertSqlCanBeParsedAndDeparsed(sql);
+    }
+
+    private static ForPortionClause portion(Statement statement) {
+        return statement instanceof Update ? ((Update) statement).getForPortionClause()
+                : ((Delete) statement).getForPortionClause();
+    }
+}


### PR DESCRIPTION
Temporal SQL consumers need to retain the interval affected by an UPDATE or DELETE. Stratum currently extracts and removes `FOR PORTION OF` before parsing, then carries that information separately ([pinned consumer workaround](https://github.com/replikativ/stratum/blob/91a436694248dc6740fb5b7bb9b38d0cc7465919/src/stratum/sql/rewrite.clj#L449)). A structured clause keeps the period and bound expressions attached to the statement, making them available to inspection, rewriting, and validation.

Support application-time `FOR PORTION OF period FROM expression TO expression` on UPDATE and DELETE targets, as documented for [MariaDB application-time periods](https://mariadb.com/docs/server/reference/sql-structure/temporal-tables/application-time-periods). For example, `UPDATE prices FOR PORTION OF valid_time FROM ? TO ? SET price = ?` now preserves the period name, both expressions, and their parameter ordering.

Both statements reuse `ForPortionClause`, one grammar production, shared deparser handling, and shared validation. Its renderer is also used by model output, while its expression traversal carries visitor context to both bounds. Table discovery visits nested bound expressions, and a dedicated validation feature is included in the MariaDB feature set. This change concerns the DML interval clause; it does not add temporal SELECT syntax or enforce database-specific restrictions on the values of the bounds.

Validation: full Java 17 Gradle `check` passes, including the zero-conflict JavaCC grammar gate, tests, formatting, Checkstyle, PMD, and SpotBugs. Tests cover both statements, aliases and quoted period names, typed literals and parameters, AST mutation, custom deparsers, nested-expression traversal, feature validation, WHERE/ORDER BY/LIMIT/RETURNING boundaries, round trips, and malformed clauses.
