### PR TITLE
Render DML source clauses through shared visitor paths

### DIFF
--- a/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/DeleteDeParser.java
@@ -13,10 +13,6 @@ import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.delete.Delete;
-import net.sf.jsqlparser.statement.select.Join;
-import net.sf.jsqlparser.statement.select.WithItem;
-
-import java.util.Iterator;
 
 import static java.util.stream.Collectors.joining;
 
@@ -25,31 +21,30 @@ public class DeleteDeParser extends AbstractDeParser<Delete> {
     private ExpressionVisitor<StringBuilder> expressionVisitor =
             new ExpressionVisitorAdapter<StringBuilder>();
 
+    private SelectDeParser selectDeParser;
+
     public DeleteDeParser() {
         super(new StringBuilder());
     }
 
     public DeleteDeParser(ExpressionVisitor<StringBuilder> expressionVisitor,
             StringBuilder buffer) {
+        this(expressionVisitor, null, buffer);
+    }
+
+    public DeleteDeParser(ExpressionVisitor<StringBuilder> expressionVisitor,
+            SelectDeParser selectDeParser, StringBuilder buffer) {
         super(buffer);
         this.expressionVisitor = expressionVisitor;
+        this.selectDeParser = selectDeParser;
     }
 
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity"})
     public void deParse(Delete delete) {
-        if (delete.getWithItemsList() != null && !delete.getWithItemsList().isEmpty()) {
-            builder.append("WITH ");
-            for (Iterator<WithItem<?>> iter = delete.getWithItemsList().iterator(); iter
-                    .hasNext();) {
-                WithItem<?> withItem = iter.next();
-                builder.append(withItem);
-                if (iter.hasNext()) {
-                    builder.append(",");
-                }
-                builder.append(" ");
-            }
-        }
+        DmlDeParserSupport sources =
+                new DmlDeParserSupport(expressionVisitor, selectDeParser, builder);
+        sources.deparseWithItems(delete.getWithItemsList(), null);
         builder.append("DELETE");
         if (delete.getOracleHint() != null) {
             builder.append(delete.getOracleHint()).append(" ");
@@ -78,20 +73,8 @@ public class DeleteDeParser extends AbstractDeParser<Delete> {
         }
         builder.append(" ").append(delete.getTable().toString());
 
-        if (delete.getUsingFromItemList() != null && !delete.getUsingFromItemList().isEmpty()) {
-            builder.append(" USING").append(
-                    delete.getUsingFromItemList().stream().map(Object::toString)
-                            .collect(joining(", ", " ", "")));
-        }
-        if (delete.getJoins() != null) {
-            for (Join join : delete.getJoins()) {
-                if (join.isSimple()) {
-                    builder.append(", ").append(join);
-                } else {
-                    builder.append(" ").append(join);
-                }
-            }
-        }
+        sources.deparseUsing(delete.getUsingFromItemList());
+        sources.deparseJoins(delete.getJoins());
 
         deparseWhereClause(delete);
 

--- a/src/main/java/net/sf/jsqlparser/util/deparser/DmlDeParserSupport.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/DmlDeParserSupport.java
@@ -1,0 +1,133 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.util.deparser;
+
+import java.util.List;
+import net.sf.jsqlparser.expression.ExpressionVisitor;
+import net.sf.jsqlparser.statement.StatementVisitorAdapter;
+import net.sf.jsqlparser.statement.delete.ParenthesedDelete;
+import net.sf.jsqlparser.statement.insert.ParenthesedInsert;
+import net.sf.jsqlparser.statement.update.ParenthesedUpdate;
+import net.sf.jsqlparser.statement.select.*;
+
+/** Shared source rendering for DML and the statements nested in WITH items. */
+final class DmlDeParserSupport {
+    private final ExpressionVisitor<StringBuilder> expressions;
+    private final SelectDeParser selects;
+    private final StringBuilder builder;
+
+    DmlDeParserSupport(ExpressionVisitor<StringBuilder> expressions, SelectDeParser selects,
+            StringBuilder builder) {
+        this.expressions = expressions;
+        this.builder = builder;
+        SelectDeParser selected = selects;
+        if (selected == null && expressions instanceof ExpressionDeParser) {
+            SelectVisitor<StringBuilder> visitor =
+                    ((ExpressionDeParser) expressions).getSelectVisitor();
+            if (visitor instanceof SelectDeParser) {
+                selected = (SelectDeParser) visitor;
+            }
+        }
+        this.selects = selected == null ? new SelectDeParser(expressions, builder) : selected;
+        this.selects.setBuilder(builder);
+        this.selects.setExpressionVisitor(expressions);
+    }
+
+    <S> void deparseWithItems(List<WithItem<?>> items, S context) {
+        if (items != null && !items.isEmpty()) {
+            builder.append("WITH ");
+            for (int i = 0; i < items.size(); i++) {
+                if (i > 0) {
+                    builder.append(", ");
+                }
+                selects.visit(items.get(i), context);
+            }
+            builder.append(' ');
+        }
+    }
+
+    void deparseJoins(List<Join> joins) {
+        if (joins != null) {
+            for (Join join : joins) {
+                selects.deparseJoin(join);
+            }
+        }
+    }
+
+    void deparseFrom(FromItem item, List<Join> joins) {
+        if (item != null) {
+            builder.append(" FROM ");
+            item.accept(selects, null);
+            deparseJoins(joins);
+        }
+    }
+
+    void deparseUsing(List<FromItem> items) {
+        if (items != null && !items.isEmpty()) {
+            builder.append(" USING ");
+            for (int i = 0; i < items.size(); i++) {
+                if (i > 0) {
+                    builder.append(", ");
+                }
+                items.get(i).accept(selects, null);
+            }
+        }
+    }
+
+    <S> StringBuilder deparseWithItem(WithItem<?> item, S context) {
+        if (item.getWithFunctionDeclaration() != null) {
+            return builder.append(item.getWithFunctionDeclaration());
+        }
+        if (item.isRecursive()) {
+            builder.append("RECURSIVE ");
+        }
+        builder.append(item.getAlias().getName());
+        if (item.getWithItemList() != null) {
+            builder.append(' ')
+                    .append(PlainSelect.getStringList(item.getWithItemList(), true, true));
+        }
+        builder.append(" AS ");
+        if (item.isMaterialized()) {
+            builder.append(item.isUsingNot() ? "NOT MATERIALIZED " : "MATERIALIZED ");
+        }
+        item.getParenthesedStatement().accept(new StatementVisitorAdapter<StringBuilder>() {
+            @Override
+            public <T> StringBuilder visit(Select select, T nestedContext) {
+                return select.accept((SelectVisitor<StringBuilder>) selects, nestedContext);
+            }
+
+            @Override
+            public <T> StringBuilder visit(ParenthesedInsert insert, T nestedContext) {
+                deparseWithItems(insert.getWithItemsList(), nestedContext);
+                builder.append('(');
+                new InsertDeParser(expressions, selects, builder).deParse(insert.getInsert());
+                return builder.append(')');
+            }
+
+            @Override
+            public <T> StringBuilder visit(ParenthesedUpdate update, T nestedContext) {
+                deparseWithItems(update.getWithItemsList(), nestedContext);
+                builder.append('(');
+                new UpdateDeParser(expressions, selects, builder).deParse(update.getUpdate());
+                return builder.append(')');
+            }
+
+            @Override
+            public <T> StringBuilder visit(ParenthesedDelete delete, T nestedContext) {
+                deparseWithItems(delete.getWithItemsList(), nestedContext);
+                builder.append('(');
+                new DeleteDeParser(expressions, selects, builder).deParse(delete.getDelete());
+                return builder.append(')');
+            }
+        }, context);
+        return item.appendRecursiveClausesTo(builder,
+                expression -> expression.accept(expressions, context));
+    }
+}

--- a/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/SelectDeParser.java
@@ -872,30 +872,8 @@ public class SelectDeParser extends AbstractDeParser<PlainSelect>
 
     @Override
     public <S> StringBuilder visit(WithItem<?> withItem, S context) {
-        if (withItem.getWithFunctionDeclaration() == null) {
-            if (withItem.isRecursive()) {
-                builder.append("RECURSIVE ");
-            }
-            builder.append(withItem.getAlias().getName());
-            if (withItem.getWithItemList() != null) {
-                builder.append(" ")
-                        .append(PlainSelect.getStringList(withItem.getWithItemList(), true, true));
-            }
-            builder.append(" AS ");
-            if (withItem.isMaterialized()) {
-                builder.append(withItem.isUsingNot()
-                        ? "NOT MATERIALIZED "
-                        : "MATERIALIZED ");
-            }
-            StatementDeParser statementDeParser =
-                    new StatementDeParser((ExpressionDeParser) expressionVisitor, this, builder);
-            statementDeParser.deParse(withItem.getParenthesedStatement());
-            withItem.appendRecursiveClausesTo(builder,
-                    expression -> expression.accept(expressionVisitor, context));
-        } else {
-            builder.append(withItem.getWithFunctionDeclaration().toString());
-        }
-        return builder;
+        return new DmlDeParserSupport(expressionVisitor, this, builder)
+                .deparseWithItem(withItem, context);
     }
 
     @Override

--- a/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/StatementDeParser.java
@@ -202,7 +202,8 @@ public class StatementDeParser extends AbstractDeParser<Statement>
 
     @Override
     public <S> StringBuilder visit(Delete delete, S context) {
-        DeleteDeParser deleteDeParser = new DeleteDeParser(expressionDeParser, builder);
+        DeleteDeParser deleteDeParser =
+                new DeleteDeParser(expressionDeParser, selectDeParser, builder);
         deleteDeParser.deParse(delete);
         return builder;
     }
@@ -301,7 +302,8 @@ public class StatementDeParser extends AbstractDeParser<Statement>
 
     @Override
     public <S> StringBuilder visit(Update update, S context) {
-        UpdateDeParser updateDeParser = new UpdateDeParser(expressionDeParser, builder);
+        UpdateDeParser updateDeParser =
+                new UpdateDeParser(expressionDeParser, selectDeParser, builder);
         updateDeParser.deParse(update);
 
         return builder;

--- a/src/main/java/net/sf/jsqlparser/util/deparser/UpdateDeParser.java
+++ b/src/main/java/net/sf/jsqlparser/util/deparser/UpdateDeParser.java
@@ -11,18 +11,16 @@ package net.sf.jsqlparser.util.deparser;
 
 import net.sf.jsqlparser.expression.ExpressionVisitor;
 import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
-import net.sf.jsqlparser.statement.select.Join;
 import net.sf.jsqlparser.statement.select.OrderByElement;
 import net.sf.jsqlparser.statement.select.OrderByVisitor;
-import net.sf.jsqlparser.statement.select.WithItem;
 import net.sf.jsqlparser.statement.update.Update;
-
-import java.util.Iterator;
 
 public class UpdateDeParser extends AbstractDeParser<Update>
         implements OrderByVisitor<StringBuilder> {
 
     private ExpressionVisitor<StringBuilder> expressionVisitor = new ExpressionVisitorAdapter<>();
+
+    private SelectDeParser selectDeParser;
 
     public UpdateDeParser() {
         super(new StringBuilder());
@@ -30,26 +28,23 @@ public class UpdateDeParser extends AbstractDeParser<Update>
 
     public UpdateDeParser(ExpressionVisitor<StringBuilder> expressionVisitor,
             StringBuilder buffer) {
+        this(expressionVisitor, null, buffer);
+    }
+
+    public UpdateDeParser(ExpressionVisitor<StringBuilder> expressionVisitor,
+            SelectDeParser selectDeParser, StringBuilder buffer) {
         super(buffer);
         this.expressionVisitor = expressionVisitor;
+        this.selectDeParser = selectDeParser;
     }
 
     @Override
     @SuppressWarnings({"PMD.CyclomaticComplexity", "PMD.NPathComplexity",
             "PMD.ExcessiveMethodLength"})
     public void deParse(Update update) {
-        if (update.getWithItemsList() != null && !update.getWithItemsList().isEmpty()) {
-            builder.append("WITH ");
-            for (Iterator<WithItem<?>> iter = update.getWithItemsList().iterator(); iter
-                    .hasNext();) {
-                WithItem<?> withItem = iter.next();
-                builder.append(withItem);
-                if (iter.hasNext()) {
-                    builder.append(",");
-                }
-                builder.append(" ");
-            }
-        }
+        DmlDeParserSupport sources =
+                new DmlDeParserSupport(expressionVisitor, selectDeParser, builder);
+        sources.deparseWithItems(update.getWithItemsList(), null);
         builder.append("UPDATE ");
         if (update.getOracleHint() != null) {
             builder.append(update.getOracleHint()).append(" ");
@@ -62,16 +57,10 @@ public class UpdateDeParser extends AbstractDeParser<Update>
         }
         builder.append(update.getTable());
         if (update.getStartJoins() != null) {
-            for (Join join : update.getStartJoins()) {
-                if (join.isSimple()) {
-                    builder.append(", ").append(join);
-                } else {
-                    builder.append(" ").append(join);
-                }
-            }
+            sources.deparseJoins(update.getStartJoins());
         }
         if (update.isFromBeforeSet()) {
-            update.appendFromTo(builder);
+            sources.deparseFrom(update.getFromItem(), update.getJoins());
         }
         builder.append(" SET ");
 
@@ -82,7 +71,7 @@ public class UpdateDeParser extends AbstractDeParser<Update>
         }
 
         if (!update.isFromBeforeSet()) {
-            update.appendFromTo(builder);
+            sources.deparseFrom(update.getFromItem(), update.getJoins());
         }
 
         deparseWhereClause(update);
@@ -116,7 +105,6 @@ public class UpdateDeParser extends AbstractDeParser<Update>
     protected void deparseUpdateSetsClause(Update update) {
         deparseUpdateSets(update.getUpdateSets(), builder, expressionVisitor);
     }
-
 
     public ExpressionVisitor<StringBuilder> getExpressionVisitor() {
         return expressionVisitor;

--- a/src/test/java/net/sf/jsqlparser/util/deparser/DmlSourceExpressionTest.java
+++ b/src/test/java/net/sf/jsqlparser/util/deparser/DmlSourceExpressionTest.java
@@ -1,0 +1,121 @@
+/*-
+ * #%L
+ * JSQLParser library
+ * %%
+ * Copyright (C) 2004 - 2019 JSQLParser
+ * %%
+ * Dual licensed under GNU LGPL 2.1 or Apache License 2.0
+ * #L%
+ */
+package net.sf.jsqlparser.util.deparser;
+
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.ArrayList;
+import java.util.List;
+import net.sf.jsqlparser.expression.LongValue;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
+import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.schema.Table;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.update.Update;
+import net.sf.jsqlparser.statement.delete.Delete;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DmlSourceExpressionTest {
+    private static Statement parse(String sql) throws Exception {
+        return CCJSqlParserUtil.parse(sql, parser -> {
+            if (sql.startsWith("UPDATE t FROM")) {
+                parser.withDialect(net.sf.jsqlparser.parser.AbstractJSqlParser.Dialect.TERADATA);
+            }
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "UPDATE t JOIN s ON s.a = 7 SET t.a = 8 WHERE t.b = 9",
+            "UPDATE t SET a = 8 FROM (SELECT 7 AS a) s JOIN q ON s.a = q.a AND q.b = 9",
+            "UPDATE t FROM s JOIN q ON q.a = 7 SET t.a = 8",
+            "WITH c AS (SELECT 7 AS a), d AS (SELECT 8 AS b) UPDATE t SET a = 9 FROM c",
+            "WITH c AS (DELETE FROM s WHERE a = 7 RETURNING a) UPDATE t SET a = 8",
+            "WITH c AS (UPDATE s SET a = 7 RETURNING a) DELETE FROM t WHERE a = 8",
+            "WITH c AS (INSERT INTO s (a) VALUES (7) RETURNING a) DELETE FROM t WHERE a = 8",
+            "DELETE t FROM t JOIN s ON s.a = 7 WHERE t.b = 8",
+            "DELETE FROM t USING (SELECT 7 AS a) s WHERE t.a = 8",
+            "DELETE FROM t USING s, (SELECT 7 AS a) q WHERE t.a = 8"
+    })
+    void visitsEverySourceExpressionOnceAndLeavesTheAstUnchanged(String sql) throws Exception {
+        Statement statement = parse(sql);
+        String original = statement.toString();
+        for (boolean direct : new boolean[] {false, true}) {
+            StringBuilder output = new StringBuilder();
+            List<Long> visited = new ArrayList<>();
+            SelectDeParser select = new SelectDeParser();
+            ExpressionDeParser expression = new ExpressionDeParser(select, output) {
+                @Override
+                public <S> StringBuilder visit(LongValue value, S context) {
+                    visited.add(value.getValue());
+                    return output.append(value.getValue() + 100);
+                }
+            };
+            select.setExpressionVisitor(expression);
+            select.setBuilder(output);
+            if (direct && statement instanceof Update) {
+                new UpdateDeParser(expression, output).deParse((Update) statement);
+            } else if (direct) {
+                new DeleteDeParser(expression, output).deParse((Delete) statement);
+            } else {
+                statement.accept(new StatementDeParser(expression, select, output), null);
+            }
+            String expected = sql.replace("7", "107").replace("8", "108").replace("9", "109");
+            assertEquals(parse(expected).toString(),
+                    parse(output.toString()).toString());
+            for (long value : new long[] {7, 8, 9}) {
+                assertEquals(sql.contains(Long.toString(value)) ? 1 : 0,
+                        visited.stream().filter(v -> v == value).count());
+            }
+            assertEquals(original, statement.toString());
+        }
+    }
+
+    @Test
+    void usesTheConfiguredSelectDeParserForDmlSources() throws Exception {
+        StringBuilder output = new StringBuilder();
+        List<String> tables = new ArrayList<>();
+        SelectDeParser selects = new SelectDeParser() {
+            @Override
+            public <S> StringBuilder visit(Table table, S context) {
+                tables.add(table.getName());
+                return super.visit(table, context);
+            }
+        };
+        parse("WITH c AS (SELECT a FROM hidden) UPDATE t "
+                + "SET a = 1 FROM source JOIN other ON source.a = other.a")
+                .accept(new StatementDeParser(new ExpressionDeParser(), selects, output), null);
+        assertEquals(List.of("hidden", "source", "other"), tables);
+    }
+
+    @Test
+    void existingSettersAndGenericExpressionVisitorsCanRenderWithItems() throws Exception {
+        StringBuilder output = new StringBuilder();
+        ExpressionVisitorAdapter<StringBuilder> expressions = new ExpressionVisitorAdapter<>() {
+            @Override
+            public <S> StringBuilder visit(LongValue value, S context) {
+                return output.append(value.getValue() + 100);
+            }
+
+            @Override
+            public <S> StringBuilder visit(Column column, S context) {
+                return output.append(column);
+            }
+        };
+        UpdateDeParser deparser = new UpdateDeParser();
+        deparser.setBuilder(output);
+        deparser.setExpressionVisitor(expressions);
+        deparser.deParse(
+                (Update) parse("WITH c AS (SELECT 7) UPDATE t SET a = 8"));
+        assertEquals("WITH c AS (SELECT 107) UPDATE t SET a = 108", output.toString());
+    }
+}


### PR DESCRIPTION
UPDATE and DELETE deparsers append CTEs and source clauses as raw AST strings. A custom expression deparser therefore rewrites SET/WHERE values but misses expressions in CTEs, joined subqueries, ON predicates, UPDATE FROM, and DELETE USING. SQL rewriting applications can produce a mixture of transformed and original expressions within one statement.

Route those sources through the configured `SelectDeParser` using common DML rendering support. Reuse the same WITH-item renderer from SELECT, including data-modifying CTEs, without casting a generic expression visitor to `ExpressionDeParser`. Existing UPDATE/DELETE constructors, visitor setters, and protected clause hooks remain available; an overload lets callers supply their select deparser explicitly. UPDATE FROM retains its position before or after SET.

Validation: `./gradlew check` passed. Regression tests cover CTEs containing SELECT/INSERT/UPDATE/DELETE, multiple CTEs, joined and USING subqueries, ON predicates, Teradata FROM placement, direct and statement-level deparsers, generic visitors, configured select visitors, visit counts, SQL reparsing, and unchanged source ASTs.
