### PR TITLE
Protect shared dialect presets from external mutation

### DIFF
--- a/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
+++ b/src/main/java/net/sf/jsqlparser/parser/AbstractJSqlParser.java
@@ -13,6 +13,7 @@ import net.sf.jsqlparser.parser.feature.Feature;
 import net.sf.jsqlparser.parser.feature.FeatureConfiguration;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
@@ -61,8 +62,9 @@ public abstract class AbstractJSqlParser<P> {
             this(AdjacentStringLiterals.OFF, lexerFeatures);
         }
 
+        /** Returns the immutable lexer defaults shared by this dialect preset. */
         public Set<Feature> getLexerFeatures() {
-            return lexerFeatures;
+            return Collections.unmodifiableSet(lexerFeatures);
         }
 
         public AdjacentStringLiterals getAdjacentStringLiterals() {
@@ -111,6 +113,10 @@ public abstract class AbstractJSqlParser<P> {
         return withFeature(Feature.timeOut, timeOutMillSeconds);
     }
 
+    /**
+     * Applies this dialect's enabled lexer defaults to the current configuration. Existing options
+     * remain set; apply explicit overrides after this call, or use a new parser for a fresh preset.
+     */
     public P withDialect(Dialect dialect) {
         withFeature(Feature.dialect, dialect.name());
         if (dialect.getAdjacentStringLiterals() != AdjacentStringLiterals.OFF) {

--- a/src/test/java/net/sf/jsqlparser/parser/DialectPresetIsolationTest.java
+++ b/src/test/java/net/sf/jsqlparser/parser/DialectPresetIsolationTest.java
@@ -1,0 +1,48 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.parser;
+
+import static org.junit.jupiter.api.Assertions.*;
+import net.sf.jsqlparser.parser.AbstractJSqlParser.Dialect;
+import net.sf.jsqlparser.parser.feature.Feature;
+import org.junit.jupiter.api.Test;
+
+class DialectPresetIsolationTest {
+    @Test
+    void callersCannotMutateSharedPresets() {
+        for (Dialect dialect : Dialect.values()) {
+            assertThrows(UnsupportedOperationException.class,
+                    () -> dialect.getLexerFeatures().add(Feature.allowHashLineComments));
+            assertThrows(UnsupportedOperationException.class,
+                    () -> dialect.getLexerFeatures().clear());
+        }
+    }
+
+    @Test
+    void explicitParserOverridesAreLocalAndDoNotModifyPresetDefaults() {
+        CCJSqlParser first = CCJSqlParserUtil.newParser("SELECT 1").withDialect(Dialect.MYSQL)
+                .withHashLineComments(false);
+        CCJSqlParser second = CCJSqlParserUtil.newParser("SELECT 1").withDialect(Dialect.MYSQL);
+        assertFalse(first.getAsBoolean(Feature.allowHashLineComments));
+        assertTrue(second.getAsBoolean(Feature.allowHashLineComments));
+        assertTrue(Dialect.MYSQL.getLexerFeatures().contains(Feature.allowHashLineComments));
+    }
+
+    @Test
+    void preservesAdditivePresetApplicationAndExplicitOverrideOrder() {
+        CCJSqlParser parser = CCJSqlParserUtil.newParser("SELECT 1").withDialect(Dialect.SQLSERVER)
+                .withDialect(Dialect.POSTGRESQL);
+        assertTrue(parser.getAsBoolean(Feature.allowSquareBracketQuotation));
+        parser.withSquareBracketQuotation(false);
+        assertFalse(parser.getAsBoolean(Feature.allowSquareBracketQuotation));
+        assertFalse(CCJSqlParserUtil.newParser("SELECT 1").withDialect(Dialect.POSTGRESQL)
+                .getAsBoolean(Feature.allowSquareBracketQuotation));
+    }
+}


### PR DESCRIPTION
`Dialect.getLexerFeatures()` exposes the mutable set stored in a shared enum constant. A caller can therefore change the defaults of parsers created elsewhere in the application, making behavior depend on unrelated configuration code.

Expose an unmodifiable view of the preset defaults and document how `withDialect` applies enabled defaults. Parser-specific overrides remain local, and the existing additive application order is preserved.

Validation: `./gradlew check` passed. Regression tests cover mutation attempts on every preset, isolation between parser instances, successive dialect application, and explicit overrides.
