### PR TITLE
Render DML RETURNING expressions through shared visitor handling

### DIFF
--- a/src/main/java/net/sf/jsqlparser/util/deparser/AbstractDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/AbstractDeParser.java
@@ -9,6 +9,7 @@
  */
 package net.sf.jsqlparser.util.deparser;
 
+import net.sf.jsqlparser.statement.ReturningClause;
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.statement.update.UpdateSet;
 
@@ -24,6 +25,14 @@ abstract class AbstractDeParser<S> {
 
     protected AbstractDeParser(StringBuilder builder) {
         this.builder = builder;
+    }
+
+    protected void deparseReturningClause(ReturningClause clause,
+            ExpressionVisitor<StringBuilder> visitor) {
+        if (clause != null) {
+            SelectDeParser selectItems = new SelectDeParser(visitor, builder);
+            clause.appendTo(builder, item -> item.accept(selectItems, null));
+        }
     }
 
     public static void deparseUpdateSets(List<UpdateSet> updateSets, StringBuilder buffer,

--- a/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
@@ -109,9 +109,7 @@ public class DeleteDeParser extends AbstractDeParser<Delete> {
             builder.append(delete.getOption());
         }
 
-        if (delete.getReturningClause() != null) {
-            delete.getReturningClause().appendTo(builder);
-        }
+        deparseReturningClause(delete.getReturningClause(), expressionVisitor);
 
     }
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/InsertDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/InsertDeParser.java
@@ -153,9 +153,7 @@ public class InsertDeParser extends AbstractDeParser<Insert> {
             insert.getConflictAction().appendTo(builder);
         }
 
-        if (insert.getReturningClause() != null) {
-            insert.getReturningClause().appendTo(builder);
-        }
+        deparseReturningClause(insert.getReturningClause(), expressionVisitor);
     }
 
     public ExpressionVisitor<StringBuilder> getExpressionVisitor() {

--- a/src/main/java/net/sf/jsqlparser/util/deparser/UpdateDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/UpdateDeParser.java
@@ -101,9 +101,7 @@ public class UpdateDeParser extends AbstractDeParser<Update>
             builder.append(update.getOption());
         }
 
-        if (update.getReturningClause() != null) {
-            update.getReturningClause().appendTo(builder);
-        }
+        deparseReturningClause(update.getReturningClause(), expressionVisitor);
     }
 
     protected void deparseWhereClause(Update update) {

--- a/src/test/java/net/sf/jsqlparser/util/deparser/DmlReturningExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/deparser/DmlReturningExpressionTest.java
@@ -1,0 +1,57 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.util.deparser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.ArrayList;
+import java.util.List;
+import net.sf.jsqlparser.expression.LongValue;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DmlReturningExpressionTest {
+    @ParameterizedTest
+    @ValueSource(strings = {"UPDATE t SET a = 7 RETURNING a + 8 AS result",
+            "DELETE FROM t WHERE a = 7 RETURNING a + 8 AS result",
+            "INSERT INTO t(a) VALUES (7) RETURNING a + 8 AS result",
+            "UPDATE t SET a = 7 RETURNING (SELECT b + 8 FROM source) AS result"})
+    void visitsReturnedExpressionsExactlyOnce(String sql) throws Exception {
+        var statement = CCJSqlParserUtil.parse(sql);
+        String original = statement.toString();
+        List<Long> seen = new ArrayList<>();
+        ExpressionDeParser expressions = new ExpressionDeParser() {
+            @Override
+            public <S> StringBuilder visit(LongValue value, S context) {
+                seen.add(value.getValue());
+                return getBuilder().append(value.getValue() + 100);
+            }
+        };
+        StringBuilder output = new StringBuilder();
+        statement.accept(new StatementDeParser(expressions, new SelectDeParser(), output), null);
+        assertEquals(List.of(7L, 8L), seen);
+        assertEquals(original.replace("7", "107").replace("8", "108"), output.toString());
+        assertEquals(original, statement.toString());
+        assertEquals(output.toString(), CCJSqlParserUtil.parse(output.toString()).toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"INSERT INTO t(a) VALUES (1) RETURNING *",
+            "DELETE FROM t RETURNING t.*, a AS result",
+            "UPDATE t SET a = 1 RETURNING a, b INTO x, y",
+            "DELETE FROM t RETURNING WITH (OLD AS o, NEW AS n) o.*, n.id"})
+    void preservesWildcardsAliasesAndOutputTargets(String sql) throws Exception {
+        var statement = CCJSqlParserUtil.parse(sql);
+        StringBuilder output = new StringBuilder();
+        statement.accept(new StatementDeParser(output), null);
+        assertEquals(statement.toString(), output.toString());
+        assertEquals(statement.toString(), CCJSqlParserUtil.parse(output.toString()).toString());
+    }
+}


### PR DESCRIPTION
A custom expression deparser changes the value in `UPDATE t SET a = 7 RETURNING a + 8` but leaves the RETURNING expression untouched. INSERT and DELETE have the same inconsistency, preventing consumers from applying one expression transformation across an entire DML statement.

Route the three RETURNING clauses through a shared deparser helper that uses the existing callback renderer and select-item visitor. Expressions, aliases, wildcards, and output targets retain the existing AST and SQL layout; nested queries use the configured expression/SELECT visitors.

Validation: full Java 17 Gradle `check` passes, including tests, formatting, Checkstyle, PMD, SpotBugs, coverage, and the grammar ambiguity gate. Tests verify one callback per expression, nested SELECTs, preserved aliases and OLD/NEW qualifiers, INTO targets, unchanged source ASTs, and round trips.
