### PR TITLE
Validate every UPDATE assignment through shared UpdateSet traversal

### DIFF
--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/AbstractValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/AbstractValidator.java
@@ -10,6 +10,9 @@
 package net.sf.jsqlparser.util.validation.validator;
 
 import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.statement.update.UpdateSet;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.SelectVisitor;
 import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.statement.select.FromItem;
 import net.sf.jsqlparser.statement.select.OrderByElement;
@@ -135,6 +138,25 @@ public abstract class AbstractValidator<S> implements Validator<S> {
 
     protected void validateOptionalExpression(Expression expression, ExpressionValidator v) {
         validateOptional(expression, e -> e.accept(v, null));
+    }
+
+    protected void validateOptionalUpdateSets(List<UpdateSet> updateSets) {
+        if (updateSets != null) {
+            for (UpdateSet updateSet : updateSets) {
+                validateOptionalExpressions(updateSet.getColumns());
+                if (updateSet.getValues() != null) {
+                    for (Expression value : updateSet.getValues()) {
+                        if (value instanceof Select) {
+                            ((Select) value).accept(
+                                    (SelectVisitor<Void>) getValidator(SelectValidator.class),
+                                    null);
+                        } else {
+                            validateOptionalExpression(value);
+                        }
+                    }
+                }
+            }
+        }
     }
 
     protected void validateOptionalExpressions(List<? extends Expression> expressions) {

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/MergeValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/MergeValidator.java
@@ -12,7 +12,6 @@ package net.sf.jsqlparser.util.validation.validator;
 import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.statement.merge.*;
 import net.sf.jsqlparser.statement.select.OptionHint;
-import net.sf.jsqlparser.statement.update.UpdateSet;
 import net.sf.jsqlparser.util.validation.ValidationCapability;
 
 /**
@@ -59,10 +58,7 @@ public class MergeValidator<Void> extends AbstractValidator<Merge>
     @Override
     public <S> Void visit(MergeUpdate mergeUpdate, S context) {
         validateOptionalExpression(mergeUpdate.getAndPredicate());
-        for (UpdateSet updateSet : mergeUpdate.getUpdateSets()) {
-            validateOptionalExpressions(updateSet.getColumns());
-            validateOptionalExpressions(updateSet.getValues());
-        }
+        validateOptionalUpdateSets(mergeUpdate.getUpdateSets());
         validateOptionalExpression(mergeUpdate.getDeleteWhereCondition());
         validateOptionalExpression(mergeUpdate.getWhereCondition());
         return null;

--- a/src/main/java/net/sf/jsqlparser/util/validation/validator/UpdateValidator.java
+++ b/src/main/java/net/sf/jsqlparser/util/validation/validator/UpdateValidator.java
@@ -10,7 +10,6 @@
 package net.sf.jsqlparser.util.validation.validator;
 
 import net.sf.jsqlparser.parser.feature.Feature;
-import net.sf.jsqlparser.statement.select.SelectVisitor;
 import net.sf.jsqlparser.statement.select.OptionHint;
 import net.sf.jsqlparser.statement.update.Update;
 import net.sf.jsqlparser.util.validation.ValidationCapability;
@@ -27,7 +26,6 @@ public class UpdateValidator extends AbstractValidator<Update> {
             validateFeature(c, Feature.update);
             validateOptionalFeature(c, update.getFromItem(), Feature.updateFrom);
             validateOptionalFeature(c, update.getStartJoins(), Feature.updateJoins);
-            validateFeature(c, update.isUseSelect(), Feature.updateUseSelect);
             validateOptionalFeature(c, update.getOrderByElements(), Feature.updateOrderBy);
             validateOptionalFeature(c, update.getLimit(), Feature.updateLimit);
             validateOptionalFeature(c, update.getReturningClause(),
@@ -41,14 +39,7 @@ public class UpdateValidator extends AbstractValidator<Update> {
         validateOptional(update.getStartJoins(),
                 j -> getValidator(SelectValidator.class).validateOptionalJoins(j));
 
-        if (update.isUseSelect()) {
-            validateOptionalExpressions(update.getColumns());
-            validateOptional(update.getSelect(),
-                    e -> e.accept((SelectVisitor<Void>) getValidator(SelectValidator.class), null));
-        } else {
-            validateOptionalExpressions(update.getColumns());
-            validateOptionalExpressions(update.getExpressions());
-        }
+        validateOptionalUpdateSets(update.getUpdateSets());
 
         if (update.getFromItem() != null) {
             validateOptionalFromItem(update.getFromItem());

--- a/src/test/java/net/sf/jsqlparser/util/validation/validator/UpdateSetValidationTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/validation/validator/UpdateSetValidationTest.java
@@ -1,0 +1,44 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2026 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.util.validation.validator;
+
+import net.sf.jsqlparser.parser.feature.Feature;
+import net.sf.jsqlparser.util.validation.ValidationTestAsserts;
+import net.sf.jsqlparser.util.validation.feature.FeaturesAllowed;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class UpdateSetValidationTest extends ValidationTestAsserts {
+    @ParameterizedTest
+    @ValueSource(strings = {"UPDATE t SET a = ?, b = 1", "UPDATE t SET a = 1, b = ?",
+            "UPDATE t SET a = 1, b = ?, c = 3", "UPDATE t SET a = 1, b = 2, c = ?",
+            "UPDATE t SET (b, c) = (2, ?), a = 1",
+            "UPDATE t SET a = 1, b = (SELECT x FROM s WHERE x = ?)",
+            "MERGE INTO t USING s ON t.id = s.id WHEN MATCHED THEN UPDATE SET a = 1, b = ?"})
+    void validatesValuesInEveryAssignment(String sql) {
+        validateNotAllowed(sql, 1, 1, FeaturesAllowed.DML.copy().remove(Feature.jdbcParameter),
+                Feature.jdbcParameter);
+        validateNoErrors(sql, 1, FeaturesAllowed.DML.copy().add(FeaturesAllowed.JDBC));
+    }
+
+    @Test
+    void reportsIndependentFeaturesAcrossDifferentAssignments() {
+        validateNotAllowed("UPDATE t SET a = 1, b = COALESCE(c, 0), d = ?", 1, 1,
+                FeaturesAllowed.UPDATE.copy().remove(Feature.function, Feature.jdbcParameter),
+                Feature.function, Feature.jdbcParameter);
+    }
+
+    @Test
+    void keepsTupleAndSubqueryAssignmentsValid() {
+        validateNoErrors("UPDATE t SET (a, b) = (SELECT c, d FROM s), e = 1", 1,
+                FeaturesAllowed.UPDATE);
+    }
+}


### PR DESCRIPTION
`UPDATE t SET a = 1, b = ?` currently passes validation even when JDBC parameters are forbidden. The validator reads deprecated accessors that expose only the first assignment, so equivalent expressions are checked differently depending on their position.

Validate the complete `UpdateSet` list and share assignment traversal with MERGE. Columns and values in every assignment are visited; direct SELECT values use the select validator. This also removes the obsolete first-assignment/select compatibility branch without changing the public UPDATE AST API.

Validation: full Java 17 Gradle `check` passes, including tests, formatting, Checkstyle, PMD, SpotBugs, coverage, and the grammar ambiguity gate. Regression tests cover first/middle/last assignments, tuples, subqueries, independent feature errors across assignments, and the existing MERGE path.
