### PR TITLE
Fix benchmark configuration and isolated parser class loading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -710,7 +710,8 @@ jmh {
             , "-XX:+DebugNonSafepoints"
     ]
 
-    profilers = ['async:libPath=/opt/async-profiler/lib/libasyncProfiler.so;output=tree;dir=build/reports/jmh']
+    // Profiling is opt-in because the native library path depends on the host.
+    profilers = providers.gradleProperty('jmhProfiler').map { [it] }.getOrElse([])
 
     includes = ['.*JSQLParserBenchmark.*']
     warmupIterations = 2

--- a/src/test/java/net/sf/jsqlparser/benchmark/DynamicParserRunner.java
+++ b/src/test/java/net/sf/jsqlparser/benchmark/DynamicParserRunner.java
@@ -9,32 +9,56 @@
  */
 package net.sf.jsqlparser.benchmark;
 
-import net.sf.jsqlparser.parser.CCJSqlParser;
-import net.sf.jsqlparser.statement.Statements;
-
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URLClassLoader;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
+/** Owns the isolated class loader and keeps its AST types behind an Object boundary. */
 public class DynamicParserRunner implements SqlParserRunner {
+    private final URLClassLoader loader;
     private final Method parseStatementsMethod;
+    private final Map<Configuration, Consumer<Object>> configurations =
+            new EnumMap<>(Configuration.class);
 
     public DynamicParserRunner(URLClassLoader loader) throws Exception {
+        this.loader = loader;
         Class<?> utilClass = loader.loadClass("net.sf.jsqlparser.parser.CCJSqlParserUtil");
-        Class<?> ccjClass = loader.loadClass("net.sf.jsqlparser.parser.CCJSqlParser");
-        Class<?> consumerClass = Class.forName("java.util.function.Consumer"); // interface OK
-        parseStatementsMethod = utilClass.getMethod(
-                "parseStatements",
-                String.class,
-                ExecutorService.class,
-                consumerClass);
+        Class<?> parserClass = loader.loadClass("net.sf.jsqlparser.parser.CCJSqlParser");
+        parseStatementsMethod = utilClass.getMethod("parseStatements", String.class,
+                ExecutorService.class, Consumer.class);
+        for (Configuration configuration : Configuration.values()) {
+            Method method = parserClass.getMethod(configuration.methodName, boolean.class);
+            configurations.put(configuration, parser -> {
+                try {
+                    method.invoke(parser, configuration.value);
+                } catch (ReflectiveOperationException ex) {
+                    throw new IllegalStateException(
+                            "Cannot apply parser configuration " + configuration, ex);
+                }
+            });
+        }
     }
 
     @Override
-    public Statements parseStatements(String sql,
-            ExecutorService executorService,
-            Consumer<CCJSqlParser> consumer) throws Exception {
-        return (Statements) parseStatementsMethod.invoke(null, sql, executorService, null);
+    public Object parseStatements(String sql, ExecutorService executorService,
+            Configuration configuration) throws Exception {
+        try {
+            return parseStatementsMethod.invoke(null, sql, executorService,
+                    configuration == null ? null : configurations.get(configuration));
+        } catch (InvocationTargetException ex) {
+            if (ex.getCause() instanceof Exception) {
+                throw (Exception) ex.getCause();
+            }
+            throw ex;
+        }
+    }
+
+    @Override
+    public void close() throws java.io.IOException {
+        loader.close();
     }
 }

--- a/src/test/java/net/sf/jsqlparser/benchmark/JSQLParserBenchmark.java
+++ b/src/test/java/net/sf/jsqlparser/benchmark/JSQLParserBenchmark.java
@@ -9,8 +9,6 @@
  */
 package net.sf.jsqlparser.benchmark;
 
-import net.sf.jsqlparser.parser.CCJSqlParser;
-import net.sf.jsqlparser.statement.Statements;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -21,7 +19,6 @@ import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.concurrent.*;
-import java.util.function.Consumer;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
@@ -44,13 +41,33 @@ public class JSQLParserBenchmark {
         } else {
             Path jarPath = downloadJsqlparserJar(version);
             URLClassLoader loader = new URLClassLoader(new URL[] {jarPath.toUri().toURL()}, null);
-            runner = new DynamicParserRunner(loader);
+            try {
+                runner = new DynamicParserRunner(loader);
+            } catch (Exception ex) {
+                loader.close();
+                throw ex;
+            }
         }
 
-        // Adjust path as necessary based on where source root is during test execution
-        Path path = Paths.get("src/test/resources/net/sf/jsqlparser/performance.sql");
-        sqlContent = Files.readString(path, StandardCharsets.UTF_8);
-        executorService = Executors.newSingleThreadExecutor();
+        // Reject incompatible SQL/configurations before collecting measurements.
+        try {
+            Path path = Paths.get("src/test/resources/net/sf/jsqlparser/performance.sql");
+            sqlContent = Files.readString(path, StandardCharsets.UTF_8);
+            executorService = Executors.newSingleThreadExecutor();
+            Object statements = runner.parseStatements(sqlContent, executorService,
+                    SqlParserRunner.Configuration.SIMPLE);
+            if (statements == null) {
+                throw new IllegalStateException("Parser " + version
+                        + " returned no statements for the benchmark corpus with SIMPLE configuration");
+            }
+        } catch (Exception ex) {
+            try {
+                tearDown();
+            } catch (Exception cleanup) {
+                ex.addSuppressed(cleanup);
+            }
+            throw ex;
+        }
     }
 
     private Path downloadJsqlparserJar(String version) throws IOException {
@@ -74,10 +91,10 @@ public class JSQLParserBenchmark {
 
     @Benchmark
     public void parseSQLStatements(Blackhole blackhole) throws Exception {
-        final Statements statements = runner.parseStatements(
+        final Object statements = runner.parseStatements(
                 sqlContent,
                 executorService,
-                (Consumer<CCJSqlParser>) parser -> parser.withAllowComplexParsing(false));
+                SqlParserRunner.Configuration.SIMPLE);
         blackhole.consume(statements);
     }
 
@@ -87,15 +104,23 @@ public class JSQLParserBenchmark {
                 + "INSERT INTO recycle_record (a,f) VALUES ('\\'anything', 'abc');\n"
                 + "INSERT INTO recycle_record (a,f) VALUES ('\\'','83653692186728700711687663398101');\n";
 
-        final Statements statements = runner.parseStatements(
+        final Object statements = runner.parseStatements(
                 sqlStr,
                 executorService,
-                (Consumer<CCJSqlParser>) parser -> parser.withBackslashEscapeCharacter(true));
+                SqlParserRunner.Configuration.BACKSLASH_ESCAPES);
         blackhole.consume(statements);
     }
 
     @TearDown(Level.Trial)
-    public void tearDown() {
-        executorService.shutdown();
+    public void tearDown() throws Exception {
+        try {
+            if (executorService != null) {
+                executorService.shutdownNow();
+            }
+        } finally {
+            if (runner != null) {
+                runner.close();
+            }
+        }
     }
 }

--- a/src/test/java/net/sf/jsqlparser/benchmark/LatestClasspathRunner.java
+++ b/src/test/java/net/sf/jsqlparser/benchmark/LatestClasspathRunner.java
@@ -9,20 +9,17 @@
  */
 package net.sf.jsqlparser.benchmark;
 
-import net.sf.jsqlparser.parser.CCJSqlParser;
-import net.sf.jsqlparser.statement.Statements;
 
 import java.util.concurrent.ExecutorService;
-import java.util.function.Consumer;
 
 public class LatestClasspathRunner implements SqlParserRunner {
 
     @Override
-    public Statements parseStatements(String sql,
+    public Object parseStatements(String sql,
             ExecutorService executorService,
-            Consumer<CCJSqlParser> consumer) throws Exception {
+            Configuration configuration) throws Exception {
         return net.sf.jsqlparser.parser.CCJSqlParserUtil.parseStatements(sql, executorService,
-                consumer);
+                configuration == null ? null : configuration.currentParserConfiguration);
     }
 }
 

--- a/src/test/java/net/sf/jsqlparser/benchmark/ParserRunnerTest.java
+++ b/src/test/java/net/sf/jsqlparser/benchmark/ParserRunnerTest.java
@@ -1,0 +1,47 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2025 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.benchmark;
+
+import static org.junit.jupiter.api.Assertions.*;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.concurrent.Executors;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import org.junit.jupiter.api.Test;
+import net.sf.jsqlparser.benchmark.SqlParserRunner.Configuration;
+
+class ParserRunnerTest {
+    @Test
+    void isolatedParserReturnsItsOwnAstAndAppliesTheSameOptions() throws Exception {
+        URL classes = CCJSqlParserUtil.class.getProtectionDomain().getCodeSource().getLocation();
+        var executor = Executors.newSingleThreadExecutor();
+        try (var current = new LatestClasspathRunner();
+                var isolated =
+                        new DynamicParserRunner(new URLClassLoader(new URL[] {classes}, null))) {
+            String sql = "SELECT 'it\\'s' AS value";
+            Object expected =
+                    current.parseStatements(sql, executor, Configuration.BACKSLASH_ESCAPES);
+            Object actual =
+                    isolated.parseStatements(sql, executor, Configuration.BACKSLASH_ESCAPES);
+            assertEquals(expected.toString(), actual.toString());
+            assertNotSame(expected.getClass(), actual.getClass());
+            assertEquals(expected.getClass().getName(), actual.getClass().getName());
+            assertEquals(
+                    current.parseStatements("SELECT 1", executor, Configuration.SIMPLE).toString(),
+                    isolated.parseStatements("SELECT 1", executor, Configuration.SIMPLE)
+                            .toString());
+            assertThrows(Exception.class,
+                    () -> isolated.parseStatements("SELECT FROM", executor, Configuration.SIMPLE));
+            assertFalse(executor.isShutdown());
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/src/test/java/net/sf/jsqlparser/benchmark/SqlParserRunner.java
+++ b/src/test/java/net/sf/jsqlparser/benchmark/SqlParserRunner.java
@@ -9,13 +9,31 @@
  */
 package net.sf.jsqlparser.benchmark;
 
-import net.sf.jsqlparser.parser.CCJSqlParser;
-import net.sf.jsqlparser.statement.Statements;
-
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
+import net.sf.jsqlparser.parser.CCJSqlParser;
 
-public interface SqlParserRunner {
-    Statements parseStatements(String sql, ExecutorService executorService,
-            Consumer<CCJSqlParser> consumer) throws Exception;
+public interface SqlParserRunner extends AutoCloseable {
+    enum Configuration {
+        SIMPLE("withAllowComplexParsing", false,
+                parser -> parser.withAllowComplexParsing(false)), BACKSLASH_ESCAPES(
+                        "withBackslashEscapeCharacter", true,
+                        parser -> parser.withBackslashEscapeCharacter(true));
+
+        final String methodName;
+        final boolean value;
+        final Consumer<CCJSqlParser> currentParserConfiguration;
+
+        Configuration(String methodName, boolean value, Consumer<CCJSqlParser> configuration) {
+            this.methodName = methodName;
+            this.value = value;
+            this.currentParserConfiguration = configuration;
+        }
+    }
+
+    Object parseStatements(String sql, ExecutorService executorService,
+            Configuration configuration) throws Exception;
+
+    @Override
+    default void close() throws Exception {}
 }


### PR DESCRIPTION
The historical-version benchmark runner discards its parser configuration and casts AST objects from an isolated class loader to the current version’s `Statements` type. Even loading the same build through an isolated loader can fail with `ClassCastException`, while ignored options make version comparisons unreliable.

Keep AST results behind an `Object` boundary, represent the benchmark’s configurations explicitly, and apply each option through the target loader’s parser methods. Share those configuration choices with the current-version runner and close the isolated loader at trial teardown. Setup now parses the corpus before measurement and rejects both exceptions and null ASTs. Native profiling becomes opt-in via the `jmhProfiler` Gradle property instead of requiring a fixed Linux library path.

Validation:
- `./gradlew check` passed, including JMH compilation and static analysis.
- An isolated-loader regression test verifies distinct AST classes, equivalent SQL output, backslash configuration, invalid SQL, and caller-owned executor lifetime.
- Manual smoke checks with the current build and the actual 5.3/5.1 release JARs apply backslash escaping successfully. The current build accepts the complete performance corpus with SIMPLE configuration; 5.3 and 5.1 return no AST for that combination, and setup now rejects those trials before measurement.

No performance result is claimed. Historical versions need a mutually supported corpus before a valid comparison. Profiling can be enabled with `./gradlew jmh -PjmhProfiler='async:libPath=/path/to/libasyncProfiler.so;output=tree;dir=build/reports/jmh'`.
